### PR TITLE
fix helm init command since helm upgrade to 3.0 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
       channel: stable
 
 before_script:
-  - helm init --client-only
+  - helm init
 
 install: pip install -r backend/requirements.txt
 


### PR DESCRIPTION
Since TravisCI is executing helm 3.0, and according to the migrate document, https://helm.sh/docs/topics/v2_v3_migration/ the `--client-only` is not supported anymore as it is the default behavior.

Let's make our CI great again ✌️ 