### PR TITLE
Fix backend domain name from dynamic to static

### DIFF
--- a/backend/substrapp/serializers/ledger/aggregatealgo/serializer.py
+++ b/backend/substrapp/serializers/ledger/aggregatealgo/serializer.py
@@ -19,20 +19,14 @@ class LedgerAggregateAlgoSerializer(serializers.Serializer):
         permissions = validated_data.get('permissions')
 
         # TODO, create a datamigration with new Site domain name when we will know the name of the final website
-        host = ''
-        protocol = 'http://'
-        request = self.context.get('request', None)
-
-        if request:
-            protocol = 'https://' if request.is_secure() else 'http://'
-            host = request.get_host()
+        current_site = getattr(settings, "DEFAULT_DOMAIN")
 
         args = {
             'name': name,
             'hash': get_hash(instance.file),
-            'storageAddress': protocol + host + reverse('substrapp:aggregate_algo-file', args=[instance.pk]),
+            'storageAddress': current_site + reverse('substrapp:aggregate_algo-file', args=[instance.pk]),
             'descriptionHash': get_hash(instance.description),
-            'descriptionStorageAddress': protocol + host + reverse(
+            'descriptionStorageAddress': current_site + reverse(
                 'substrapp:aggregate_algo-description', args=[instance.pk]),
             'permissions': {'process': {
                 'public': permissions.get('public'),

--- a/backend/substrapp/serializers/ledger/algo/serializer.py
+++ b/backend/substrapp/serializers/ledger/algo/serializer.py
@@ -19,20 +19,14 @@ class LedgerAlgoSerializer(serializers.Serializer):
         permissions = validated_data.get('permissions')
 
         # TODO, create a datamigration with new Site domain name when we will know the name of the final website
-        host = ''
-        protocol = 'http://'
-        request = self.context.get('request', None)
-
-        if request:
-            protocol = 'https://' if request.is_secure() else 'http://'
-            host = request.get_host()
+        current_site = getattr(settings, "DEFAULT_DOMAIN")
 
         args = {
             'name': name,
             'hash': get_hash(instance.file),
-            'storageAddress': protocol + host + reverse('substrapp:algo-file', args=[instance.pk]),
+            'storageAddress': current_site + reverse('substrapp:algo-file', args=[instance.pk]),
             'descriptionHash': get_hash(instance.description),
-            'descriptionStorageAddress': protocol + host + reverse('substrapp:algo-description', args=[instance.pk]),
+            'descriptionStorageAddress': current_site + reverse('substrapp:algo-description', args=[instance.pk]),
             'permissions': {'process': {
                 'public': permissions.get('public'),
                 'authorizedIDs': permissions.get('authorized_ids'),

--- a/backend/substrapp/serializers/ledger/compositealgo/serializer.py
+++ b/backend/substrapp/serializers/ledger/compositealgo/serializer.py
@@ -19,20 +19,14 @@ class LedgerCompositeAlgoSerializer(serializers.Serializer):
         permissions = validated_data.get('permissions')
 
         # TODO, create a datamigration with new Site domain name when we will know the name of the final website
-        host = ''
-        protocol = 'http://'
-        request = self.context.get('request', None)
-
-        if request:
-            protocol = 'https://' if request.is_secure() else 'http://'
-            host = request.get_host()
+        current_site = getattr(settings, "DEFAULT_DOMAIN")
 
         args = {
             'name': name,
             'hash': get_hash(instance.file),
-            'storageAddress': protocol + host + reverse('substrapp:composite_algo-file', args=[instance.pk]),
+            'storageAddress': current_site + reverse('substrapp:composite_algo-file', args=[instance.pk]),
             'descriptionHash': get_hash(instance.description),
-            'descriptionStorageAddress': protocol + host + reverse(
+            'descriptionStorageAddress': current_site + reverse(
                 'substrapp:composite_algo-description', args=[instance.pk]),
             'permissions': {'process': {
                 'public': permissions.get('public'),

--- a/backend/substrapp/serializers/ledger/datamanager/serializer.py
+++ b/backend/substrapp/serializers/ledger/datamanager/serializer.py
@@ -23,22 +23,16 @@ class LedgerDataManagerSerializer(serializers.Serializer):
         objective_key = validated_data.get('objective_key', '')
 
         # TODO, create a datamigration with new Site domain name when we will know the name of the final website
-        host = ''
-        protocol = 'http://'
-        request = self.context.get('request', None)
-
-        if request:
-            protocol = 'https://' if request.is_secure() else 'http://'
-            host = request.get_host()
+        current_site = getattr(settings, "DEFAULT_DOMAIN")
 
         args = {
             'name': name,
             'openerHash': get_hash(instance.data_opener),
-            'openerStorageAddress': protocol + host + reverse('substrapp:data_manager-opener', args=[instance.pk]),
+            'openerStorageAddress': current_site + reverse('substrapp:data_manager-opener', args=[instance.pk]),
             'type': data_type,
             'descriptionHash': get_hash(instance.description),
-            'descriptionStorageAddress': protocol + host + reverse('substrapp:data_manager-description',
-                                                                   args=[instance.pk]),
+            'descriptionStorageAddress': current_site + reverse('substrapp:data_manager-description',
+                                                                args=[instance.pk]),
             'objectiveKey': objective_key,
             'permissions': {'process': {
                 'public': permissions.get('public'),

--- a/backend/substrapp/serializers/ledger/objective/serializer.py
+++ b/backend/substrapp/serializers/ledger/objective/serializer.py
@@ -27,21 +27,15 @@ class LedgerObjectiveSerializer(serializers.Serializer):
         test_data_sample_keys = validated_data.get('test_data_sample_keys', [])
 
         # TODO, create a datamigration with new Site domain name when we will know the name of the final website
-        host = ''
-        protocol = 'http://'
-        request = self.context.get('request', None)
-
-        if request:
-            protocol = 'https://' if request.is_secure() else 'http://'
-            host = request.get_host()
+        current_site = getattr(settings, "DEFAULT_DOMAIN")
 
         args = {
             'name': name,
             'descriptionHash': get_hash(instance.description),
-            'descriptionStorageAddress': protocol + host + reverse('substrapp:objective-description', args=[instance.pk]),  # noqa
+            'descriptionStorageAddress': current_site + reverse('substrapp:objective-description', args=[instance.pk]),  # noqa
             'metricsName': metrics_name,
             'metricsHash': get_hash(instance.metrics),
-            'metricsStorageAddress': protocol + host + reverse('substrapp:objective-metrics', args=[instance.pk]),
+            'metricsStorageAddress': current_site + reverse('substrapp:objective-metrics', args=[instance.pk]),
             'testDataset': {
                 'dataManagerKey': test_data_manager_key,
                 'dataSampleKeys': test_data_sample_keys,

--- a/backend/substrapp/tests/query/tests_query_algo.py
+++ b/backend/substrapp/tests/query/tests_query_algo.py
@@ -26,6 +26,7 @@ MEDIA_ROOT = tempfile.mkdtemp()
 @override_settings(MEDIA_ROOT=MEDIA_ROOT)
 @override_settings(LEDGER={'name': 'test-org', 'peer': 'test-peer'})
 @override_settings(LEDGER_SYNC_ENABLED=True)
+@override_settings(DEFAULT_DOMAIN='http://testserver')
 class AlgoQueryTests(APITestCase):
     client_class = AuthenticatedClient
 

--- a/backend/substrapp/tests/query/tests_query_datamanager.py
+++ b/backend/substrapp/tests/query/tests_query_datamanager.py
@@ -21,6 +21,7 @@ MEDIA_ROOT = tempfile.mkdtemp()
 @override_settings(MEDIA_ROOT=MEDIA_ROOT)
 @override_settings(LEDGER={'name': 'test-org', 'peer': 'test-peer'})
 @override_settings(LEDGER_SYNC_ENABLED=True)
+@override_settings(DEFAULT_DOMAIN='http://testserver')
 class DataManagerQueryTests(APITestCase):
     client_class = AuthenticatedClient
 

--- a/backend/substrapp/tests/query/tests_query_datasample.py
+++ b/backend/substrapp/tests/query/tests_query_datasample.py
@@ -30,6 +30,7 @@ MEDIA_ROOT = tempfile.mkdtemp()
 @override_settings(MEDIA_ROOT=MEDIA_ROOT)
 @override_settings(LEDGER={'name': 'test-org', 'peer': 'test-peer'})
 @override_settings(LEDGER_SYNC_ENABLED=True)
+@override_settings(DEFAULT_DOMAIN='http://testserver')
 class DataSampleQueryTests(APITestCase):
     client_class = AuthenticatedClient
 

--- a/backend/substrapp/tests/query/tests_query_objective.py
+++ b/backend/substrapp/tests/query/tests_query_objective.py
@@ -23,6 +23,7 @@ MEDIA_ROOT = tempfile.mkdtemp()
 @override_settings(MEDIA_ROOT=MEDIA_ROOT)
 @override_settings(LEDGER={'name': 'test-org', 'peer': 'test-peer'})
 @override_settings(LEDGER_SYNC_ENABLED=True)
+@override_settings(DEFAULT_DOMAIN='http://testserver')
 class ObjectiveQueryTests(APITestCase):
     client_class = AuthenticatedClient
 


### PR DESCRIPTION
Using a dynamic domain name infered from the request can be problematic.
For instance if a request is in https until a firewall/reverse proxy and went to be http inside the infrastructure it can generate conflict.