### PR TITLE
worker: review retry when communicating with ledger in case of timeout

### DIFF
--- a/backend/backend/settings/deps/ledger.py
+++ b/backend/backend/settings/deps/ledger.py
@@ -21,6 +21,8 @@ LEDGER = json.load(open(LEDGER_CONFIG_FILE, 'r'))
 LEDGER_SYNC_ENABLED = True
 LEDGER_CALL_RETRY = True
 
+LEDGER_MAX_RETRY_TIMEOUT = 5
+
 PEER_PORT = LEDGER['peer']['port'][os.environ.get('BACKEND_PEER_PORT', 'external')]
 
 LEDGER['requestor'] = create_user(

--- a/backend/substrapp/ledger_utils.py
+++ b/backend/substrapp/ledger_utils.py
@@ -260,7 +260,7 @@ def _wait_until_status_after_timeout(tuple_type, tuple_key, expected_status):
     }
     query_fcn = query_fcns[tuple_type]
 
-    max_tries = 5
+    max_tries = getattr(settings, 'LEDGER_MAX_RETRY_TIMEOUT', 5)
     trie = 1
     backoff = 5
 

--- a/backend/substrapp/ledger_utils.py
+++ b/backend/substrapp/ledger_utils.py
@@ -229,7 +229,7 @@ def invoke_ledger(*args, **kwargs):
 
 
 @retry_on_error()
-def _update_ledger(*args, **kwargs):
+def update_ledger(*args, **kwargs):
     return _invoke_ledger(*args, **kwargs)
 
 
@@ -295,7 +295,7 @@ def log_fail_tuple(tuple_type, tuple_key, err_msg):
     }
 
     try:
-        _update_ledger(fcn=invoke_fcn, args=invoke_args, sync=True)
+        update_ledger(fcn=invoke_fcn, args=invoke_args, sync=True)
     except LedgerTimeout:
         _wait_until_status_after_timeout(tuple_type, tuple_key, 'failed')
 
@@ -350,7 +350,7 @@ def log_success_tuple(tuple_type, tuple_key, res):
         raise NotImplementedError()
 
     try:
-        _update_ledger(fcn=invoke_fcn, args=invoke_args, sync=True)
+        update_ledger(fcn=invoke_fcn, args=invoke_args, sync=True)
     except LedgerTimeout:
         _wait_until_status_after_timeout(tuple_type, tuple_key, 'done')
 
@@ -367,6 +367,6 @@ def log_start_tuple(tuple_type, tuple_key):
     invoke_args = {'key': tuple_key}
 
     try:
-        _update_ledger(fcn=invoke_fcn, args=invoke_args, sync=True)
+        update_ledger(fcn=invoke_fcn, args=invoke_args, sync=True)
     except LedgerTimeout:
         _wait_until_status_after_timeout(tuple_type, tuple_key, 'doing')

--- a/backend/substrapp/serializers/ledger/aggregatetuple/util.py
+++ b/backend/substrapp/serializers/ledger/aggregatetuple/util.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import, unicode_literals
 
 
-from substrapp.ledger_utils import invoke_ledger, retry_on_error
+from substrapp.ledger_utils import invoke_ledger
 
 
-@retry_on_error(nbtries=3)
 def createLedgerAggregateTuple(args, sync=False):
     return invoke_ledger(fcn='createAggregatetuple', args=args, sync=sync)

--- a/backend/substrapp/serializers/ledger/compositetraintuple/util.py
+++ b/backend/substrapp/serializers/ledger/compositetraintuple/util.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import, unicode_literals
 
 
-from substrapp.ledger_utils import invoke_ledger, retry_on_error
+from substrapp.ledger_utils import invoke_ledger
 
 
-@retry_on_error(nbtries=3)
 def createLedgerCompositeTraintuple(args, sync=False):
     return invoke_ledger(fcn='createCompositeTraintuple', args=args, sync=sync)

