### PR TITLE
Handle algo and composite algo as similar in filters

### DIFF
--- a/backend/substrapp/tests/views/tests_views_compositealgo.py
+++ b/backend/substrapp/tests/views/tests_views_compositealgo.py
@@ -19,7 +19,7 @@ from substrapp.ledger_utils import LedgerError
 from substrapp.utils import get_hash
 
 from ..common import get_sample_composite_algo, AuthenticatedClient
-from ..assets import objective, datamanager, compositealgo, traintuple, model
+from ..assets import objective, datamanager, compositealgo, traintuple, model, algo
 
 MEDIA_ROOT = "/tmp/unittests_views/"
 
@@ -83,7 +83,7 @@ class CompositeAlgoViewTests(APITestCase):
         with mock.patch('substrapp.views.compositealgo.query_ledger') as mquery_ledger:
             mquery_ledger.return_value = compositealgo
 
-            search_params = '?search=compositealgo%253Aname%253AComposite%2520Algo'
+            search_params = '?search=composite_algo%253Aname%253AComposite%2520Algo'
             response = self.client.get(url + search_params, **self.extra)
             r = response.json()
 
@@ -94,12 +94,23 @@ class CompositeAlgoViewTests(APITestCase):
         with mock.patch('substrapp.views.compositealgo.query_ledger') as mquery_ledger:
             mquery_ledger.return_value = compositealgo
 
-            search_params = '?search=compositealgo%253Aname%253AComposite%2520Algo'
-            search_params += f'%2Ccompositealgo%253Aowner%253A{compositealgo[1]["owner"]}'
+            search_params = '?search=composite_algo%253Aname%253AComposite%2520Algo'
+            search_params += f'%2Ccomposite_algo%253Aowner%253A{compositealgo[1]["owner"]}'
             response = self.client.get(url + search_params, **self.extra)
             r = response.json()
 
             self.assertEqual(len(r[0]), 1)
+
+    def test_composite_algo_list_filter_algo(self):
+        url = reverse('substrapp:composite_algo-list')
+        with mock.patch('substrapp.views.compositealgo.query_ledger') as mquery_ledger:
+            mquery_ledger.return_value = compositealgo
+
+            search_params = f'?search=algo%253Akey%253A{algo[0]["key"]}'
+            response = self.client.get(url + search_params, **self.extra)
+            r = response.json()
+
+            self.assertEqual(len(r[0]), 0)
 
     def test_composite_algo_list_filter_datamanager_fail(self):
         url = reverse('substrapp:composite_algo-list')

--- a/backend/substrapp/tests/views/tests_views_compositetraintuples.py
+++ b/backend/substrapp/tests/views/tests_views_compositetraintuples.py
@@ -106,7 +106,7 @@ class CompositeTraintupleViewTests(APITestCase):
         with mock.patch('substrapp.views.compositetraintuple.query_ledger') as mquery_ledger:
             mquery_ledger.return_value = compositetraintuple
 
-            search_params = '?search=compositetraintuple%253Atag%253Asubstra'
+            search_params = '?search=composite_traintuple%253Atag%253Asubstra'
             response = self.client.get(url + search_params, **self.extra)
             r = response.json()
 
@@ -117,7 +117,7 @@ class CompositeTraintupleViewTests(APITestCase):
         with mock.patch('substrapp.views.compositetraintuple.query_ledger') as mquery_ledger:
             mquery_ledger.return_value = compositetraintuple
             compute_plan_id = get_compute_plan_id(compositetraintuple)
-            search_params = f'?search=compositetraintuple%253AcomputePlanID%253A{compute_plan_id}'
+            search_params = f'?search=composite_traintuple%253AcomputePlanID%253A{compute_plan_id}'
             response = self.client.get(url + search_params, **self.extra)
             r = response.json()
 

