### PR TITLE
fix: don't retry on LedgerTimeout when doing an invoke

### DIFF
--- a/backend/substrapp/ledger_utils.py
+++ b/backend/substrapp/ledger_utils.py
@@ -223,7 +223,7 @@ def query_ledger(fcn, args=None):
     return call_ledger('query', fcn=fcn, args=args)
 
 
-@retry_on_error(exceptions=[LedgerTimeout])
+@retry_on_error()
 def invoke_ledger(*args, **kwargs):
     return _invoke_ledger(*args, **kwargs)
 


### PR DESCRIPTION
LedgerTimeout errors raised by invoke query on asset creation should be propagated from the chaincode to the substra client.

Actually, the substra sdk has a retry mechanism in case of LedgerTimeout on asset creation (retry till the asset exists).

Issue has been introduced by: https://github.com/SubstraFoundation/substra-backend/commit/da66d0e5f5a9b69f968ac0aa435cabbb185a8b42.