### PR TITLE
Fix deployment through travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ script:
   - pip install flake8
   - flake8
   - coverage run manage.py test
+  - cd ..
 
 after_script:
   - 'if ! git diff --quiet --exit-code $TRAVIS_COMMIT_RANGE charts; then CHART_CHANGED="true"; else CHART_CHANGED="false"; fi'


### PR DESCRIPTION
The deployment was failing due to the step `cd backend` resulting in the following error in travis:
```
Error: could not find /home/travis/build/SubstraFoundation/substra-backend/backend/charts/substra-backend: stat /home/travis/build/SubstraFoundation/substra-backend/backend/charts/substra-backend: no such file or directory
```
I initially thought that the context, aka the current directory was reset from a stage to another but I was wrong obviously :P As this doesn't trigger a build failure as it's an `after` step it was hard to spot. Sorry about that