### PR TITLE
Fail fast: remove evaluation for train like tuples

### DIFF
--- a/backend/substrapp/ledger_utils.py
+++ b/backend/substrapp/ledger_utils.py
@@ -252,7 +252,6 @@ def log_success_tuple(tuple_type, tuple_key, res):
                 'hash': res["end_model_file_hash"],
                 'storageAddress': res["end_model_file"],
             },
-            'perf': float(res["global_perf"]),
             'log': '',
         }
 
@@ -276,7 +275,6 @@ def log_success_tuple(tuple_type, tuple_key, res):
                 'hash': res["end_trunk_model_file_hash"],
                 'storageAddress': res["end_trunk_model_file"],
             },
-            'perf': float(res["global_perf"]),
             'log': '',
         }
 
@@ -288,7 +286,6 @@ def log_success_tuple(tuple_type, tuple_key, res):
                 'hash': res["end_model_file_hash"],
                 'storageAddress': res["end_model_file"],
             },
-            'perf': float(res["global_perf"]),
             'log': '',
         }
 

--- a/backend/substrapp/serializers/ledger/aggregatetuple/serializer.py
+++ b/backend/substrapp/serializers/ledger/aggregatetuple/serializer.py
@@ -8,7 +8,6 @@ from .tasks import createLedgerAggregateTupleAsync
 
 class LedgerAggregateTupleSerializer(serializers.Serializer):
     algo_key = serializers.CharField(min_length=64, max_length=64)
-    objective_key = serializers.CharField(min_length=64, max_length=64)
     rank = serializers.IntegerField(allow_null=True, required=False, default=0)
     worker = serializers.CharField()
     compute_plan_id = serializers.CharField(min_length=64, max_length=64, allow_blank=True, required=False)
@@ -19,7 +18,6 @@ class LedgerAggregateTupleSerializer(serializers.Serializer):
 
     def get_args(self, validated_data):
         algo_key = validated_data.get('algo_key')
-        objective_key = validated_data.get('objective_key')
         rank = validated_data.get('rank', '')
         rank = '' if rank is None else str(rank)
         worker = validated_data.get('worker')
