### PR TITLE
Do not include tests in containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+backend/node/tests
+backend/substrapp/tests


### PR DESCRIPTION
The .dockerignore will prevent tests from being included in containers. Which also means that while running `skaffold dev`, we'll be able to edit tests without seeing the images being rebuilt continuously.