### PR TITLE
Update volume binding for read write once

### DIFF
--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -150,7 +150,7 @@ def get_and_put_local_model_content(tuple_key, out_model, model_dst_path):
         raise Exception('Local Model Hash in Subtuple is not the same as in local db')
 
     if not os.path.exists(model_dst_path):
-        os.link(model.file.path, model_dst_path)
+        os.symlink(model.file.path, model_dst_path)
     else:
         # verify that local subtuple model file is not corrupted
         if get_hash(model_dst_path, tuple_key) != out_model['hash']:
@@ -938,7 +938,8 @@ def get_subtuple_directory(subtuple):
 
 
 def get_chainkeys_directory(compute_plan_id):
-    return path.join(getattr(settings, 'MEDIA_ROOT'), 'computeplan', compute_plan_id, 'chainkeys')
+    return path.join(getattr(settings, 'MEDIA_ROOT'), 'computeplan',
+                     compute_plan_id, 'chainkeys')
 
 
 def remove_algo_images(algo_hashes):

--- a/backend/substrapp/tests/tests_tasks.py
+++ b/backend/substrapp/tests/tests_tasks.py
@@ -20,7 +20,7 @@ from substrapp.tasks.tasks import (build_subtuple_folders, get_algo, get_objecti
 
 from .common import (get_sample_algo, get_sample_script, get_sample_zip_data_sample, get_sample_tar_data_sample,
                      get_sample_model)
-from .common import FakeObjective, FakeDataManager, FakeRequest
+from .common import FakeDataManager, FakeRequest
 from . import assets
 from node.models import OutgoingNode
 
@@ -303,28 +303,16 @@ class TasksTests(APITestCase):
         metrics_content = self.script.read().encode('utf-8')
         objective_hash = get_hash(self.script)
 
-        with mock.patch('substrapp.models.Objective.objects.get') as mget:
-
-            mget.return_value = FakeObjective()
-
-            objective = get_objective({'objective': {'hash': objective_hash,
-                                                     'metrics': ''}})
-            self.assertTrue(isinstance(objective, bytes))
-            self.assertEqual(objective, b'foo')
-
         with mock.patch('substrapp.tasks.utils.get_remote_file_content') as mget_remote_file, \
                 mock.patch('substrapp.tasks.tasks.get_object_from_ledger'), \
-                mock.patch('substrapp.tasks.utils.authenticate_worker'),\
-                mock.patch('substrapp.models.Objective.objects.update_or_create') as mupdate_or_create:
+                mock.patch('substrapp.tasks.utils.authenticate_worker'):
 
-            mget.return_value = FakeObjective()
             mget_remote_file.return_value = metrics_content
-            mupdate_or_create.return_value = FakeObjective(), True
 
             objective = get_objective({'objective': {'hash': objective_hash,
                                                      'metrics': ''}})
             self.assertTrue(isinstance(objective, bytes))
-            self.assertEqual(objective, b'foo')
+            self.assertEqual(objective, metrics_content)
 
     def test_compute_docker(self):
         cpu_set, gpu_set = None, None

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-backend
 home: https://substra.org/
-version: 1.0.0-alpha.23
+version: 1.0.0-alpha.24
 description: Main package for Substra
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/substra-backend/templates/deployment-server.yaml
+++ b/charts/substra-backend/templates/deployment-server.yaml
@@ -75,8 +75,14 @@ spec:
             containerPort: {{ .Values.backend.service.port }}
             protocol: TCP
         volumeMounts:
-          - name: data
-            mountPath: {{ .Values.persistence.hostPath }}
+          {{- range .Values.persistence.volumes }}
+          - name: data-{{ .name }}
+            mountPath: {{ $.Values.persistence.hostPath }}/medias/{{ .name }}
+            readOnly: {{ .readOnly.server }}
+          {{- end }}
+          - name: data-servermedias
+            mountPath: {{ $.Values.persistence.hostPath }}/servermedias
+            readOnly: true
           - name: statics
             mountPath: /usr/src/app/backend/statics
           - name: config
@@ -154,9 +160,14 @@ spec:
             mountPath: /usr/src/app/backend/statics
       {{- end }}
       volumes:
-      - name: data
+      {{- range .Values.persistence.volumes }}
+      - name: data-{{ .name }}
         persistentVolumeClaim:
-          claimName: {{ include "substra.fullname" . }}
+          claimName: {{ include "substra.fullname" $ }}-{{ .name }}
+      {{- end }}
+      - name: data-servermedias
+        persistentVolumeClaim:
+          claimName: {{ include "substra.fullname" $ }}-servermedias
       - name: statics
         emptyDir: {}
       - name: config

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -68,8 +68,14 @@ spec:
           volumeMounts:
             - name: dockersocket
               mountPath: /var/run/docker.sock
-            - name: data
-              mountPath: {{ .Values.persistence.hostPath }}
+            {{- range .Values.persistence.volumes }}
+            - name: data-{{ .name }}
+              mountPath: {{ $.Values.persistence.hostPath }}/medias/{{ .name }}
+              readOnly: {{ .readOnly.worker }}
+            {{- end }}
+            - name: data-servermedias
+              mountPath: {{ $.Values.persistence.hostPath }}/servermedias
+              readOnly: true
             - name: config
               mountPath: /conf/{{ .Values.organization.name }}/substra-backend
               readOnly: true
@@ -94,9 +100,14 @@ spec:
       - name: dockersocket
         hostPath:
           path: /var/run/docker.sock
-      - name: data
+      {{- range .Values.persistence.volumes }}
+      - name: data-{{ .name }}
         persistentVolumeClaim:
-          claimName: {{ include "substra.fullname" . }}
+          claimName: {{ include "substra.fullname" $ }}-{{ .name }}
+      {{- end }}
+      - name: data-servermedias
+        persistentVolumeClaim:
+          claimName: {{ include "substra.fullname" $ }}-servermedias
       - name: config
         configMap:
           name: {{ include "substra.fullname" . }}-server

--- a/charts/substra-backend/templates/storage.yaml
+++ b/charts/substra-backend/templates/storage.yaml
@@ -10,7 +10,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: {{ $.Values.persistence.size | quote }}
+      storage: {{ .size | quote }}
   selector:
     matchLabels:
       app.kubernetes.io/managed-by: {{ $.Release.Service }}
@@ -36,7 +36,7 @@ spec:
     name: {{ template "substra.fullname" $ }}-{{ .name }}
     namespace: {{ $.Release.Namespace }}
   capacity:
-    storage: {{ $.Values.persistence.size | quote }}
+    storage: {{ .size | quote }}
   accessModes:
     - ReadWriteOnce
   hostPath:

--- a/charts/substra-backend/templates/storage.yaml
+++ b/charts/substra-backend/templates/storage.yaml
@@ -17,7 +17,7 @@ spec:
       app.kubernetes.io/instance: {{ $.Release.Name }}
       helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
       app.kubernetes.io/name: {{ template "substra.name" $ }}-{{ .name }}
-      app.kubernetes.io/part-of: {{ template "substra.name" $ }}
+      app.kubernetes.io/part-of: {{ template "substra.name" $ }}-{{ .name }}
 ---
 apiVersion: v1
 kind: PersistentVolume
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/instance: {{ $.Release.Name }}
     helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
     app.kubernetes.io/name: {{ template "substra.name" $ }}-{{ .name }}
-    app.kubernetes.io/part-of: {{ template "substra.name" $ }}
+    app.kubernetes.io/part-of: {{ template "substra.name" $ }}-{{ .name }}
 spec:
   storageClassName: ""
   persistentVolumeReclaimPolicy: Recycle
@@ -61,7 +61,7 @@ spec:
       app.kubernetes.io/instance: {{ $.Release.Name }}
       helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
       app.kubernetes.io/name: {{ template "substra.name" $ }}-servermedias
-      app.kubernetes.io/part-of: {{ template "substra.name" $ }}
+      app.kubernetes.io/part-of: {{ template "substra.name" $ }}-servermedias
 ---
 apiVersion: v1
 kind: PersistentVolume
@@ -72,7 +72,7 @@ metadata:
     app.kubernetes.io/instance: {{ $.Release.Name }}
     helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
     app.kubernetes.io/name: {{ template "substra.name" $ }}-servermedias
-    app.kubernetes.io/part-of: {{ template "substra.name" $ }}
+    app.kubernetes.io/part-of: {{ template "substra.name" $ }}-servermedias
 spec:
   storageClassName: ""
   persistentVolumeReclaimPolicy: Recycle

--- a/charts/substra-backend/templates/storage.yaml
+++ b/charts/substra-backend/templates/storage.yaml
@@ -1,40 +1,88 @@
+{{- range .Values.persistence.volumes }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: {{ template "substra.fullname" . }}
+  name: {{ template "substra.fullname" $ }}-{{ .name }}
 spec:
   storageClassName: ""
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
   resources:
     requests:
-      storage: {{ .Values.persistence.size | quote }}
+      storage: {{ $.Values.persistence.size | quote }}
   selector:
     matchLabels:
-      app.kubernetes.io/managed-by: {{ .Release.Service }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-      app.kubernetes.io/name: {{ template "substra.name" . }}
-      app.kubernetes.io/part-of: {{ template "substra.name" . }}
+      app.kubernetes.io/managed-by: {{ $.Release.Service }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+      helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+      app.kubernetes.io/name: {{ template "substra.name" $ }}-{{ .name }}
+      app.kubernetes.io/part-of: {{ template "substra.name" $ }}
 ---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ template "substra.fullname" . }}
+  name: {{ template "substra.fullname" $ }}-{{ .name }}
   labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/name: {{ template "substra.name" . }}
-    app.kubernetes.io/part-of: {{ template "substra.name" . }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/name: {{ template "substra.name" $ }}-{{ .name }}
+    app.kubernetes.io/part-of: {{ template "substra.name" $ }}
 spec:
   storageClassName: ""
   persistentVolumeReclaimPolicy: Recycle
+  claimRef:
+    name: {{ template "substra.fullname" $ }}-{{ .name }}
+    namespace: {{ $.Release.Namespace }}
   capacity:
-    storage: {{ .Values.persistence.size | quote }}
+    storage: {{ $.Values.persistence.size | quote }}
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
   hostPath:
-    path: {{ .Values.persistence.hostPath | quote }}
+    path: {{ $.Values.persistence.hostPath }}/medias/{{ .name }}
+    type: DirectoryOrCreate
+{{- end }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "substra.fullname" $ }}-servermedias
+spec:
+  storageClassName: ""
+  accessModes:
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: {{ $.Values.persistence.size | quote }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: {{ $.Release.Service }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+      helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+      app.kubernetes.io/name: {{ template "substra.name" $ }}-servermedias
+      app.kubernetes.io/part-of: {{ template "substra.name" $ }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ template "substra.fullname" $ }}-servermedias
+  labels:
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/name: {{ template "substra.name" $ }}-servermedias
+    app.kubernetes.io/part-of: {{ template "substra.name" $ }}
+spec:
+  storageClassName: ""
+  persistentVolumeReclaimPolicy: Recycle
+  claimRef:
+    name: {{ template "substra.fullname" $ }}-servermedias
+    namespace: {{ $.Release.Namespace }}
+  capacity:
+    storage: {{ $.Values.persistence.size | quote }}
+  accessModes:
+    - ReadOnlyMany
+  hostPath:
+    path: {{ $.Values.persistence.hostPath }}/servermedias
     type: DirectoryOrCreate

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -77,6 +77,11 @@ users: []
 persistence:
   hostPath: "/substra"
   size: "10Gi"
+  volumes: []
+  # - name: data
+  #   readOnly:
+  #     server: false
+  #     worker: true
 
 # Secrets names
 secrets:

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -77,11 +77,52 @@ users: []
 persistence:
   hostPath: "/substra"
   size: "10Gi"
-  volumes: []
-  # - name: data
-  #   readOnly:
-  #     server: false
-  #     worker: true
+  volumes:
+    - name: algos
+      size: "10Gi"
+      readOnly:
+        server: false
+        worker: true
+    - name: aggregatealgos
+      size: "10Gi"
+      readOnly:
+        server: false
+        worker: true
+    - name: compositealgos
+      size: "10Gi"
+      readOnly:
+        server: false
+        worker: true
+    - name: datamanagers
+      size: "10Gi"
+      readOnly:
+        server: false
+        worker: true
+    - name: datasamples
+      size: "10Gi"
+      readOnly:
+        server: false
+        worker: true
+    - name: objectives
+      size: "10Gi"
+      readOnly:
+        server: false
+        worker: true
+    - name: models
+      size: "10Gi"
+      readOnly:
+        server: true
+        worker: false
+    - name: subtuple
+      size: "10Gi"
+      readOnly:
+        server: true
+        worker: false
+    - name: computeplan
+      size: "10Gi"
+      readOnly:
+        server: true
+        worker: false
 
 # Secrets names
 secrets:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -57,6 +57,43 @@ deploy:
             mspID: MyOrg1MSP
           persistence:
             hostPath: /tmp/org-1
+            volumes:
+              - name: algos
+                readOnly:
+                  server: false
+                  worker: true
+              - name: aggregatealgos
+                readOnly:
+                  server: false
+                  worker: true
+              - name: compositealgos
+                readOnly:
+                  server: false
+                  worker: true
+              - name: datamanagers
+                readOnly:
+                  server: false
+                  worker: true
+              - name: datasamples
+                readOnly:
+                  server: false
+                  worker: true
+              - name: objectives
+                readOnly:
+                  server: false
+                  worker: true
+              - name: models
+                readOnly:
+                  server: true
+                  worker: false
+              - name: subtuple
+                readOnly:
+                  server: true
+                  worker: false
+              - name: computeplan
+                readOnly:
+                  server: true
+                  worker: false
           incomingNodes:
             - { name: MyOrg1MSP, secret: selfSecret1 }
             - { name: MyOrg2MSP, secret: nodeSecret1w2 }
@@ -99,6 +136,43 @@ deploy:
             mspID: MyOrg2MSP
           persistence:
             hostPath: /tmp/org-2
+            volumes:
+              - name: algos
+                readOnly:
+                  server: false
+                  worker: true
+              - name: aggregatealgos
+                readOnly:
+                  server: false
+                  worker: true
+              - name: compositealgos
+                readOnly:
+                  server: false
+                  worker: true
+              - name: datamanagers
+                readOnly:
+                  server: false
+                  worker: true
+              - name: datasamples
+                readOnly:
+                  server: false
+                  worker: true
+              - name: objectives
+                readOnly:
+                  server: false
+                  worker: true
+              - name: models
+                readOnly:
+                  server: true
+                  worker: false
+              - name: subtuple
+                readOnly:
+                  server: true
+                  worker: false
+              - name: computeplan
+                readOnly:
+                  server: true
+                  worker: false
           incomingNodes:
             - { name: MyOrg1MSP, secret: nodeSecret2w1 }
             - { name: MyOrg2MSP, secret: selfSecret2 }

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -57,43 +57,6 @@ deploy:
             mspID: MyOrg1MSP
           persistence:
             hostPath: /tmp/org-1
-            volumes:
-              - name: algos
-                readOnly:
-                  server: false
-                  worker: true
-              - name: aggregatealgos
-                readOnly:
-                  server: false
-                  worker: true
-              - name: compositealgos
-                readOnly:
-                  server: false
-                  worker: true
-              - name: datamanagers
-                readOnly:
-                  server: false
-                  worker: true
-              - name: datasamples
-                readOnly:
-                  server: false
-                  worker: true
-              - name: objectives
-                readOnly:
-                  server: false
-                  worker: true
-              - name: models
-                readOnly:
-                  server: true
-                  worker: false
-              - name: subtuple
-                readOnly:
-                  server: true
-                  worker: false
-              - name: computeplan
-                readOnly:
-                  server: true
-                  worker: false
           incomingNodes:
             - { name: MyOrg1MSP, secret: selfSecret1 }
             - { name: MyOrg2MSP, secret: nodeSecret1w2 }
@@ -136,43 +99,6 @@ deploy:
             mspID: MyOrg2MSP
           persistence:
             hostPath: /tmp/org-2
-            volumes:
-              - name: algos
-                readOnly:
-                  server: false
-                  worker: true
-              - name: aggregatealgos
-                readOnly:
-                  server: false
-                  worker: true
-              - name: compositealgos
-                readOnly:
-                  server: false
-                  worker: true
-              - name: datamanagers
-                readOnly:
-                  server: false
-                  worker: true
-              - name: datasamples
-                readOnly:
-                  server: false
-                  worker: true
-              - name: objectives
-                readOnly:
-                  server: false
-                  worker: true
-              - name: models
-                readOnly:
-                  server: true
-                  worker: false
-              - name: subtuple
-                readOnly:
-                  server: true
-                  worker: false
-              - name: computeplan
-                readOnly:
-                  server: true
-                  worker: false
           incomingNodes:
             - { name: MyOrg1MSP, secret: nodeSecret2w1 }
             - { name: MyOrg2MSP, secret: selfSecret2 }


### PR DESCRIPTION
For the mission kubernetize hlf we improve substrabac volume handling to allow only read-write-once on it.
It changes the `get_objective` workflow (we do not register the objective in the local db anymore)

Companion PR https://github.com/SubstraFoundation/substra-tests/pull/82