@@ -29,7 +27,6 @@ class LedgerAggregateTupleSerializer(serializers.Serializer):
 
         args = {
             'algoKey': algo_key,
-            'objectiveKey': objective_key,
             'inModels': in_models_keys,
             'computePlanID': compute_plan_id,
             'rank': rank,

--- a/backend/substrapp/serializers/ledger/compositetraintuple/serializer.py
+++ b/backend/substrapp/serializers/ledger/compositetraintuple/serializer.py
@@ -11,7 +11,6 @@ from substrapp.serializers.ledger.utils import PermissionsSerializer
 class LedgerCompositeTraintupleSerializer(serializers.Serializer):
     algo_key = serializers.CharField(min_length=64, max_length=64)
     data_manager_key = serializers.CharField(min_length=64, max_length=64)
-    objective_key = serializers.CharField(min_length=64, max_length=64)
     rank = serializers.IntegerField(allow_null=True, required=False, default=0)
     compute_plan_id = serializers.CharField(min_length=64, max_length=64, allow_blank=True, required=False)
     in_head_model_key = serializers.CharField(min_length=64, max_length=64, allow_blank=True, required=False)
@@ -24,7 +23,6 @@ class LedgerCompositeTraintupleSerializer(serializers.Serializer):
     def get_args(self, validated_data):
         algo_key = validated_data.get('algo_key')
         data_manager_key = validated_data.get('data_manager_key')
-        objective_key = validated_data.get('objective_key')
         rank = validated_data.get('rank', '')
         rank = '' if rank is None else str(rank)
         compute_plan_id = validated_data.get('compute_plan_id', '')
@@ -36,7 +34,6 @@ class LedgerCompositeTraintupleSerializer(serializers.Serializer):
 
         args = {
             'algoKey': algo_key,
-            'objectiveKey': objective_key,
             'inHeadModelKey': in_head_model_key,
             'inTrunkModelKey': in_trunk_model_key,
             'outTrunkModelPermissions': {'process': {

--- a/backend/substrapp/serializers/ledger/computeplan/serializer.py
+++ b/backend/substrapp/serializers/ledger/computeplan/serializer.py
@@ -24,6 +24,7 @@ class ComputePlanTraintupleSerializer(serializers.Serializer):
 
 class ComputePlanTesttupleSerializer(serializers.Serializer):
     traintuple_id = serializers.CharField(min_length=1, max_length=64)
+    objective_key = serializers.CharField(min_length=64, max_length=64)
     data_manager_key = serializers.CharField(min_length=64, max_length=64, required=False)
     test_data_sample_keys = serializers.ListField(
         child=serializers.CharField(min_length=64, max_length=64),
@@ -59,7 +60,6 @@ class ComputePlanAggregatetupleSerializer(serializers.Serializer):
 
 
 class LedgerComputePlanSerializer(serializers.Serializer):
-    objective_key = serializers.CharField(min_length=64, max_length=64)
     traintuples = ComputePlanTraintupleSerializer(many=True)
     testtuples = ComputePlanTesttupleSerializer(many=True)
     composite_traintuples = ComputePlanCompositeTrainTupleSerializer(many=True)
@@ -86,6 +86,7 @@ class LedgerComputePlanSerializer(serializers.Serializer):
         for data_testtuple in data['testtuples']:
             testtuple = {
                 'traintupleID': data_testtuple['traintuple_id'],
+                'objectiveKey': data_testtuple['objective_key'],
             }
             if 'tag' in data_testtuple:
                 testtuple['tag'] = data_testtuple['tag']
@@ -134,7 +135,6 @@ class LedgerComputePlanSerializer(serializers.Serializer):
             aggregatetuples.append(aggregatetuple)
 
         return {
-            'objectiveKey': data['objective_key'],
             'traintuples': traintuples,
             'testtuples': testtuples,
             'compositeTraintuples': composite_traintuples,

--- a/backend/substrapp/serializers/ledger/testtuple/serializer.py
+++ b/backend/substrapp/serializers/ledger/testtuple/serializer.py
@@ -8,6 +8,7 @@ from .tasks import createLedgerTesttupleAsync
 
 class LedgerTestTupleSerializer(serializers.Serializer):
     traintuple_key = serializers.CharField(min_length=64, max_length=64)
+    objective_key = serializers.CharField(min_length=64, max_length=64)
     data_manager_key = serializers.CharField(min_length=64, max_length=64, allow_blank=True, required=False)
     test_data_sample_keys = serializers.ListField(child=serializers.CharField(min_length=64, max_length=64),
                                                   min_length=0,
@@ -16,12 +17,14 @@ class LedgerTestTupleSerializer(serializers.Serializer):
 
     def get_args(self, validated_data):
         traintuple_key = validated_data.get('traintuple_key')
+        objective_key = validated_data.get('objective_key')
         data_manager_key = validated_data.get('data_manager_key', '')
         test_data_sample_keys = validated_data.get('test_data_sample_keys', [])
         tag = validated_data.get('tag', '')
 
         args = {
             'traintupleKey': traintuple_key,
+            'objectiveKey': objective_key,
             'dataManagerKey': data_manager_key,
             'dataSampleKeys': test_data_sample_keys,
             'tag': tag

--- a/backend/substrapp/serializers/ledger/traintuple/serializer.py
+++ b/backend/substrapp/serializers/ledger/traintuple/serializer.py
@@ -9,7 +9,6 @@ from .tasks import createLedgerTraintupleAsync
 class LedgerTrainTupleSerializer(serializers.Serializer):
     algo_key = serializers.CharField(min_length=64, max_length=64)
     data_manager_key = serializers.CharField(min_length=64, max_length=64)
-    objective_key = serializers.CharField(min_length=64, max_length=64)
     rank = serializers.IntegerField(allow_null=True, required=False, default=0)
     compute_plan_id = serializers.CharField(min_length=64, max_length=64, allow_blank=True, required=False)
     in_models_keys = serializers.ListField(child=serializers.CharField(min_length=64, max_length=64),
@@ -22,7 +21,6 @@ class LedgerTrainTupleSerializer(serializers.Serializer):
     def get_args(self, validated_data):
         algo_key = validated_data.get('algo_key')
         data_manager_key = validated_data.get('data_manager_key')
-        objective_key = validated_data.get('objective_key')
         rank = validated_data.get('rank', '')
         rank = '' if rank is None else str(rank)
         compute_plan_id = validated_data.get('compute_plan_id', '')
@@ -32,7 +30,6 @@ class LedgerTrainTupleSerializer(serializers.Serializer):
 
         args = {
             'algoKey': algo_key,
-            'objectiveKey': objective_key,
             'inModels': in_models_keys,
             'dataManagerKey': data_manager_key,
             'dataSampleKeys': train_data_sample_keys,

--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -484,7 +484,8 @@ def prepare_materials(subtuple, tuple_type):
     directory = build_subtuple_folders(subtuple)
 
     # metrics
-    prepare_objective(directory, subtuple)
+    if tuple_type == TESTTUPLE_TYPE:
+        prepare_objective(directory, subtuple)
 
     # algo
     traintuple_type = (subtuple['traintupleType'] if tuple_type == TESTTUPLE_TYPE else
@@ -689,8 +690,7 @@ def _do_task(client, subtuple_directory, tuple_type, subtuple, compute_plan_id, 
         result['end_trunk_model_file'] = end_trunk_model_file
 
     # evaluation
-    if tuple_type == AGGREGATETUPLE_TYPE:  # skip evaluation
-        result['global_perf'] = 0
+    if tuple_type != TESTTUPLE_TYPE:  # skip evaluation
         return result
 
     metrics_path = f'{subtuple_directory}/metrics'

--- a/backend/substrapp/tests/query/tests_query_tuples.py
+++ b/backend/substrapp/tests/query/tests_query_tuples.py
@@ -182,7 +182,7 @@ class TesttupleQueryTests(APITestCase):
 
         self.objective_description, self.objective_description_filename, \
             self.objective_metrics, self.objective_metrics_filename = get_sample_objective()
-
+        self.objective_key = '5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0a088'
         self.test_data_sample_keys = ['5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b422']
         self.fake_key = '5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0a088'
 
@@ -198,6 +198,7 @@ class TesttupleQueryTests(APITestCase):
         url = reverse('substrapp:testtuple-list')
 
         data = {
+            'objective_key': self.objective_key,
             'test_data_sample_keys': self.test_data_sample_keys,
             'traintuple_key': self.fake_key,
             'data_manager_key': self.fake_key}
@@ -232,6 +233,7 @@ class TesttupleQueryTests(APITestCase):
         url = reverse('substrapp:testtuple-list')
 
         data = {
+            'objective_key': self.objective_key,
             'test_data_sample_keys': self.test_data_sample_keys,
             'traintuple_key': self.fake_key,
             'data_manager_key': self.fake_key}

--- a/backend/substrapp/tests/tests_misc.py
+++ b/backend/substrapp/tests/tests_misc.py
@@ -73,7 +73,6 @@ class MiscTests(TestCase):
             res = {
                 'end_model_file_hash': 'hash',
                 'end_model_file': 'storageAddress',
-                'global_perf': '0.99',
                 'job_task_log': 'log',
             }
             log_success_tuple('traintuple', 'pk', res)

--- a/backend/substrapp/tests/views/tests_views_computeplan.py
+++ b/backend/substrapp/tests/views/tests_views_computeplan.py
@@ -41,7 +41,6 @@ class ComputePlanViewTests(APITestCase):
         dummy_key = 'x' * 64
 
         data = {
-            'objective_key': dummy_key,
             'traintuples': [{
                 'algo_key': dummy_key,
                 'data_manager_key': dummy_key,
@@ -50,6 +49,7 @@ class ComputePlanViewTests(APITestCase):
             }],
             'testtuples': [{
                 'traintuple_id': dummy_key,
+                'objective_key': dummy_key,
                 'data_manager_key': dummy_key,
             }],
             'composite_traintuples': [],

--- a/backend/substrapp/views/aggregatetuple.py
+++ b/backend/substrapp/views/aggregatetuple.py
@@ -35,7 +35,6 @@ class AggregateTupleViewSet(mixins.CreateModelMixin,
     def _create(self, request):
         data = {
             'algo_key': request.data.get('algo_key'),
-            'objective_key': request.data.get('objective_key'),
             'rank': request.data.get('rank'),
             'compute_plan_id': request.data.get('compute_plan_id', ''),
             'in_models_keys': request.data.getlist('in_models_keys'),

--- a/backend/substrapp/views/compositetraintuple.py
+++ b/backend/substrapp/views/compositetraintuple.py
@@ -36,7 +36,6 @@ class CompositeTraintupleViewSet(mixins.CreateModelMixin,
         data = {
             'algo_key': request.data.get('algo_key'),
             'data_manager_key': request.data.get('data_manager_key'),
-            'objective_key': request.data.get('objective_key'),
             'rank': request.data.get('rank'),
             'compute_plan_id': request.data.get('compute_plan_id', ''),
             'in_head_model_key': request.data.get('in_head_model_key', ''),

--- a/backend/substrapp/views/testtuple.py
+++ b/backend/substrapp/views/testtuple.py
@@ -34,6 +34,7 @@ class TestTupleViewSet(mixins.CreateModelMixin,
 
     def _create(self, request):
         data = {
+            'objective_key': request.data.get('objective_key'),
             'traintuple_key': request.data.get('traintuple_key'),
             'data_manager_key': request.data.get('data_manager_key', ''),
             'test_data_sample_keys': request.data.getlist('test_data_sample_keys'),

--- a/backend/substrapp/views/traintuple.py
+++ b/backend/substrapp/views/traintuple.py
@@ -36,7 +36,6 @@ class TrainTupleViewSet(mixins.CreateModelMixin,
         data = {
             'algo_key': request.data.get('algo_key'),
             'data_manager_key': request.data.get('data_manager_key'),
-            'objective_key': request.data.get('objective_key'),
             'rank': request.data.get('rank'),
             'compute_plan_id': request.data.get('compute_plan_id', ''),
             'in_models_keys': request.data.getlist('in_models_keys'),

--- a/populate.py
+++ b/populate.py
@@ -352,7 +352,6 @@ def do_populate():
     print('create traintuple')
     data = {
         'algo_key': algo_key,
-        'objective_key': objective_key,
         'data_manager_key': data_manager_org1_key,
         'train_data_sample_keys': train_data_sample_keys[:2]
         # This traintuple should succeed.
@@ -365,7 +364,6 @@ def do_populate():
     data = {
         'algo_key': algo_key_2,
         'data_manager_key': data_manager_org1_key,
-        'objective_key': objective_key,
         'train_data_sample_keys': train_data_sample_keys[:2],
         'tag': '(should fail) My super tag'
     }
@@ -376,7 +374,6 @@ def do_populate():
     data = {
         'algo_key': algo_key_3,
         'data_manager_key': data_manager_org1_key,
-        'objective_key': objective_key,
         'train_data_sample_keys': train_data_sample_keys[:2],
         'tag': '(should fail) My other tag'
     }
@@ -392,6 +389,7 @@ def do_populate():
     # create testtuple
     print('create testtuple')
     data = {
+        'objective_key': objective_key,
         'traintuple_key': traintuple_key,
         'tag': 'substra',
     }
@@ -412,6 +410,7 @@ def do_populate():
     print('create compute plan')
     traintuples_data = [
         {
+            "objective_key": objective_key,  # org 0
             "algo_key": algo_key,  # logistic regression, org2
             "data_manager_key": data_manager_org1_key,
             "train_data_sample_keys": [train_data_sample_keys[0], train_data_sample_keys[2]],
@@ -427,7 +426,6 @@ def do_populate():
         # }
     ]
     compute_plan_data = {
-        "objective_key": objective_key,  # org 0
         "traintuples": traintuples_data,
         "testtuples": testtuples_data,
         "aggregatetuples": [],
@@ -459,7 +457,6 @@ def do_populate():
     # This composite traintuple is the same as the first traintuple except it saves 2 models
     data = {
         'algo_key': composite_algo_key,
-        'objective_key': objective_key,
         'data_manager_key': data_manager_org1_key,
         'train_data_sample_keys': train_data_sample_keys[:2],
         'tag': 'substra',


### PR DESCRIPTION
Tasks:
- [x] views: remove link between train like tuples and objective
- [x] views: add link between testtuple and objective
- [x] views: update compute plan accordingly (remove global objective_key and define it at the tuple level)
- [x] compute: remove evaluation step for train like tuples
- [x] update populate

Companion PRs:
- [chaincode](https://github.com/SubstraFoundation/substra-chaincode/pull/50)
- [substra](https://github.com/SubstraFoundation/substra/pull/52)
- [tests](https://github.com/SubstraFoundation/substra-tests/pull/25)