### PR TITLE
Retry a failed task up to 5 times

### DIFF
--- a/backend/backend/settings/common.py
+++ b/backend/backend/settings/common.py
@@ -16,6 +16,20 @@ from datetime import timedelta
 
 from libs.gen_secret_key import write_secret_key
 
+
+TRUE_VALUES = {
+    't', 'T',
+    'y', 'Y', 'yes', 'YES',
+    'true', 'True', 'TRUE',
+    'on', 'On', 'ON',
+    '1', 1,
+    True
+}
+
+def to_bool(value):
+    return value in TRUE_VALUES
+
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 PROJECT_ROOT = os.path.dirname(BASE_DIR)
@@ -168,11 +182,19 @@ MEDIA_URL = '/media/'
 
 SITE_ID = 1
 
+TASK = {
+    'CAPTURE_LOGS': to_bool(os.environ.get('TASK_CAPTURE_LOGS', True)),
+    'CLEAN_EXECUTION_ENVIRONMENT': to_bool(os.environ.get('TASK_CLEAN_EXECUTION_ENVIRONMENT', True)),
+    'CACHE_DOCKER_IMAGES': to_bool(os.environ.get('TASK_CACHE_DOCKER_IMAGES', False)),
+}
+
 CELERY_RESULT_BACKEND = 'django-db'
 CELERY_ACCEPT_CONTENT = ['application/json']
 CELERY_RESULT_SERIALIZER = 'json'
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_TASK_TRACK_STARTED = True  # since 4.0
+CELERY_TASK_MAX_RETRIES = 5
+CELERY_TASK_RETRY_DELAY_SECONDS = 2
 CELERY_WORKER_CONCURRENCY = 1
 CELERY_BROKER_URL = os.environ.get('CELERY_BROKER_URL', 'amqp://localhost:5672//'),
 
@@ -180,15 +202,3 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000
 
 EXPIRY_TOKEN_LIFETIME = timedelta(minutes=int(os.environ.get('EXPIRY_TOKEN_LIFETIME', 24*60)))
 
-TRUE_VALUES = {
-    't', 'T',
-    'y', 'Y', 'yes', 'YES',
-    'true', 'True', 'TRUE',
-    'on', 'On', 'ON',
-    '1', 1,
-    True
-}
-
-
-def to_bool(value):
-    return value in TRUE_VALUES

--- a/backend/backend/settings/dev.py
+++ b/backend/backend/settings/dev.py
@@ -6,13 +6,6 @@ from .deps.org import *
 from .deps.restframework import *
 
 DEBUG = True
-
-TASK = {
-    'CAPTURE_LOGS': to_bool(os.environ.get('TASK_CAPTURE_LOGS', True)),
-    'CLEAN_EXECUTION_ENVIRONMENT': to_bool(os.environ.get('TASK_CLEAN_EXECUTION_ENVIRONMENT', True)),
-    'CACHE_DOCKER_IMAGES': to_bool(os.environ.get('TASK_CACHE_DOCKER_IMAGES', False)),
-}
-
 # LEDGER_CALL_RETRY = False  # uncomment to overwrite the ledger setting value
 
 # Database

--- a/backend/backend/settings/prod.py
+++ b/backend/backend/settings/prod.py
@@ -9,12 +9,6 @@ from .deps.restframework import *
 
 DEBUG = False
 
-TASK = {
-    'CAPTURE_LOGS': to_bool(os.environ.get('TASK_CAPTURE_LOGS', True)),
-    'CLEAN_EXECUTION_ENVIRONMENT': to_bool(os.environ.get('TASK_CLEAN_EXECUTION_ENVIRONMENT', True)),
-    'CACHE_DOCKER_IMAGES': to_bool(os.environ.get('TASK_CACHE_DOCKER_IMAGES', False)),
-}
-
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 os.environ['HTTPS'] = "on"

--- a/backend/substrapp/tests/tests_tasks.py
+++ b/backend/substrapp/tests/tests_tasks.py
@@ -455,23 +455,11 @@ class TasksTests(APITestCase):
 
     def test_compute_task(self):
 
-        class FakeSettings(object):
-            def __init__(self):
-                self.LEDGER = {'signcert': 'signcert',
-                               'org': 'owkin',
-                               'peer': 'peer'}
-
-                self.MEDIA_ROOT = MEDIA_ROOT
-
         subtuple_key = 'test_owkin'
         subtuple = {'key': subtuple_key, 'inModels': None}
         subtuple_directory = build_subtuple_folders(subtuple)
 
-        with mock.patch('substrapp.tasks.tasks.settings') as msettings, \
-                mock.patch('substrapp.tasks.tasks.getattr') as mgetattr, \
-                mock.patch('substrapp.tasks.tasks.log_start_tuple') as mlog_start_tuple:
-            msettings.return_value = FakeSettings()
-            mgetattr.return_value = self.subtuple_path
+        with mock.patch('substrapp.tasks.tasks.log_start_tuple') as mlog_start_tuple:
             mlog_start_tuple.return_value = 'data', 200
 
             for name in ['opener', 'metrics']:
@@ -503,7 +491,9 @@ class TasksTests(APITestCase):
                 with mock.patch('substrapp.tasks.tasks.log_fail_tuple') as mlog_fail_tuple:
                     mdo_task.side_effect = Exception("Test")
                     mlog_fail_tuple.return_value = 'data', 404
-                    compute_task('traintuple', subtuple, None)
+                    with self.assertRaises(Exception) as exc:
+                        compute_task('traintuple', subtuple, None)
+                    self.assertEqual(str(exc.exception), "Test")
 
     def test_prepare_materials(self):
 


### PR DESCRIPTION
This PR introduces an auto-retry mechanism for compute tasks: up to 5 retries (i.e. 6 attempts in total), with 2 secs between each attempt.

The retry logic is handled by Celery. Most of the changes in this PR are just moving things around. The actual retry logic is only the `raise self.retry(...)` line (!)

:warning: **Following this PR, compute task results and exceptions are now passed back to Celery**. Prior to this PR, the result (or exception) from `do_task` was passed to `log_success_tuple` (or `log_fail_tuple`) and didn't leave the `compute_task` function. That's not the case anymore. Now the result/exception is returned to Celery (via `return` or `raise`). Celery, in turn, either retries, calls `on_succeed` or calls `on_failure`. I don't think that's a problem because 1. I'm not sure those return/exceptions are stored in DB anyway by celery and 2. Even if they are stored in DB, they are stored on the current node only. It just seemed significant enough of a change for me to mention it.

Also note that I moved around some seemingly unrelated settings and test code: that's because `compute_task(...)` now calls `settings.TASK`, so I had to do move a few settings things around in order to accomodate for that. I also had to remove the `getattr` mock because this mock was always returning `MEDIA_ROOT` (which turned out to not be necessary anyway)
