### PR TITLE
Implement cancel compute plan view

### DIFF
--- a/backend/substrapp/tests/views/tests_views_computeplan.py
+++ b/backend/substrapp/tests/views/tests_views_computeplan.py
@@ -115,8 +115,8 @@ class ComputePlanViewTests(APITestCase):
     def test_computeplan_cancel(self):
         cp = computeplan[0]
         key = cp['computePlanID']
-        with mock.patch('substrapp.views.computeplan.query_ledger') as mquery_ledger:
-            mquery_ledger.return_value = cp
+        with mock.patch('substrapp.views.computeplan.invoke_ledger') as minvoke_ledger:
+            minvoke_ledger.return_value = cp
 
             url = reverse('substrapp:compute_plan-cancel', args=[key])
             response = self.client.post(url, **self.extra)

--- a/backend/substrapp/tests/views/tests_views_computeplan.py
+++ b/backend/substrapp/tests/views/tests_views_computeplan.py
@@ -111,3 +111,14 @@ class ComputePlanViewTests(APITestCase):
             search_params = computeplan[0]['computePlanID']
             response = self.client.get(url + search_params + '/', **self.extra)
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_computeplan_cancel(self):
+        cp = computeplan[0]
+        key = cp['computePlanID']
+        with mock.patch('substrapp.views.computeplan.query_ledger') as mquery_ledger:
+            mquery_ledger.return_value = cp
+
+            url = reverse('substrapp:compute_plan-cancel', args=[key])
+            response = self.client.post(url, **self.extra)
+            r = response.json()
+            self.assertEqual(r, cp)

--- a/backend/substrapp/views/computeplan.py
+++ b/backend/substrapp/views/computeplan.py
@@ -92,7 +92,7 @@ class ComputePlanViewSet(mixins.CreateModelMixin,
         validate_pk(pk)
 
         try:
-            compute_plan = query_ledger(fcn='cancelComputePlan', args={'key': pk})
+            compute_plan = invoke_ledger(fcn='cancelComputePlan', args={'key': pk})
         except LedgerError as e:
             return Response({'message': str(e.msg)}, status=e.status)
         return Response(compute_plan, status=status.HTTP_200_OK)

--- a/backend/substrapp/views/computeplan.py
+++ b/backend/substrapp/views/computeplan.py
@@ -92,7 +92,7 @@ class ComputePlanViewSet(mixins.CreateModelMixin,
         validate_pk(pk)
 
         try:
-            compute_plan = invoke_ledger(fcn='cancelComputePlan', args={'key': pk})
+            compute_plan = invoke_ledger(fcn='cancelComputePlan', args={'key': pk}, only_pkhash=False)
         except LedgerError as e:
             return Response({'message': str(e.msg)}, status=e.status)
         return Response(compute_plan, status=status.HTTP_200_OK)

--- a/backend/substrapp/views/computeplan.py
+++ b/backend/substrapp/views/computeplan.py
@@ -6,7 +6,7 @@ from rest_framework.viewsets import GenericViewSet
 from rest_framework.decorators import action
 
 from substrapp.serializers import LedgerComputePlanSerializer
-from substrapp.ledger_utils import query_ledger, LedgerError, get_object_from_ledger, LedgerConflict
+from substrapp.ledger_utils import invoke_ledger, query_ledger, LedgerError, get_object_from_ledger, LedgerConflict
 from substrapp.views.utils import get_success_create_code, validate_pk
 from substrapp.views.filters_utils import filter_list
 

--- a/backend/substrapp/views/computeplan.py
+++ b/backend/substrapp/views/computeplan.py
@@ -3,6 +3,7 @@ import logging
 from rest_framework import mixins, status
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
+from rest_framework.decorators import action
 
 from substrapp.serializers import LedgerComputePlanSerializer
 from substrapp.ledger_utils import query_ledger, LedgerError, get_object_from_ledger, LedgerConflict
@@ -85,3 +86,13 @@ class ComputePlanViewSet(mixins.CreateModelMixin,
                     status=status.HTTP_400_BAD_REQUEST)
 
         return Response(compute_plan_list, status=status.HTTP_200_OK)
+
+    @action(detail=True, methods=['POST'])
+    def cancel(self, request, pk):
+        validate_pk(pk)
+
+        try:
+            compute_plan = query_ledger(fcn='cancelComputePlan', args={'key': pk})
+        except LedgerError as e:
+            return Response({'message': str(e.msg)}, status=e.status)
+        return Response(compute_plan, status=status.HTTP_200_OK)


### PR DESCRIPTION
Tasks:
- [x] implement new view: `POST /computeplan/<id>/cancel`
- [x] check if modifications required to handle new tuple status (canceled)

Companion PR:
- [substra](https://github.com/SubstraFoundation/substra/pull/56)
- [chaincode](https://github.com/SubstraFoundation/substra-chaincode/pull/53)
- [tests](https://github.com/SubstraFoundation/substra-tests/pull/26)
- [frontend](https://github.com/SubstraFoundation/substra-frontend/pull/33)