### PR TITLE
List and retrieve compute_plans

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+backend/node/tests
+backend/substrapp/tests

--- a/backend/substrapp/tests/assets.py
+++ b/backend/substrapp/tests/assets.py
@@ -22,7 +22,7 @@ objective = [
         },
         "metrics": {
             "name": "macro-average recall",
-            "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
+            "hash": "e5762042461c355761dd8986b510ea23494d5638a671370dabbf0ac73f8a3208",
             "storageAddress": "http://testserver/objective/1cdafbb018dd195690111d74916b76c96892d897ec3587c814f287946db446c3/metrics/"
         },
         "owner": "MyPeer1MSP",
@@ -43,7 +43,7 @@ objective = [
         },
         "metrics": {
             "name": "macro-average recall",
-            "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
+            "hash": "e5762042461c355761dd8986b510ea23494d5638a671370dabbf0ac73f8a3208",
             "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
         },
         "owner": "MyPeer1MSP",
@@ -189,11 +189,11 @@ traintuple = [
         },
         "computePlanID": "",
         "inModels": None,
-        "log": "[00-01-0032-7da30ce]",
+        "log": "[01-01-0014-2cdf475]",
         "objective": {
             "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
             "metrics": {
-                "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
+                "hash": "e5762042461c355761dd8986b510ea23494d5638a671370dabbf0ac73f8a3208",
                 "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
             }
         },
@@ -225,13 +225,13 @@ traintuple = [
             "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
             "perf": 0
         },
-        "computePlanID": "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3",
+        "computePlanID": "",
         "inModels": None,
-        "log": "[00-01-0032-27dbbe0]",
+        "log": "[01-01-0014-619b4a4]",
         "objective": {
             "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
             "metrics": {
-                "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
+                "hash": "e5762042461c355761dd8986b510ea23494d5638a671370dabbf0ac73f8a3208",
                 "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
             }
         },
@@ -261,21 +261,21 @@ traintuple = [
                 "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
             ],
             "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
-            "perf": 0
+            "perf": 1
         },
         "computePlanID": "",
         "inModels": None,
