### PR TITLE
Bump chart version

### DIFF
--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-backend
 home: https://substra.org/
-version: 1.0.0-alpha.11
+version: 1.0.0-alpha.12
 description: Main package for Substra
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:


### PR DESCRIPTION
During the "users" mission the chart got modified but the version of the chart was not bumped resulting in the version not being usable from the public registry.