--- a/backend/substrapp/serializers/ledger/testtuple/util.py
+++ b/backend/substrapp/serializers/ledger/testtuple/util.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import, unicode_literals
 
 
-from substrapp.ledger_utils import invoke_ledger, retry_on_error
+from substrapp.ledger_utils import invoke_ledger
 
 
-@retry_on_error(nbtries=3)
 def createLedgerTesttuple(args, sync=False):
     return invoke_ledger(fcn='createTesttuple', args=args, sync=sync)

--- a/backend/substrapp/serializers/ledger/traintuple/util.py
+++ b/backend/substrapp/serializers/ledger/traintuple/util.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import, unicode_literals
 
 
-from substrapp.ledger_utils import invoke_ledger, retry_on_error
+from substrapp.ledger_utils import invoke_ledger
 
 
-@retry_on_error(nbtries=3)
 def createLedgerTraintuple(args, sync=False):
     return invoke_ledger(fcn='createTraintuple', args=args, sync=sync)

--- a/backend/substrapp/tests/tests_misc.py
+++ b/backend/substrapp/tests/tests_misc.py
@@ -50,26 +50,26 @@ class MiscTests(TestCase):
             self.assertEqual(data['key'], 'pk')
 
     def test_log_fail_tuple(self):
-        with patch('substrapp.ledger_utils.invoke_ledger') as minvoke_ledger:
-            minvoke_ledger.return_value = None
+        with patch('substrapp.ledger_utils.update_ledger') as mupdate_ledger:
+            mupdate_ledger.return_value = None
             log_fail_tuple('traintuple', 'pk', 'error_msg')
 
-        with patch('substrapp.ledger_utils.invoke_ledger') as minvoke_ledger:
-            minvoke_ledger.return_value = None
+        with patch('substrapp.ledger_utils.update_ledger') as mupdate_ledger:
+            mupdate_ledger.return_value = None
             log_fail_tuple('testtuple', 'pk', 'error_msg')
 
     def test_log_start_tuple(self):
-        with patch('substrapp.ledger_utils.invoke_ledger') as minvoke_ledger:
-            minvoke_ledger.return_value = None
+        with patch('substrapp.ledger_utils.update_ledger') as mupdate_ledger:
+            mupdate_ledger.return_value = None
             log_start_tuple('traintuple', 'pk')
 
-        with patch('substrapp.ledger_utils.invoke_ledger') as minvoke_ledger:
-            minvoke_ledger.return_value = None
+        with patch('substrapp.ledger_utils.update_ledger') as mupdate_ledger:
+            mupdate_ledger.return_value = None
             log_start_tuple('testtuple', 'pk')
 
     def test_log_success_tuple(self):
-        with patch('substrapp.ledger_utils.invoke_ledger') as minvoke_ledger:
-            minvoke_ledger.return_value = None
+        with patch('substrapp.ledger_utils.update_ledger') as mupdate_ledger:
+            mupdate_ledger.return_value = None
             res = {
                 'end_model_file_hash': 'hash',
                 'end_model_file': 'storageAddress',
@@ -77,8 +77,8 @@ class MiscTests(TestCase):
             }
             log_success_tuple('traintuple', 'pk', res)
 
-        with patch('substrapp.ledger_utils.invoke_ledger') as minvoke_ledger:
-            minvoke_ledger.return_value = None
+        with patch('substrapp.ledger_utils.update_ledger') as mupdate_ledger:
+            mupdate_ledger.return_value = None
             res = {
                 'global_perf': '0.99',
                 'job_task_log': 'log',


### PR DESCRIPTION
Fix #72 
- fix bug: retry was called several times for a unique call to the ledger
- when doing an invoke to update a tuple status, don't retry on timeout errors
- when updating a status, in case of timeout wait for status to be as expected
- reordering of methods in ledger_utils: group low level functions requesting the ledger at the top

⚠️  It won't fix #10 and #77: as the fix will work only for the log methods (worker side)