-        "log": "[01-01-0014-b8a6e50]",
+        "log": "",
         "objective": {
             "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
             "metrics": {
-                "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
+                "hash": "e5762042461c355761dd8986b510ea23494d5638a671370dabbf0ac73f8a3208",
                 "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
             }
         },
         "outModel": {
-            "hash": "88c1b3c49f54601effbac2027ec5e562c1e6b33b9734fb0c86fa40f4f46745f9",
-            "storageAddress": "http://testserver/model/88c1b3c49f54601effbac2027ec5e562c1e6b33b9734fb0c86fa40f4f46745f9/file/"
+            "hash": "3aba7b675ed1218df54d332c1d2f0b760651b82b08f196cdc2c9406d104a10a1",
+            "storageAddress": "http://testserver/model/3aba7b675ed1218df54d332c1d2f0b760651b82b08f196cdc2c9406d104a10a1/file/"
         },
         "permissions": {
             "process": {
@@ -284,8 +284,8 @@ traintuple = [
             }
         },
         "rank": 0,
-        "status": "failed",
-        "tag": "(should fail) My other tag"
+        "status": "done",
+        "tag": ""
     },
     {
         "key": "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3",
@@ -310,13 +310,13 @@ traintuple = [
         "objective": {
             "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
             "metrics": {
-                "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
+                "hash": "e5762042461c355761dd8986b510ea23494d5638a671370dabbf0ac73f8a3208",
                 "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
             }
         },
         "outModel": {
-            "hash": "4ae17bbc616c22b6186c2b1a51316f3ccd41c1baf076be218159c5cac3a966f8",
-            "storageAddress": "http://testserver/model/4ae17bbc616c22b6186c2b1a51316f3ccd41c1baf076be218159c5cac3a966f8/file/"
+            "hash": "438a2086ea1ec817cba2f21dec43aa0691f4ed26a605dae9345502e8d3c36293",
+            "storageAddress": "http://testserver/model/438a2086ea1ec817cba2f21dec43aa0691f4ed26a605dae9345502e8d3c36293/file/"
         },
         "permissions": {
             "process": {
@@ -351,24 +351,31 @@ testtuple = [
         },
         "log": "",
         "traintupleKey": "39005faca3fd168e513c812de144b62fa4ce48df9d0ba1a03c56fae76aebae80",
-        "model": {
-            "traintupleKey": "39005faca3fd168e513c812de144b62fa4ce48df9d0ba1a03c56fae76aebae80",
-            "hash": "88c1b3c49f54601effbac2027ec5e562c1e6b33b9734fb0c86fa40f4f46745f9",
-            "storageAddress": "http://testserver/model/88c1b3c49f54601effbac2027ec5e562c1e6b33b9734fb0c86fa40f4f46745f9/file/"
-        },
         "objective": {
             "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
             "metrics": {
-                "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
+                "hash": "e5762042461c355761dd8986b510ea23494d5638a671370dabbf0ac73f8a3208",
                 "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
             }
         },
-        "status": "failed",
+        "status": "done",
         "tag": "substra"
     }
 ]
 
 computeplan = [
+    {
+        "computePlanID": "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3",
+        "algoKey": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
+        "objectiveKey": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
+        "traintuples": [
+            "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3"
+        ],
+        "testtuples": None
+    }
+]
+
+model = [
     {
         "traintuple": {
             "key": "939e412a4045f17d9c3d7e4b46399afcd78f77647bc74681c259271dc3a3127e",
@@ -389,11 +396,11 @@ computeplan = [
             },
             "computePlanID": "",
             "inModels": None,
-            "log": "[00-01-0032-7da30ce]",
+            "log": "[01-01-0014-2cdf475]",
             "objective": {
                 "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
                 "metrics": {
-                    "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
+                    "hash": "e5762042461c355761dd8986b510ea23494d5638a671370dabbf0ac73f8a3208",
                     "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
                 }
             },
@@ -416,7 +423,6 @@ computeplan = [
             "dataset": None,
             "log": "",
             "traintupleKey": "",
-            "model": None,
             "objective": None,
             "status": "",
             "tag": ""
@@ -446,13 +452,13 @@ computeplan = [
             "objective": {
                 "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
                 "metrics": {
-                    "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
+                    "hash": "e5762042461c355761dd8986b510ea23494d5638a671370dabbf0ac73f8a3208",
                     "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
                 }
             },
             "outModel": {
-                "hash": "88c1b3c49f54601effbac2027ec5e562c1e6b33b9734fb0c86fa40f4f46745f9",
-                "storageAddress": "http://testserver/model/88c1b3c49f54601effbac2027ec5e562c1e6b33b9734fb0c86fa40f4f46745f9/file/"
+                "hash": "3aba7b675ed1218df54d332c1d2f0b760651b82b08f196cdc2c9406d104a10a1",
+                "storageAddress": "http://testserver/model/3aba7b675ed1218df54d332c1d2f0b760651b82b08f196cdc2c9406d104a10a1/file/"
             },
             "permissions": {
                 "process": {
@@ -484,23 +490,18 @@ computeplan = [
             },
             "log": "",
             "traintupleKey": "39005faca3fd168e513c812de144b62fa4ce48df9d0ba1a03c56fae76aebae80",
-            "model": {
-                "traintupleKey": "39005faca3fd168e513c812de144b62fa4ce48df9d0ba1a03c56fae76aebae80",
-                "hash": "88c1b3c49f54601effbac2027ec5e562c1e6b33b9734fb0c86fa40f4f46745f9",
-                "storageAddress": "http://testserver/model/88c1b3c49f54601effbac2027ec5e562c1e6b33b9734fb0c86fa40f4f46745f9/file/"
-            },
             "objective": {
                 "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
                 "metrics": {
-                    "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
+                    "hash": "e5762042461c355761dd8986b510ea23494d5638a671370dabbf0ac73f8a3208",
                     "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
                 }
             },
-            "status": "failed",
+            "status": "done",
             "tag": "substra"
         }
     },
-{
+    {
         "traintuple": {
             "key": "102d2f2a63ae1dfd118a3349b1f1fe8c8dedf36dfd198597bd7bc03d5367b38b",
             "algo": {
@@ -520,11 +521,11 @@ computeplan = [
             },
             "computePlanID": "",
             "inModels": None,
-            "log": "[00-01-0032-27dbbe0]",
+            "log": "[01-01-0014-619b4a4]",
             "objective": {
                 "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
                 "metrics": {
-                    "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
+                    "hash": "e5762042461c355761dd8986b510ea23494d5638a671370dabbf0ac73f8a3208",
                     "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
                 }
             },
@@ -547,7 +548,6 @@ computeplan = [
             "dataset": None,
             "log": "",
             "traintupleKey": "",
-            "model": None,
             "objective": None,
             "status": "",
             "tag": ""
@@ -577,13 +577,13 @@ computeplan = [
             "objective": {
                 "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
                 "metrics": {
-                    "hash": "e1dec0cdb193497bfad300bcb98b59a05d0055e0d5c9a8347e12f63c2ba8fa35",
+                    "hash": "e5762042461c355761dd8986b510ea23494d5638a671370dabbf0ac73f8a3208",
                     "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
                 }
             },
             "outModel": {
-                "hash": "4ae17bbc616c22b6186c2b1a51316f3ccd41c1baf076be218159c5cac3a966f8",
-                "storageAddress": "http://testserver/model/4ae17bbc616c22b6186c2b1a51316f3ccd41c1baf076be218159c5cac3a966f8/file/"
+                "hash": "438a2086ea1ec817cba2f21dec43aa0691f4ed26a605dae9345502e8d3c36293",
+                "storageAddress": "http://testserver/model/438a2086ea1ec817cba2f21dec43aa0691f4ed26a605dae9345502e8d3c36293/file/"
             },
             "permissions": {
                 "process": {
@@ -603,7 +603,6 @@ computeplan = [
             "dataset": None,
             "log": "",
             "traintupleKey": "",
-            "model": None,
             "objective": None,
             "status": "",
             "tag": ""

--- a/backend/substrapp/tests/assets.py
+++ b/backend/substrapp/tests/assets.py
@@ -421,7 +421,7 @@ model = [
             "status": "",
             "tag": ""
         }
-    },    
+    },
     {
         "traintuple": {
             "key": "39005faca3fd168e513c812de144b62fa4ce48df9d0ba1a03c56fae76aebae80",
@@ -611,3 +611,6 @@ model = [
     }
 ]
 
+computeplan = [
+    # todo
+]

--- a/backend/substrapp/tests/assets.py
+++ b/backend/substrapp/tests/assets.py
@@ -225,7 +225,7 @@ traintuple = [
             "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
             "perf": 0
         },
-        "computePlanID": "",
+        "computePlanID": "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3",
         "inModels": None,
         "log": "[00-01-0032-27dbbe0]",
         "objective": {
@@ -261,11 +261,11 @@ traintuple = [
                 "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
             ],
             "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
-            "perf": 1
+            "perf": 0
         },
         "computePlanID": "",
         "inModels": None,
-        "log": "",
+        "log": "[01-01-0014-b8a6e50]",
         "objective": {
             "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
             "metrics": {
@@ -284,8 +284,8 @@ traintuple = [
             }
         },
         "rank": 0,
-        "status": "done",
-        "tag": ""
+        "status": "failed",
+        "tag": "(should fail) My other tag"
     },
     {
         "key": "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3",
@@ -363,12 +363,12 @@ testtuple = [
                 "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
             }
         },
-        "status": "done",
+        "status": "failed",
         "tag": "substra"
     }
 ]
 
-model = [
+computeplan = [
     {
         "traintuple": {
             "key": "939e412a4045f17d9c3d7e4b46399afcd78f77647bc74681c259271dc3a3127e",
@@ -496,7 +496,7 @@ model = [
                     "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
                 }
             },
-            "status": "done",
+            "status": "failed",
             "tag": "substra"
         }
     },
@@ -609,8 +609,4 @@ model = [
             "tag": ""
         }
     }
-]
-
-computeplan = [
-    # todo
 ]

--- a/backend/substrapp/tests/assets.py
+++ b/backend/substrapp/tests/assets.py
@@ -25,7 +25,7 @@ objective = [
             "hash": "e5762042461c355761dd8986b510ea23494d5638a671370dabbf0ac73f8a3208",
             "storageAddress": "http://testserver/objective/1cdafbb018dd195690111d74916b76c96892d897ec3587c814f287946db446c3/metrics/"
         },
-        "owner": "MyPeer1MSP",
+        "owner": "MyOrg1MSP",
         "testDataset": None,
         "permissions": {
             "process": {
@@ -46,7 +46,7 @@ objective = [
             "hash": "e5762042461c355761dd8986b510ea23494d5638a671370dabbf0ac73f8a3208",
             "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
         },
-        "owner": "MyPeer1MSP",
+        "owner": "MyOrg1MSP",
         "testDataset": {
             "dataManagerKey": "ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932",
             "dataSampleKeys": [
@@ -77,7 +77,7 @@ datamanager = [
             "hash": "ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932",
             "storageAddress": "http://testserver/data_manager/ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932/opener/"
         },
-        "owner": "MyPeer1MSP",
+        "owner": "MyOrg1MSP",
         "permissions": {
             "process": {
                 "public": True,
@@ -98,7 +98,7 @@ datamanager = [
             "hash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
             "storageAddress": "http://testserver/data_manager/8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca/opener/"
         },
-        "owner": "MyPeer2MSP",
+        "owner": "MyOrg2MSP",
         "permissions": {
             "process": {
                 "public": True,
@@ -121,7 +121,7 @@ algo = [
             "hash": "124a0425b746d7072282d167b53cb6aab3a31bf1946dae89135c15b0126ebec3",
             "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/description/"
         },
-        "owner": "MyPeer1MSP",
+        "owner": "MyOrg1MSP",
         "permissions": {
             "process": {
                 "public": True,
@@ -140,7 +140,7 @@ algo = [
             "hash": "b9463411a01ea00869bdffce6e59a5c100a4e635c0a9386266cad3c77eb28e9e",
             "storageAddress": "http://testserver/algo/0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f/description/"
         },
-        "owner": "MyPeer2MSP",
+        "owner": "MyOrg2MSP",
         "permissions": {
             "process": {
                 "public": True,
@@ -159,7 +159,7 @@ algo = [
             "hash": "4acea40c4b51996c88ef279c5c9aa41ab77b97d38c5ca167e978a98b2e402675",
             "storageAddress": "http://testserver/algo/9c3d8777e11fd72cbc0fd672bec3a0848f8518b4d56706008cc05f8a1cee44f9/description/"
         },
-        "owner": "MyPeer2MSP",
+        "owner": "MyOrg2MSP",
         "permissions": {
             "process": {
                 "public": True,
@@ -171,15 +171,15 @@ algo = [
 
 traintuple = [
     {
-        "key": "939e412a4045f17d9c3d7e4b46399afcd78f77647bc74681c259271dc3a3127e",
+        "key": "c1d77d8e53f048b60863a1c453c60392e3f2b7b38dd0853f9b9664a5cef1c7cc",
         "algo": {
             "name": "Neural Network",
             "hash": "0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f",
             "storageAddress": "http://testserver/algo/0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f/file/"
         },
-        "creator": "MyPeer2MSP",
+        "creator": "MyOrg2MSP",
         "dataset": {
-            "worker": "MyPeer2MSP",
+            "worker": "MyOrg2MSP",
             "keys": [
                 "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
                 "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
@@ -189,7 +189,7 @@ traintuple = [
         },
         "computePlanID": "",
         "inModels": None,
-        "log": "[01-01-0014-2cdf475]",
+        "log": "[01-01-0014-f7f130b]",
         "objective": {
             "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
             "metrics": {
@@ -209,15 +209,15 @@ traintuple = [
         "tag": "(should fail) My super tag"
     },
     {
-        "key": "102d2f2a63ae1dfd118a3349b1f1fe8c8dedf36dfd198597bd7bc03d5367b38b",
+        "key": "a55fb929e12bca0be8e7d6db58bc7f5b6d2134c7c36d29961729da54d383dc01",
         "algo": {
             "name": "Random Forest",
             "hash": "9c3d8777e11fd72cbc0fd672bec3a0848f8518b4d56706008cc05f8a1cee44f9",
             "storageAddress": "http://testserver/algo/9c3d8777e11fd72cbc0fd672bec3a0848f8518b4d56706008cc05f8a1cee44f9/file/"
         },
-        "creator": "MyPeer2MSP",
+        "creator": "MyOrg2MSP",
         "dataset": {
-            "worker": "MyPeer2MSP",
+            "worker": "MyOrg2MSP",
             "keys": [
                 "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
                 "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
@@ -227,7 +227,7 @@ traintuple = [
         },
         "computePlanID": "",
         "inModels": None,
-        "log": "[01-01-0014-619b4a4]",
+        "log": "[01-01-0014-01b28b3]",
         "objective": {
             "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
             "metrics": {
@@ -247,15 +247,15 @@ traintuple = [
         "tag": "(should fail) My other tag"
     },
     {
-        "key": "39005faca3fd168e513c812de144b62fa4ce48df9d0ba1a03c56fae76aebae80",
+        "key": "d7e429016148abfac682ec6a183b7883ccb96cd375bb3c7f5d3c35816c04f7d6",
         "algo": {
             "name": "Logistic regression",
             "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
             "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/"
         },
-        "creator": "MyPeer2MSP",
+        "creator": "MyOrg2MSP",
         "dataset": {
-            "worker": "MyPeer2MSP",
+            "worker": "MyOrg2MSP",
             "keys": [
                 "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
                 "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
@@ -274,8 +274,8 @@ traintuple = [
             }
         },
         "outModel": {
-            "hash": "3aba7b675ed1218df54d332c1d2f0b760651b82b08f196cdc2c9406d104a10a1",
-            "storageAddress": "http://testserver/model/3aba7b675ed1218df54d332c1d2f0b760651b82b08f196cdc2c9406d104a10a1/file/"
+            "hash": "53fbedaf9b84a3c9a8a473501caef845f55ea16c693e32f0b13c1cf02ada7ef7",
+            "storageAddress": "http://testserver/model/53fbedaf9b84a3c9a8a473501caef845f55ea16c693e32f0b13c1cf02ada7ef7/file/"
         },
         "permissions": {
             "process": {
@@ -288,15 +288,15 @@ traintuple = [
         "tag": ""
     },
     {
-        "key": "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3",
+        "key": "d376a672c7231fba31e23c868202e088a06783da48577654360025050eaf88cc",
         "algo": {
             "name": "Logistic regression",
             "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
             "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/"
         },
-        "creator": "MyPeer2MSP",
+        "creator": "MyOrg2MSP",
         "dataset": {
-            "worker": "MyPeer2MSP",
+            "worker": "MyOrg2MSP",
             "keys": [
                 "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
                 "e3644123451975be20909fcfd9c664a0573d9bfe04c5021625412d78c3536f1c"
@@ -304,7 +304,7 @@ traintuple = [
             "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
             "perf": 1
         },
-        "computePlanID": "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3",
+        "computePlanID": "d376a672c7231fba31e23c868202e088a06783da48577654360025050eaf88cc",
         "inModels": None,
         "log": "",
         "objective": {
@@ -315,8 +315,8 @@ traintuple = [
             }
         },
         "outModel": {
-            "hash": "438a2086ea1ec817cba2f21dec43aa0691f4ed26a605dae9345502e8d3c36293",
-            "storageAddress": "http://testserver/model/438a2086ea1ec817cba2f21dec43aa0691f4ed26a605dae9345502e8d3c36293/file/"
+            "hash": "97ba127dac7394c6af47b922c7d31aef9019fa26db803476170d44a389486f92",
+            "storageAddress": "http://testserver/model/97ba127dac7394c6af47b922c7d31aef9019fa26db803476170d44a389486f92/file/"
         },
         "permissions": {
             "process": {
@@ -332,16 +332,16 @@ traintuple = [
 
 testtuple = [
     {
-        "key": "5821c61f285939aec24bc764c5caee81cb9a2e80ff2b8a7c11db0d6d6adfb05b",
+        "key": "b835634d3ffb38fa98101619717aa07b62051ab2caa7be784dd1cfaef374d99a",
         "algo": {
             "name": "Logistic regression",
             "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
             "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/"
         },
         "certified": True,
-        "creator": "MyPeer2MSP",
+        "creator": "MyOrg2MSP",
         "dataset": {
-            "worker": "MyPeer1MSP",
+            "worker": "MyOrg1MSP",
             "keys": [
                 "17d58b67ae2028018108c9bf555fa58b2ddcfe560e0117294196e79d26140b2a",
                 "8bf3bf4f753a32f27d18c86405e7a406a83a55610d91abcca9acc525061b8ecf"
@@ -350,7 +350,7 @@ testtuple = [
             "perf": 0
         },
         "log": "",
-        "traintupleKey": "39005faca3fd168e513c812de144b62fa4ce48df9d0ba1a03c56fae76aebae80",
+        "traintupleKey": "d7e429016148abfac682ec6a183b7883ccb96cd375bb3c7f5d3c35816c04f7d6",
         "objective": {
             "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
             "metrics": {
@@ -365,11 +365,11 @@ testtuple = [
 
 computeplan = [
     {
-        "computePlanID": "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3",
+        "computePlanID": "d376a672c7231fba31e23c868202e088a06783da48577654360025050eaf88cc",
         "algoKey": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
         "objectiveKey": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
         "traintuples": [
-            "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3"
+            "d376a672c7231fba31e23c868202e088a06783da48577654360025050eaf88cc"
         ],
         "testtuples": None
     }
@@ -378,15 +378,15 @@ computeplan = [
 model = [
     {
         "traintuple": {
-            "key": "939e412a4045f17d9c3d7e4b46399afcd78f77647bc74681c259271dc3a3127e",
+            "key": "c1d77d8e53f048b60863a1c453c60392e3f2b7b38dd0853f9b9664a5cef1c7cc",
             "algo": {
                 "name": "Neural Network",
                 "hash": "0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f",
                 "storageAddress": "http://testserver/algo/0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f/file/"
             },
-            "creator": "MyPeer2MSP",
+            "creator": "MyOrg2MSP",
             "dataset": {
-                "worker": "MyPeer2MSP",
+                "worker": "MyOrg2MSP",
                 "keys": [
                     "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
                     "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
@@ -396,7 +396,7 @@ model = [
             },
             "computePlanID": "",
             "inModels": None,
-            "log": "[01-01-0014-2cdf475]",
+            "log": "[01-01-0014-f7f130b]",
             "objective": {
                 "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
                 "metrics": {
@@ -430,15 +430,15 @@ model = [
     },
     {
         "traintuple": {
-            "key": "39005faca3fd168e513c812de144b62fa4ce48df9d0ba1a03c56fae76aebae80",
+            "key": "d7e429016148abfac682ec6a183b7883ccb96cd375bb3c7f5d3c35816c04f7d6",
             "algo": {
                 "name": "Logistic regression",
                 "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
                 "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/"
             },
-            "creator": "MyPeer2MSP",
+            "creator": "MyOrg2MSP",
             "dataset": {
-                "worker": "MyPeer2MSP",
+                "worker": "MyOrg2MSP",
                 "keys": [
                     "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
                     "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
@@ -457,8 +457,8 @@ model = [
                 }
             },
             "outModel": {
-                "hash": "3aba7b675ed1218df54d332c1d2f0b760651b82b08f196cdc2c9406d104a10a1",
-                "storageAddress": "http://testserver/model/3aba7b675ed1218df54d332c1d2f0b760651b82b08f196cdc2c9406d104a10a1/file/"
+                "hash": "53fbedaf9b84a3c9a8a473501caef845f55ea16c693e32f0b13c1cf02ada7ef7",
+                "storageAddress": "http://testserver/model/53fbedaf9b84a3c9a8a473501caef845f55ea16c693e32f0b13c1cf02ada7ef7/file/"
             },
             "permissions": {
                 "process": {
@@ -471,16 +471,16 @@ model = [
             "tag": ""
         },
         "testtuple": {
-            "key": "5821c61f285939aec24bc764c5caee81cb9a2e80ff2b8a7c11db0d6d6adfb05b",
+            "key": "b835634d3ffb38fa98101619717aa07b62051ab2caa7be784dd1cfaef374d99a",
             "algo": {
                 "name": "Logistic regression",
                 "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
                 "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/"
             },
             "certified": True,
-            "creator": "MyPeer2MSP",
+            "creator": "MyOrg2MSP",
             "dataset": {
-                "worker": "MyPeer1MSP",
+                "worker": "MyOrg1MSP",
                 "keys": [
                     "17d58b67ae2028018108c9bf555fa58b2ddcfe560e0117294196e79d26140b2a",
                     "8bf3bf4f753a32f27d18c86405e7a406a83a55610d91abcca9acc525061b8ecf"
@@ -489,7 +489,7 @@ model = [
                 "perf": 0
             },
             "log": "",
-            "traintupleKey": "39005faca3fd168e513c812de144b62fa4ce48df9d0ba1a03c56fae76aebae80",
+            "traintupleKey": "d7e429016148abfac682ec6a183b7883ccb96cd375bb3c7f5d3c35816c04f7d6",
             "objective": {
                 "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
                 "metrics": {
@@ -503,15 +503,15 @@ model = [
     },
     {
         "traintuple": {
-            "key": "102d2f2a63ae1dfd118a3349b1f1fe8c8dedf36dfd198597bd7bc03d5367b38b",
+            "key": "a55fb929e12bca0be8e7d6db58bc7f5b6d2134c7c36d29961729da54d383dc01",
             "algo": {
                 "name": "Random Forest",
                 "hash": "9c3d8777e11fd72cbc0fd672bec3a0848f8518b4d56706008cc05f8a1cee44f9",
                 "storageAddress": "http://testserver/algo/9c3d8777e11fd72cbc0fd672bec3a0848f8518b4d56706008cc05f8a1cee44f9/file/"
             },
-            "creator": "MyPeer2MSP",
+            "creator": "MyOrg2MSP",
             "dataset": {
-                "worker": "MyPeer2MSP",
+                "worker": "MyOrg2MSP",
                 "keys": [
                     "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
                     "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
@@ -521,7 +521,7 @@ model = [
             },
             "computePlanID": "",
             "inModels": None,
-            "log": "[01-01-0014-619b4a4]",
+            "log": "[01-01-0014-01b28b3]",
             "objective": {
                 "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
                 "metrics": {
@@ -555,15 +555,15 @@ model = [
     },
     {
         "traintuple": {
-            "key": "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3",
+            "key": "d376a672c7231fba31e23c868202e088a06783da48577654360025050eaf88cc",
             "algo": {
                 "name": "Logistic regression",
                 "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
                 "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/"
             },
-            "creator": "MyPeer2MSP",
+            "creator": "MyOrg2MSP",
             "dataset": {
-                "worker": "MyPeer2MSP",
+                "worker": "MyOrg2MSP",
                 "keys": [
                     "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
                     "e3644123451975be20909fcfd9c664a0573d9bfe04c5021625412d78c3536f1c"
@@ -571,7 +571,7 @@ model = [
                 "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
                 "perf": 1
             },
-            "computePlanID": "d4ca4befe79e56b98168b80e17db415f5be8c138ddeb600b6937a3f2aa809de3",
+            "computePlanID": "d376a672c7231fba31e23c868202e088a06783da48577654360025050eaf88cc",
             "inModels": None,
             "log": "",
             "objective": {
@@ -582,8 +582,8 @@ model = [
                 }
             },
             "outModel": {
-                "hash": "438a2086ea1ec817cba2f21dec43aa0691f4ed26a605dae9345502e8d3c36293",
-                "storageAddress": "http://testserver/model/438a2086ea1ec817cba2f21dec43aa0691f4ed26a605dae9345502e8d3c36293/file/"
+                "hash": "97ba127dac7394c6af47b922c7d31aef9019fa26db803476170d44a389486f92",
+                "storageAddress": "http://testserver/model/97ba127dac7394c6af47b922c7d31aef9019fa26db803476170d44a389486f92/file/"
             },
             "permissions": {
                 "process": {

--- a/backend/substrapp/tests/generate_assets.py
+++ b/backend/substrapp/tests/generate_assets.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import json
 import substra
@@ -7,13 +8,18 @@ dir_path = os.path.dirname(__file__)
 assets_path = os.path.join(dir_path, 'assets.py')
 
 
-def main():
+def main(network):
 
     client = substra.Client()
-    client.add_profile('owkin', 'substra', 'p@$swr0d44', 'http://substra-backend.owkin.xyz:8000', '0.0')
-    client.login()
+    if network == 'docker':
+        client.add_profile('default', 'substra', 'p@$swr0d44', 'http://substra-backend.owkin.xyz', '0.0')
+    elif network == 'skaffold':
+        client.add_profile('default', 'node-1', 'p@$swr0d44', 'http://substra-backend.node-1.com', '0.0')
+    else:
+        raise Exception('Unknow network')
 
-    client.set_profile('owkin')
+    client.login()
+    client.set_profile('default')
 
     assets = {}
     assets['objective'] = json.dumps(client.list_objective(), indent=4)
@@ -21,6 +27,7 @@ def main():
     assets['algo'] = json.dumps(client.list_algo(), indent=4)
     assets['traintuple'] = json.dumps(client.list_traintuple(), indent=4)
     assets['testtuple'] = json.dumps(client.list_testtuple(), indent=4)
+    assets['computeplan'] = json.dumps(client.list_compute_plan(), indent=4)
 
     assets['model'] = json.dumps([res for res in client.client.list('model')
                                   if ('traintuple' in res and 'testtuple' in res)], indent=4)
@@ -33,8 +40,12 @@ def main():
                 '2. run populate.py\n'
                 '3. run substrapp/tests/generate_assets.py\n"""\n\n')
         for k, v in assets.items():
-            v = v.replace('substra-backend.owkin.xyz:8000', 'testserver')
-            v = v.replace('substra-backend.chunantes.xyz:8001', 'testserver')
+            if network == 'docker':
+                v = v.replace('substra-backend.owkin.xyz:8000', 'testserver')
+                v = v.replace('substra-backend.chunantes.xyz:8001', 'testserver')
+            if network == 'skaffold':
+                v = v.replace('substra-backend.node-1.com', 'testserver')
+                v = v.replace('substra-backend.node-2.com', 'testserver')
             v = v.replace('true', 'True')
             v = v.replace('false', 'False')
             v = v.replace('null', 'None')
@@ -43,4 +54,11 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-s', '--skaffold', action='store_true',
+                        help='Launch generate_assets with skaffold (K8S) network')
+
+    args = parser.parse_args()
+    network = 'skaffold' if args.skaffold else 'docker'
+
+    main(network)

--- a/backend/substrapp/tests/views/tests_views_computeplan.py
+++ b/backend/substrapp/tests/views/tests_views_computeplan.py
@@ -83,12 +83,11 @@ class ComputePlanViewTests(APITestCase):
             self.assertEqual(r, [computeplan])
 
     def test_computeplan_retrieve(self):
-        url = reverse('substrapp:data_manager-list')
         with mock.patch('substrapp.views.computeplan.get_object_from_ledger') as mget_object_from_ledger:
             mget_object_from_ledger.return_value = computeplan[0]
 
-            search_params = computeplan[0]['key']
-            response = self.client.get(url + search_params, **self.extra)
+            url = reverse('substrapp:compute_plan-detail', args=[computeplan[0]['computePlanID']])
+            response = self.client.get(url, **self.extra)
             r = response.json()
 
             self.assertEqual(r, computeplan[0])
@@ -109,6 +108,6 @@ class ComputePlanViewTests(APITestCase):
         with mock.patch('substrapp.views.computeplan.get_object_from_ledger') as mget_object_from_ledger:
             mget_object_from_ledger.side_effect = LedgerError('TEST')
 
-            search_params = computeplan[0]['key']
-            response = self.client.get(url + search_params, **self.extra)
+            search_params = computeplan[0]['computePlanID']
+            response = self.client.get(url + search_params + '/', **self.extra)
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/backend/substrapp/tests/views/tests_views_computeplan.py
+++ b/backend/substrapp/tests/views/tests_views_computeplan.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-
 import mock
 
 from django.urls import reverse
@@ -9,8 +8,11 @@ from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from substrapp.ledger_utils import LedgerError
 from substrapp.serializers import LedgerComputePlanSerializer
+
 from ..common import AuthenticatedClient
+from ..assets import computeplan
 
 MEDIA_ROOT = "/tmp/unittests_views/"
 
@@ -61,3 +63,52 @@ class ComputePlanViewTests(APITestCase):
 
         self.assertEqual(response.json(), {})
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_computeplan_list_empty(self):
+        url = reverse('substrapp:compute_plan-list')
+        with mock.patch('substrapp.views.computeplan.query_ledger') as mquery_ledger:
+            mquery_ledger.return_value = []
+
+            response = self.client.get(url, **self.extra)
+            r = response.json()
+            self.assertEqual(r, [[]])
+
+    def test_computeplan_list_success(self):
+        url = reverse('substrapp:compute_plan-list')
+        with mock.patch('substrapp.views.computeplan.query_ledger') as mquery_ledger:
+            mquery_ledger.return_value = computeplan
+
+            response = self.client.get(url, **self.extra)
+            r = response.json()
+            self.assertEqual(r, [computeplan])
+
+    def test_computeplan_retrieve(self):
+        url = reverse('substrapp:data_manager-list')
+        with mock.patch('substrapp.views.computeplan.get_object_from_ledger') as mget_object_from_ledger:
+            mget_object_from_ledger.return_value = computeplan[0]
+
+            search_params = computeplan[0]['key']
+            response = self.client.get(url + search_params, **self.extra)
+            r = response.json()
+
+            self.assertEqual(r, computeplan[0])
+
+    def test_computeplan_retrieve_fail(self):
+        url = reverse('substrapp:compute_plan-list')
+
+        # PK hash < 64 chars
+        search_params = '42303efa663015e729159833a12ffb510ff/'
+        response = self.client.get(url + search_params, **self.extra)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # PK hash not hexa
+        search_params = 'X' * 64 + '/'
+        response = self.client.get(url + search_params, **self.extra)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        with mock.patch('substrapp.views.computeplan.get_object_from_ledger') as mget_object_from_ledger:
+            mget_object_from_ledger.side_effect = LedgerError('TEST')
+
+            search_params = computeplan[0]['key']
+            response = self.client.get(url + search_params, **self.extra)
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/backend/substrapp/views/computeplan.py
+++ b/backend/substrapp/views/computeplan.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from substrapp.serializers import LedgerComputePlanSerializer
-from substrapp.ledger_utils import query_ledger, LedgerError, get_object_from_ledger
+from substrapp.ledger_utils import query_ledger, LedgerError, get_object_from_ledger, LedgerConflict
 from substrapp.views.utils import get_success_create_code, validate_pk
 from substrapp.views.filters_utils import filter_list
 
@@ -24,6 +24,9 @@ class ComputePlanViewSet(mixins.CreateModelMixin,
         args = serializer.get_args(serializer.validated_data)
         try:
             ledger_response = query_ledger(fcn='createComputePlan', args=args)
+        except LedgerConflict as e:
+            error = {'message': str(e.msg), 'pkhash': e.pkhash}
+            return Response(error, status=e.status)
         except LedgerError as e:
             error = {'message': str(e.msg)}
             return Response(error, status=e.status)

--- a/backend/substrapp/views/computeplan.py
+++ b/backend/substrapp/views/computeplan.py
@@ -1,10 +1,13 @@
-from rest_framework import mixins
+import logging
+
+from rest_framework import mixins, status
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from substrapp.serializers import LedgerComputePlanSerializer
-from substrapp.ledger_utils import query_ledger, LedgerError
-from substrapp.views.utils import get_success_create_code
+from substrapp.ledger_utils import query_ledger, LedgerError, get_object_from_ledger
+from substrapp.views.utils import get_success_create_code, validate_pk
+from substrapp.views.filters_utils import filter_list
 
 
 class ComputePlanViewSet(mixins.CreateModelMixin,
@@ -37,3 +40,42 @@ class ComputePlanViewSet(mixins.CreateModelMixin,
         headers = self.get_success_headers(data)
         status = get_success_create_code()
         return Response(data, status=status, headers=headers)
+
+    def retrieve(self, request, *args, **kwargs):
+        lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
+        pk = self.kwargs[lookup_url_kwarg]
+
+        try:
+            validate_pk(pk)
+            data = get_object_from_ledger(pk, 'queryComputePlan')
+        except LedgerError as e:
+            return Response({'message': str(e.msg)}, status=e.status)
+        except Exception as e:
+            return Response({'message': str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        else:
+            return Response(data, status=status.HTTP_200_OK)
+
+    def list(self, request, *args, **kwargs):
+        try:
+            data = query_ledger(fcn='queryComputePlans', args=[])
+        except LedgerError as e:
+            return Response({'message': str(e.msg)}, status=e.status)
+
+        compute_plan_list = [data]
+
+        query_params = request.query_params.get('search', None)
+        if query_params is not None:
+            try:
+                compute_plan_list = filter_list(
+                    object_type='compute_plan',
+                    data=data,
+                    query_params=query_params)
+            except LedgerError as e:
+                return Response({'message': str(e.msg)}, status=e.status)
+            except Exception as e:
+                logging.exception(e)
+                return Response(
+                    {'message': f'Malformed search filters {query_params}'},
+                    status=status.HTTP_400_BAD_REQUEST)
+
+        return Response(compute_plan_list, status=status.HTTP_200_OK)

--- a/backend/substrapp/views/computeplan.py
+++ b/backend/substrapp/views/computeplan.py
@@ -15,6 +15,9 @@ class ComputePlanViewSet(mixins.CreateModelMixin,
 
     serializer_class = LedgerComputePlanSerializer
 
+    def get_queryset(self):
+        return []
+
     def create(self, request, *args, **kwargs):
         # rely on serializer to parse and validate request data
         serializer = self.get_serializer(data=dict(request.data))
@@ -64,7 +67,7 @@ class ComputePlanViewSet(mixins.CreateModelMixin,
         except LedgerError as e:
             return Response({'message': str(e.msg)}, status=e.status)
 
-        compute_plan_list = [data]
+        compute_plan_list = [data] if data else [[]]
 
         query_params = request.query_params.get('search', None)
         if query_params is not None:

--- a/backend/substrapp/views/filters_utils.py
+++ b/backend/substrapp/views/filters_utils.py
@@ -11,6 +11,7 @@ FILTER_QUERIES = {
 }
 
 AUTHORIZED_FILTERS = {
+    'compute_plan': ['compute_plan'],
     'dataset': ['dataset', 'model', 'objective'],
     'algo': ['model', 'algo'],
     'objective': ['model', 'dataset', 'objective'],


### PR DESCRIPTION
Add routes to list and retrieve compute plans.

~~This PR depends on a chaincode update: https://github.com/SubstraFoundation/substra-chaincode/pull/22~~ Merged!

In order to add compute plans to the tests assets fixtures, I wanted to run generate_assets.py against  skaffold instead of docker-compose. I updated the script with a `-s` option that will use our standard skafold dev env.

In order to fully test this PR, you'll need the companion PR in the cli/SDK: https://github.com/SubstraFoundation/substra/pull/24

Then:
1. Run the populate.py
2. Try `substra list compute_plan` and `substra get compute_plan <key>`
3. Use DRF's browsable API and navigate to `/compute_plan/`


NB: the assets.py fixtures will have to be re-generated once the related chaincode PR is finalized.