### PR TITLE
Testtuples: Use reference to traintuple instead of using direct reference to model

### DIFF
--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -94,8 +94,10 @@ def get_models(subtuple):
     else:
         return []
 
+
 def get_traintuple_metadata(traintupleKey):
     return get_object_from_ledger(traintupleKey, 'queryTraintuple')
+
 
 def _put_model(subtuple, subtuple_directory, model_content, model_hash, traintuple_key):
     if not model_content:

--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -87,8 +87,8 @@ def get_model(testtuple):
         return None
 
 
-def get_models(subtuple):
-    input_models = subtuple.get('inModels')
+def get_models(traintuple):
+    input_models = traintuple.get('inModels')
     if input_models:
         return [_get_model(item['traintupleKey']) for item in input_models]
     else:

--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -95,18 +95,18 @@ def get_models(traintuple):
         return []
 
 
-def get_traintuple_metadata(traintupleKey):
-    return get_object_from_ledger(traintupleKey, 'queryTraintuple')
+def get_traintuple_metadata(traintuple_hash):
+    return get_object_from_ledger(traintuple_hash, 'queryTraintuple')
 
 
-def _put_model(subtuple, subtuple_directory, model_content, model_hash, traintuple_key):
+def _put_model(subtuple, subtuple_directory, model_content, model_hash, traintuple_hash):
     if not model_content:
         raise Exception('Model content should not be empty')
 
     from substrapp.models import Model
 
     # store a model in local subtuple directory from input model content
-    model_dst_path = path.join(subtuple_directory, f'model/{traintuple_key}')
+    model_dst_path = path.join(subtuple_directory, f'model/{traintuple_hash}')
     model = None
     try:
         model = Model.objects.get(pk=model_hash)