--- a/backend/substrapp/views/compositealgo.py
+++ b/backend/substrapp/views/compositealgo.py
@@ -185,7 +185,7 @@ class CompositeAlgoViewSet(mixins.CreateModelMixin,
         if query_params is not None:
             try:
                 composite_algos_list = filter_list(
-                    object_type='compositealgo',
+                    object_type='composite_algo',
                     data=data,
                     query_params=query_params)
             except LedgerError as e:

--- a/backend/substrapp/views/compositetraintuple.py
+++ b/backend/substrapp/views/compositetraintuple.py
@@ -87,7 +87,7 @@ class CompositeTraintupleViewSet(mixins.CreateModelMixin,
         if query_params is not None:
             try:
                 compositetraintuple_list = filter_list(
-                    object_type='compositetraintuple',
+                    object_type='composite_traintuple',
                     data=data,
                     query_params=query_params)
             except LedgerError as e:

--- a/backend/substrapp/views/filters_utils.py
+++ b/backend/substrapp/views/filters_utils.py
@@ -8,18 +8,18 @@ FILTER_QUERIES = {
     'algo': 'queryAlgos',
     'objective': 'queryObjectives',
     'model': 'queryTraintuples',
-    'compositealgo': 'queryCompositeAlgos'
+    'composite_algo': 'queryCompositeAlgos'
 }
 
 AUTHORIZED_FILTERS = {
     'dataset': ['dataset', 'model', 'objective'],
-    'algo': ['model', 'algo'],
-    'compositealgo': ['compositealgo', 'model'],
+    'algo': ['model', 'algo', 'composite_algo'],
+    'composite_algo': ['composite_algo', 'algo', 'model'],
     'objective': ['model', 'dataset', 'objective'],
     'model': ['model', 'algo', 'dataset', 'objective'],
     'traintuple': ['traintuple'],
     'testtuple': ['testtuple'],
-    'compositetraintuple': ['compositetraintuple']
+    'composite_traintuple': ['composite_traintuple']
 }
 
 
@@ -62,6 +62,17 @@ def get_filters(query_params):
     return filters
 
 
+def _same_nature(filter_key, object_type):
+    if filter_key == object_type:
+        return True
+
+    # algo and composite algos are of the same nature
+    if {filter_key, object_type} <= {'algo', 'composite_algo'}:
+        return True
+
+    return False
+
+
 def filter_list(object_type, data, query_params):
 
     filters = get_filters(query_params)
@@ -78,7 +89,7 @@ def filter_list(object_type, data, query_params):
             # Will be appended in object_list after been filtered
             filtered_list = data
 
-            if filter_key == object_type:
+            if _same_nature(filter_key, object_type):
                 # Filter by own asset
                 if filter_key == 'model':
                     for attribute, val in subfilters.items():
@@ -103,7 +114,7 @@ def filter_list(object_type, data, query_params):
 
                 filtering_data = filtering_data if filtering_data else []
 
-                if filter_key in ('algo', 'compositealgo'):
+                if filter_key in ('algo', 'composite_algo'):
                     for attribute, val in subfilters.items():
                         filtering_data = [x for x in filtering_data if x[attribute] in val]
                         hashes = [x['key'] for x in filtering_data]

--- a/backend/substrapp/views/filters_utils.py
+++ b/backend/substrapp/views/filters_utils.py
@@ -67,10 +67,7 @@ def _same_nature(filter_key, object_type):
         return True
 
     # algo and composite algos are of the same nature
-    if {filter_key, object_type} <= {'algo', 'composite_algo'}:
-        return True
-
-    return False
+    return {filter_key, object_type} <= {'algo', 'composite_algo'}
 
 
 def filter_list(object_type, data, query_params):


### PR DESCRIPTION
In this PR:

Use `composite_algo` and `composite_traintuple` as asset keywords in filters instead of `compositealgo` and `compositetraintuple` to harmonize with the URLs and the denominations of assets in the cli / frontend.

Apply `composite_algo` filters on `algo` assets and vice versa. This means that requesting `/compositealgo?search=algo:key:foo` will return no results instead of previously returning all results.

This last change allows to query both `/algo` and `/compositealgo` with the same search string and be able to treat the responses as part of a larger query on all types of algos.