@@ -115,14 +115,14 @@ def _put_model(subtuple, subtuple_directory, model_content, model_hash, traintup
             f.write(model_content)
     else:
         # verify that local db model file is not corrupted
-        if get_hash(model.file.path, traintuple_key) != model_hash:
+        if get_hash(model.file.path, traintuple_hash) != model_hash:
             raise Exception('Model Hash in Subtuple is not the same as in local db')
 
         if not os.path.exists(model_dst_path):
             os.link(model.file.path, model_dst_path)
         else:
             # verify that local subtuple model file is not corrupted
-            if get_hash(model_dst_path, traintuple_key) != model_hash:
+            if get_hash(model_dst_path, traintuple_hash) != model_hash:
                 raise Exception('Model Hash in Subtuple is not the same as in local medias')
 
 

--- a/backend/substrapp/tests/assets.py
+++ b/backend/substrapp/tests/assets.py
@@ -22,10 +22,10 @@ objective = [
         },
         "metrics": {
             "name": "macro-average recall",
-            "hash": "506dacd8800c36e70ad3df7379c9164e03452d700bd2c3edb472e6bd0dc01f2e",
+            "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
             "storageAddress": "http://testserver/objective/1cdafbb018dd195690111d74916b76c96892d897ec3587c814f287946db446c3/metrics/"
         },
-        "owner": "owkinMSP",
+        "owner": "MyPeer1MSP",
         "testDataset": None,
         "permissions": {
             "process": {
@@ -43,10 +43,10 @@ objective = [
         },
         "metrics": {
             "name": "macro-average recall",
-            "hash": "506dacd8800c36e70ad3df7379c9164e03452d700bd2c3edb472e6bd0dc01f2e",
+            "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
             "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
         },
-        "owner": "owkinMSP",
+        "owner": "MyPeer1MSP",
         "testDataset": {
             "dataManagerKey": "ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932",
             "dataSampleKeys": [
@@ -68,16 +68,16 @@ datamanager = [
     {
         "objectiveKey": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
         "description": {
-            "hash": "15863c2af1fcfee9ca6f61f04be8a0eaaf6a45e4d50c421788d450d198e580f1",
-            "storageAddress": "http://testserver/data_manager/8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca/description/"
+            "hash": "258bef187a166b3fef5cb86e68c8f7e154c283a148cd5bc344fec7e698821ad3",
+            "storageAddress": "http://testserver/data_manager/ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932/description/"
         },
-        "key": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
-        "name": "ISIC 2018",
+        "key": "ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932",
+        "name": "Simplified ISIC 2018",
         "opener": {
-            "hash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
-            "storageAddress": "http://testserver/data_manager/8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca/opener/"
+            "hash": "ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932",
+            "storageAddress": "http://testserver/data_manager/ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932/opener/"
         },
-        "owner": "chu-nantesMSP",
+        "owner": "MyPeer1MSP",
         "permissions": {
             "process": {
                 "public": True,
@@ -89,16 +89,16 @@ datamanager = [
     {
         "objectiveKey": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
         "description": {
-            "hash": "258bef187a166b3fef5cb86e68c8f7e154c283a148cd5bc344fec7e698821ad3",
-            "storageAddress": "http://testserver/data_manager/ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932/description/"
+            "hash": "15863c2af1fcfee9ca6f61f04be8a0eaaf6a45e4d50c421788d450d198e580f1",
+            "storageAddress": "http://testserver/data_manager/8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca/description/"
         },
-        "key": "ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932",
-        "name": "Simplified ISIC 2018",
+        "key": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
+        "name": "ISIC 2018",
         "opener": {
-            "hash": "ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932",
-            "storageAddress": "http://testserver/data_manager/ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932/opener/"
+            "hash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
+            "storageAddress": "http://testserver/data_manager/8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca/opener/"
         },
-        "owner": "owkinMSP",
+        "owner": "MyPeer2MSP",
         "permissions": {
             "process": {
                 "public": True,
@@ -111,6 +111,25 @@ datamanager = [
 
 algo = [
     {
+        "key": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
+        "name": "Logistic regression",
+        "content": {
+            "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
+            "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/"
+        },
+        "description": {
+            "hash": "124a0425b746d7072282d167b53cb6aab3a31bf1946dae89135c15b0126ebec3",
+            "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/description/"
+        },
+        "owner": "MyPeer1MSP",
+        "permissions": {
+            "process": {
+                "public": True,
+                "authorizedIDs": []
+            }
+        }
+    },
+    {
         "key": "0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f",
         "name": "Neural Network",
         "content": {
@@ -121,7 +140,7 @@ algo = [
             "hash": "b9463411a01ea00869bdffce6e59a5c100a4e635c0a9386266cad3c77eb28e9e",
             "storageAddress": "http://testserver/algo/0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f/description/"
         },
-        "owner": "chu-nantesMSP",
+        "owner": "MyPeer2MSP",
         "permissions": {
             "process": {
                 "public": True,
@@ -140,26 +159,7 @@ algo = [
             "hash": "4acea40c4b51996c88ef279c5c9aa41ab77b97d38c5ca167e978a98b2e402675",
             "storageAddress": "http://testserver/algo/9c3d8777e11fd72cbc0fd672bec3a0848f8518b4d56706008cc05f8a1cee44f9/description/"
         },
-        "owner": "chu-nantesMSP",
-        "permissions": {
-            "process": {
-                "public": True,
-                "authorizedIDs": []
-            }
-        }
-    },
-    {
-        "key": "6523012b72bcd0299f709bc6aaa084d2092dddb9a6256fbffa64645478995a1d",
-        "name": "Logistic regression",
-        "content": {
-            "hash": "6523012b72bcd0299f709bc6aaa084d2092dddb9a6256fbffa64645478995a1d",
-            "storageAddress": "http://testserver/algo/6523012b72bcd0299f709bc6aaa084d2092dddb9a6256fbffa64645478995a1d/file/"
-        },
-        "description": {
-            "hash": "124a0425b746d7072282d167b53cb6aab3a31bf1946dae89135c15b0126ebec3",
-            "storageAddress": "http://testserver/algo/6523012b72bcd0299f709bc6aaa084d2092dddb9a6256fbffa64645478995a1d/description/"
-        },
-        "owner": "owkinMSP",
+        "owner": "MyPeer2MSP",
         "permissions": {
             "process": {
                 "public": True,
@@ -171,17 +171,17 @@ algo = [
 
 traintuple = [
     {
-        "key": "363f70dcc3bf22fdce65e36c957e855b7cd3e2828e6909f34ccc97ee6218541a",
+        "key": "939e412a4045f17d9c3d7e4b46399afcd78f77647bc74681c259271dc3a3127e",
         "algo": {
             "name": "Neural Network",
             "hash": "0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f",
             "storageAddress": "http://testserver/algo/0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f/file/"
         },
-        "creator": "chu-nantesMSP",
+        "creator": "MyPeer2MSP",
         "dataset": {
-            "worker": "chu-nantesMSP",
+            "worker": "MyPeer2MSP",
             "keys": [
-                "dacc0288138cb50569250f996bbe716ec8968fb334d32f29f174c9e79a224127",
+                "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
                 "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
             ],
             "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
@@ -189,11 +189,11 @@ traintuple = [
         },
         "computePlanID": "",
         "inModels": None,
-        "log": "[00-01-0032-e18ebeb]",
+        "log": "[00-01-0032-7da30ce]",
         "objective": {
             "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
             "metrics": {
-                "hash": "506dacd8800c36e70ad3df7379c9164e03452d700bd2c3edb472e6bd0dc01f2e",
+                "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
                 "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
             }
         },
@@ -206,20 +206,58 @@ traintuple = [
         },
         "rank": 0,
         "status": "failed",
-        "tag": "My super tag"
+        "tag": "(should fail) My super tag"
     },
     {
-        "key": "05b44fa4b94d548e35922629f7b23dd84f777d09925bbecb0362081ca528f746",
+        "key": "102d2f2a63ae1dfd118a3349b1f1fe8c8dedf36dfd198597bd7bc03d5367b38b",
+        "algo": {
+            "name": "Random Forest",
+            "hash": "9c3d8777e11fd72cbc0fd672bec3a0848f8518b4d56706008cc05f8a1cee44f9",
+            "storageAddress": "http://testserver/algo/9c3d8777e11fd72cbc0fd672bec3a0848f8518b4d56706008cc05f8a1cee44f9/file/"
+        },
+        "creator": "MyPeer2MSP",
+        "dataset": {
+            "worker": "MyPeer2MSP",
+            "keys": [
+                "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
+                "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
+            ],
+            "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
+            "perf": 0
+        },
+        "computePlanID": "",
+        "inModels": None,
+        "log": "[00-01-0032-27dbbe0]",
+        "objective": {
+            "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
+            "metrics": {
+                "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
+                "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
+            }
+        },
+        "outModel": None,
+        "permissions": {
+            "process": {
+                "public": True,
+                "authorizedIDs": []
+            }
+        },
+        "rank": 0,
+        "status": "failed",
+        "tag": "(should fail) My other tag"
+    },
+    {
+        "key": "39005faca3fd168e513c812de144b62fa4ce48df9d0ba1a03c56fae76aebae80",
         "algo": {
             "name": "Logistic regression",
-            "hash": "6523012b72bcd0299f709bc6aaa084d2092dddb9a6256fbffa64645478995a1d",
-            "storageAddress": "http://testserver/algo/6523012b72bcd0299f709bc6aaa084d2092dddb9a6256fbffa64645478995a1d/file/"
+            "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
+            "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/"
         },
-        "creator": "chu-nantesMSP",
+        "creator": "MyPeer2MSP",
         "dataset": {
-            "worker": "chu-nantesMSP",
+            "worker": "MyPeer2MSP",
             "keys": [
-                "dacc0288138cb50569250f996bbe716ec8968fb334d32f29f174c9e79a224127",
+                "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
                 "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
             ],
             "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
@@ -231,54 +269,13 @@ traintuple = [
         "objective": {
             "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
             "metrics": {
-                "hash": "506dacd8800c36e70ad3df7379c9164e03452d700bd2c3edb472e6bd0dc01f2e",
+                "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
                 "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
             }
         },
         "outModel": {
-            "hash": "e6a16f5bea8a485f48a8aa8c462155d2d500022a9459c1ff4b3c32acd168ff99",
-            "storageAddress": "http://testserver/model/e6a16f5bea8a485f48a8aa8c462155d2d500022a9459c1ff4b3c32acd168ff99/file/"
-        },
-        "permissions": {
-            "process": {
-                "public": True,
-                "authorizedIDs": []
-            }
-        },
-        "rank": 0,
-        "status": "done",
-        "tag": "substra"
-    },
-    {
-        "key": "32070e156eb4f97d85ff8448ea2ab71f4f275ab845159029354e4446aff974e0",
-        "algo": {
-            "name": "Logistic regression",
-            "hash": "6523012b72bcd0299f709bc6aaa084d2092dddb9a6256fbffa64645478995a1d",
-            "storageAddress": "http://testserver/algo/6523012b72bcd0299f709bc6aaa084d2092dddb9a6256fbffa64645478995a1d/file/"
-        },
-        "creator": "chu-nantesMSP",
-        "dataset": {
-            "worker": "chu-nantesMSP",
-            "keys": [
-                "dacc0288138cb50569250f996bbe716ec8968fb334d32f29f174c9e79a224127",
-                "e3644123451975be20909fcfd9c664a0573d9bfe04c5021625412d78c3536f1c"
-            ],
-            "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
-            "perf": 1
-        },
-        "computePlanID": "32070e156eb4f97d85ff8448ea2ab71f4f275ab845159029354e4446aff974e0",
-        "inModels": None,
-        "log": "",
-        "objective": {
-            "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
-            "metrics": {
-                "hash": "506dacd8800c36e70ad3df7379c9164e03452d700bd2c3edb472e6bd0dc01f2e",
-                "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
-            }
-        },
-        "outModel": {
-            "hash": "0b1ce6f2bd9247a262c3695aa07aad5ef187197f118c73c60a42e176f8f53b98",
-            "storageAddress": "http://testserver/model/0b1ce6f2bd9247a262c3695aa07aad5ef187197f118c73c60a42e176f8f53b98/file/"
+            "hash": "88c1b3c49f54601effbac2027ec5e562c1e6b33b9734fb0c86fa40f4f46745f9",
+            "storageAddress": "http://testserver/model/88c1b3c49f54601effbac2027ec5e562c1e6b33b9734fb0c86fa40f4f46745f9/file/"
         },
         "permissions": {
             "process": {
@@ -291,33 +288,36 @@ traintuple = [
         "tag": ""
     },
     {
-        "key": "a2171a1c09738c677748346d22d2b5eea47f874a3b4f4b75224674235892de72",
+        "key": "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3",
         "algo": {
-            "name": "Random Forest",
-            "hash": "9c3d8777e11fd72cbc0fd672bec3a0848f8518b4d56706008cc05f8a1cee44f9",
-            "storageAddress": "http://testserver/algo/9c3d8777e11fd72cbc0fd672bec3a0848f8518b4d56706008cc05f8a1cee44f9/file/"
+            "name": "Logistic regression",
+            "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
+            "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/"
         },
-        "creator": "chu-nantesMSP",
+        "creator": "MyPeer2MSP",
         "dataset": {
-            "worker": "chu-nantesMSP",
+            "worker": "MyPeer2MSP",
             "keys": [
-                "dacc0288138cb50569250f996bbe716ec8968fb334d32f29f174c9e79a224127",
-                "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
+                "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
+                "e3644123451975be20909fcfd9c664a0573d9bfe04c5021625412d78c3536f1c"
             ],
             "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
-            "perf": 0
+            "perf": 1
         },
-        "computePlanID": "",
+        "computePlanID": "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3",
         "inModels": None,
-        "log": "[00-01-0032-8189cc5]",
+        "log": "",
         "objective": {
             "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
             "metrics": {
-                "hash": "506dacd8800c36e70ad3df7379c9164e03452d700bd2c3edb472e6bd0dc01f2e",
+                "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
                 "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
             }
         },
-        "outModel": None,
+        "outModel": {
+            "hash": "4ae17bbc616c22b6186c2b1a51316f3ccd41c1baf076be218159c5cac3a966f8",
+            "storageAddress": "http://testserver/model/4ae17bbc616c22b6186c2b1a51316f3ccd41c1baf076be218159c5cac3a966f8/file/"
+        },
         "permissions": {
             "process": {
                 "public": True,
@@ -325,23 +325,23 @@ traintuple = [
             }
         },
         "rank": 0,
-        "status": "failed",
+        "status": "done",
         "tag": ""
     }
 ]
 
 testtuple = [
     {
-        "key": "b2d127e65583080bf85d51f4bbc6b04e420414dd668f921c419eb6f078e428ae",
+        "key": "5821c61f285939aec24bc764c5caee81cb9a2e80ff2b8a7c11db0d6d6adfb05b",
         "algo": {
             "name": "Logistic regression",
-            "hash": "6523012b72bcd0299f709bc6aaa084d2092dddb9a6256fbffa64645478995a1d",
-            "storageAddress": "http://testserver/algo/6523012b72bcd0299f709bc6aaa084d2092dddb9a6256fbffa64645478995a1d/file/"
+            "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
+            "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/"
         },
         "certified": True,
-        "creator": "chu-nantesMSP",
+        "creator": "MyPeer2MSP",
         "dataset": {
-            "worker": "owkinMSP",
+            "worker": "MyPeer1MSP",
             "keys": [
                 "17d58b67ae2028018108c9bf555fa58b2ddcfe560e0117294196e79d26140b2a",
                 "8bf3bf4f753a32f27d18c86405e7a406a83a55610d91abcca9acc525061b8ecf"
@@ -350,15 +350,16 @@ testtuple = [
             "perf": 0
         },
         "log": "",
+        "traintupleKey": "39005faca3fd168e513c812de144b62fa4ce48df9d0ba1a03c56fae76aebae80",
         "model": {
-            "traintupleKey": "05b44fa4b94d548e35922629f7b23dd84f777d09925bbecb0362081ca528f746",
-            "hash": "e6a16f5bea8a485f48a8aa8c462155d2d500022a9459c1ff4b3c32acd168ff99",
-            "storageAddress": "http://testserver/model/e6a16f5bea8a485f48a8aa8c462155d2d500022a9459c1ff4b3c32acd168ff99/file/"
+            "traintupleKey": "39005faca3fd168e513c812de144b62fa4ce48df9d0ba1a03c56fae76aebae80",
+            "hash": "88c1b3c49f54601effbac2027ec5e562c1e6b33b9734fb0c86fa40f4f46745f9",
+            "storageAddress": "http://testserver/model/88c1b3c49f54601effbac2027ec5e562c1e6b33b9734fb0c86fa40f4f46745f9/file/"
         },
         "objective": {
             "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
             "metrics": {
-                "hash": "506dacd8800c36e70ad3df7379c9164e03452d700bd2c3edb472e6bd0dc01f2e",
+                "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
                 "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
             }
         },
@@ -370,17 +371,17 @@ testtuple = [
 model = [
     {
         "traintuple": {
-            "key": "363f70dcc3bf22fdce65e36c957e855b7cd3e2828e6909f34ccc97ee6218541a",
+            "key": "939e412a4045f17d9c3d7e4b46399afcd78f77647bc74681c259271dc3a3127e",
             "algo": {
                 "name": "Neural Network",
                 "hash": "0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f",
                 "storageAddress": "http://testserver/algo/0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f/file/"
             },
-            "creator": "chu-nantesMSP",
+            "creator": "MyPeer2MSP",
             "dataset": {
-                "worker": "chu-nantesMSP",
+                "worker": "MyPeer2MSP",
                 "keys": [
-                    "dacc0288138cb50569250f996bbe716ec8968fb334d32f29f174c9e79a224127",
+                    "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
                     "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
                 ],
                 "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
@@ -388,11 +389,11 @@ model = [
             },
             "computePlanID": "",
             "inModels": None,
-            "log": "[00-01-0032-e18ebeb]",
+            "log": "[00-01-0032-7da30ce]",
             "objective": {
                 "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
                 "metrics": {
-                    "hash": "506dacd8800c36e70ad3df7379c9164e03452d700bd2c3edb472e6bd0dc01f2e",
+                    "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
                     "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
                 }
             },
@@ -405,7 +406,7 @@ model = [
             },
             "rank": 0,
             "status": "failed",
-            "tag": "My super tag"
+            "tag": "(should fail) My super tag"
         },
         "testtuple": {
             "key": "",
@@ -414,25 +415,26 @@ model = [
             "creator": "",
             "dataset": None,
             "log": "",
+            "traintupleKey": "",
             "model": None,
             "objective": None,
             "status": "",
             "tag": ""
         }
-    },
+    },    
     {
         "traintuple": {
-            "key": "05b44fa4b94d548e35922629f7b23dd84f777d09925bbecb0362081ca528f746",
+            "key": "39005faca3fd168e513c812de144b62fa4ce48df9d0ba1a03c56fae76aebae80",
             "algo": {
                 "name": "Logistic regression",
-                "hash": "6523012b72bcd0299f709bc6aaa084d2092dddb9a6256fbffa64645478995a1d",
-                "storageAddress": "http://testserver/algo/6523012b72bcd0299f709bc6aaa084d2092dddb9a6256fbffa64645478995a1d/file/"
+                "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
+                "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/"
             },
-            "creator": "chu-nantesMSP",
+            "creator": "MyPeer2MSP",
             "dataset": {
-                "worker": "chu-nantesMSP",
+                "worker": "MyPeer2MSP",
                 "keys": [
-                    "dacc0288138cb50569250f996bbe716ec8968fb334d32f29f174c9e79a224127",
+                    "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
                     "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
                 ],
                 "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
@@ -444,13 +446,13 @@ model = [
             "objective": {
                 "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
                 "metrics": {
-                    "hash": "506dacd8800c36e70ad3df7379c9164e03452d700bd2c3edb472e6bd0dc01f2e",
+                    "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
                     "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
                 }
             },
             "outModel": {
-                "hash": "e6a16f5bea8a485f48a8aa8c462155d2d500022a9459c1ff4b3c32acd168ff99",
-                "storageAddress": "http://testserver/model/e6a16f5bea8a485f48a8aa8c462155d2d500022a9459c1ff4b3c32acd168ff99/file/"
+                "hash": "88c1b3c49f54601effbac2027ec5e562c1e6b33b9734fb0c86fa40f4f46745f9",
+                "storageAddress": "http://testserver/model/88c1b3c49f54601effbac2027ec5e562c1e6b33b9734fb0c86fa40f4f46745f9/file/"
             },
             "permissions": {
                 "process": {
@@ -460,19 +462,19 @@ model = [
             },
             "rank": 0,
             "status": "done",
-            "tag": "substra"
+            "tag": ""
         },
         "testtuple": {
-            "key": "b2d127e65583080bf85d51f4bbc6b04e420414dd668f921c419eb6f078e428ae",
+            "key": "5821c61f285939aec24bc764c5caee81cb9a2e80ff2b8a7c11db0d6d6adfb05b",
             "algo": {
                 "name": "Logistic regression",
-                "hash": "6523012b72bcd0299f709bc6aaa084d2092dddb9a6256fbffa64645478995a1d",
-                "storageAddress": "http://testserver/algo/6523012b72bcd0299f709bc6aaa084d2092dddb9a6256fbffa64645478995a1d/file/"
+                "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
+                "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/"
             },
             "certified": True,
-            "creator": "chu-nantesMSP",
+            "creator": "MyPeer2MSP",
             "dataset": {
-                "worker": "owkinMSP",
+                "worker": "MyPeer1MSP",
                 "keys": [
                     "17d58b67ae2028018108c9bf555fa58b2ddcfe560e0117294196e79d26140b2a",
                     "8bf3bf4f753a32f27d18c86405e7a406a83a55610d91abcca9acc525061b8ecf"
@@ -481,15 +483,16 @@ model = [
                 "perf": 0
             },
             "log": "",
+            "traintupleKey": "39005faca3fd168e513c812de144b62fa4ce48df9d0ba1a03c56fae76aebae80",
             "model": {
-                "traintupleKey": "05b44fa4b94d548e35922629f7b23dd84f777d09925bbecb0362081ca528f746",
-                "hash": "e6a16f5bea8a485f48a8aa8c462155d2d500022a9459c1ff4b3c32acd168ff99",
-                "storageAddress": "http://testserver/model/e6a16f5bea8a485f48a8aa8c462155d2d500022a9459c1ff4b3c32acd168ff99/file/"
+                "traintupleKey": "39005faca3fd168e513c812de144b62fa4ce48df9d0ba1a03c56fae76aebae80",
+                "hash": "88c1b3c49f54601effbac2027ec5e562c1e6b33b9734fb0c86fa40f4f46745f9",
+                "storageAddress": "http://testserver/model/88c1b3c49f54601effbac2027ec5e562c1e6b33b9734fb0c86fa40f4f46745f9/file/"
             },
             "objective": {
                 "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
                 "metrics": {
-                    "hash": "506dacd8800c36e70ad3df7379c9164e03452d700bd2c3edb472e6bd0dc01f2e",
+                    "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
                     "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
                 }
             },
@@ -497,74 +500,19 @@ model = [
             "tag": "substra"
         }
     },
-    {
+{
         "traintuple": {
-            "key": "32070e156eb4f97d85ff8448ea2ab71f4f275ab845159029354e4446aff974e0",
-            "algo": {
-                "name": "Logistic regression",
-                "hash": "6523012b72bcd0299f709bc6aaa084d2092dddb9a6256fbffa64645478995a1d",
-                "storageAddress": "http://testserver/algo/6523012b72bcd0299f709bc6aaa084d2092dddb9a6256fbffa64645478995a1d/file/"
-            },
-            "creator": "chu-nantesMSP",
-            "dataset": {
-                "worker": "chu-nantesMSP",
-                "keys": [
-                    "dacc0288138cb50569250f996bbe716ec8968fb334d32f29f174c9e79a224127",
-                    "e3644123451975be20909fcfd9c664a0573d9bfe04c5021625412d78c3536f1c"
-                ],
-                "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
-                "perf": 1
-            },
-            "computePlanID": "32070e156eb4f97d85ff8448ea2ab71f4f275ab845159029354e4446aff974e0",
-            "inModels": None,
-            "log": "",
-            "objective": {
-                "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
-                "metrics": {
-                    "hash": "506dacd8800c36e70ad3df7379c9164e03452d700bd2c3edb472e6bd0dc01f2e",
-                    "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
-                }
-            },
-            "outModel": {
-                "hash": "0b1ce6f2bd9247a262c3695aa07aad5ef187197f118c73c60a42e176f8f53b98",
-                "storageAddress": "http://testserver/model/0b1ce6f2bd9247a262c3695aa07aad5ef187197f118c73c60a42e176f8f53b98/file/"
-            },
-            "permissions": {
-                "process": {
-                    "public": True,
-                    "authorizedIDs": []
-                }
-            },
-            "rank": 0,
-            "status": "done",
-            "tag": ""
-        },
-        "testtuple": {
-            "key": "",
-            "algo": None,
-            "certified": False,
-            "creator": "",
-            "dataset": None,
-            "log": "",
-            "model": None,
-            "objective": None,
-            "status": "",
-            "tag": ""
-        }
-    },
-    {
-        "traintuple": {
-            "key": "a2171a1c09738c677748346d22d2b5eea47f874a3b4f4b75224674235892de72",
+            "key": "102d2f2a63ae1dfd118a3349b1f1fe8c8dedf36dfd198597bd7bc03d5367b38b",
             "algo": {
                 "name": "Random Forest",
                 "hash": "9c3d8777e11fd72cbc0fd672bec3a0848f8518b4d56706008cc05f8a1cee44f9",
                 "storageAddress": "http://testserver/algo/9c3d8777e11fd72cbc0fd672bec3a0848f8518b4d56706008cc05f8a1cee44f9/file/"
             },
-            "creator": "chu-nantesMSP",
+            "creator": "MyPeer2MSP",
             "dataset": {
-                "worker": "chu-nantesMSP",
+                "worker": "MyPeer2MSP",
                 "keys": [
-                    "dacc0288138cb50569250f996bbe716ec8968fb334d32f29f174c9e79a224127",
+                    "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
                     "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
                 ],
                 "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
@@ -572,11 +520,11 @@ model = [
             },
             "computePlanID": "",
             "inModels": None,
-            "log": "[00-01-0032-8189cc5]",
+            "log": "[00-01-0032-27dbbe0]",
             "objective": {
                 "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
                 "metrics": {
-                    "hash": "506dacd8800c36e70ad3df7379c9164e03452d700bd2c3edb472e6bd0dc01f2e",
+                    "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
                     "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
                 }
             },
@@ -589,6 +537,62 @@ model = [
             },
             "rank": 0,
             "status": "failed",
+            "tag": "(should fail) My other tag"
+        },
+        "testtuple": {
+            "key": "",
+            "algo": None,
+            "certified": False,
+            "creator": "",
+            "dataset": None,
+            "log": "",
+            "traintupleKey": "",
+            "model": None,
+            "objective": None,
+            "status": "",
+            "tag": ""
+        }
+    },
+    {
+        "traintuple": {
+            "key": "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3",
+            "algo": {
+                "name": "Logistic regression",
+                "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
+                "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/"
+            },
+            "creator": "MyPeer2MSP",
+            "dataset": {
+                "worker": "MyPeer2MSP",
+                "keys": [
+                    "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
+                    "e3644123451975be20909fcfd9c664a0573d9bfe04c5021625412d78c3536f1c"
+                ],
+                "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
+                "perf": 1
+            },
+            "computePlanID": "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3",
+            "inModels": None,
+            "log": "",
+            "objective": {
+                "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
+                "metrics": {
+                    "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
+                    "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
+                }
+            },
+            "outModel": {
+                "hash": "4ae17bbc616c22b6186c2b1a51316f3ccd41c1baf076be218159c5cac3a966f8",
+                "storageAddress": "http://testserver/model/4ae17bbc616c22b6186c2b1a51316f3ccd41c1baf076be218159c5cac3a966f8/file/"
+            },
+            "permissions": {
+                "process": {
+                    "public": True,
+                    "authorizedIDs": []
+                }
+            },
+            "rank": 0,
+            "status": "done",
             "tag": ""
         },
         "testtuple": {
@@ -598,6 +602,7 @@ model = [
             "creator": "",
             "dataset": None,
             "log": "",
+            "traintupleKey": "",
             "model": None,
             "objective": None,
             "status": "",
@@ -605,3 +610,4 @@ model = [
         }
     }
 ]
+

--- a/backend/substrapp/tests/tests_tasks.py
+++ b/backend/substrapp/tests/tests_tasks.py
@@ -390,7 +390,6 @@ class TasksTests(APITestCase):
     def test_get_model(self):
         model_content = self.model.read().encode()
         traintupleKey = compute_hash(model_content)
-        model_hash = compute_hash(model_content, traintupleKey)
         subtuple = {'traintupleKey': traintupleKey}
 
         with mock.patch('substrapp.tasks.utils.get_remote_file_content') as mget_remote_file, \

--- a/backend/substrapp/tests/tests_tasks.py
+++ b/backend/substrapp/tests/tests_tasks.py
@@ -396,8 +396,8 @@ class TasksTests(APITestCase):
                 mock.patch('substrapp.tasks.utils.get_owner') as mget_owner,\
                 mock.patch('substrapp.tasks.tasks.get_object_from_ledger') as mget_object_from_ledger:
             mget_remote_file.return_value = model_content
-            mget_owner.return_value = assets.traintuple[1]['creator']
-            mget_object_from_ledger.return_value = assets.traintuple[1]  # uses index 1 to have a set value of outModel
+            mget_owner.return_value = assets.traintuple[2]['creator']
+            mget_object_from_ledger.return_value = assets.traintuple[2]  # uses index 1 to have a set value of outModel
             model_content = get_model(subtuple)
 
         self.assertIsNotNone(model_content)

--- a/backend/substrapp/tests/views/tests_views_tuples.py
+++ b/backend/substrapp/tests/views/tests_views_tuples.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import logging
+import urllib
 
 import mock
 
@@ -105,8 +106,8 @@ class TraintupleViewTests(APITestCase):
         url = reverse('substrapp:traintuple-list')
         with mock.patch('substrapp.views.traintuple.query_ledger') as mquery_ledger:
             mquery_ledger.return_value = traintuple
-
-            search_params = '?search=traintuple%253Atag%253Asubstra'
+            targetTag = '(should fail) My super tag'
+            search_params = '?search=traintuple%253Atag%253A' + urllib.parse.quote_plus(targetTag)
             response = self.client.get(url + search_params, **self.extra)
             r = response.json()
 


### PR DESCRIPTION
See also: https://github.com/SubstraFoundation/substra-chaincode/pull/21

--- 

Instead of accessing `model.hash` and `model.storageAddress` directly, use the new `testtuple.traintupleKey` field. Use that traintuple key to obtain the model hash and storage address by requesting the traintuple metadata. 

Since traintuples and testtuples now have a different structure, update the name of function parameters to make it clear which functions take a `traintuple` or a `testtuple` as an argument.