### PR TITLE
Fix issue with celerybeat periodic tasks

### DIFF
--- a/backend/backend/celery.py
+++ b/backend/backend/celery.py
@@ -23,7 +23,7 @@ app.autodiscover_tasks()
 def setup_periodic_tasks(sender, **kwargs):
     from substrapp.tasks.tasks import prepare_training_task, prepare_testing_task
 
-    period = 3 * 3600
+    period = int(os.environ.get('SCHEDULE_TASK_PERIOD', 3 * 3600))
     sender.add_periodic_task(period, prepare_training_task.s(), queue='scheduler',
                              name='query Traintuples to prepare train task on todo traintuples')
     sender.add_periodic_task(period, prepare_testing_task.s(), queue='scheduler',

--- a/backend/backend/settings/common.py
+++ b/backend/backend/settings/common.py
@@ -189,7 +189,6 @@ TASK = {
     'CHAINKEYS_ENABLED': to_bool(os.environ.get('TASK_CHAINKEYS_ENABLED', False)),
 }
 
-CELERY_RESULT_BACKEND = 'django-db'
 CELERY_ACCEPT_CONTENT = ['application/json']
 CELERY_RESULT_SERIALIZER = 'json'
 CELERY_TASK_SERIALIZER = 'json'

--- a/backend/backend/settings/dev.py
+++ b/backend/backend/settings/dev.py
@@ -27,6 +27,8 @@ MEDIA_ROOT = os.environ.get('MEDIA_ROOT', os.path.join(PROJECT_ROOT, f'medias/{O
 SITE_HOST = f'substra-backend.{ORG_NAME}.xyz'
 SITE_PORT = DEFAULT_PORT
 DEFAULT_DOMAIN = os.environ.get('DEFAULT_DOMAIN', f'http://{SITE_HOST}:{SITE_PORT}')
+
+CELERY_RESULT_BACKEND = 'django-db'
 CELERY_TASK_MAX_RETRIES = 1 # 1 retry == 2 attempts
 CELERY_TASK_RETRY_DELAY_SECONDS = 0
 

--- a/backend/backend/settings/prod.py
+++ b/backend/backend/settings/prod.py
@@ -37,6 +37,8 @@ SITE_HOST = os.environ.get('SITE_HOST', f'substra-backend.{ORG_NAME}.xyz')
 SITE_PORT = os.environ.get('SITE_PORT', DEFAULT_PORT)
 DEFAULT_DOMAIN = os.environ.get('DEFAULT_DOMAIN', f'http://{SITE_HOST}:{SITE_PORT}')
 
+CELERY_RESULT_BACKEND = 'django-db'
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,

--- a/charts/substra-backend/templates/deployment-celerybeat.yaml
+++ b/charts/substra-backend/templates/deployment-celerybeat.yaml
@@ -39,6 +39,8 @@ spec:
               value: "amqp://{{ .Values.rabbitmq.rabbitmq.username }}:{{ .Values.rabbitmq.rabbitmq.password }}@{{ .Release.Name }}-{{ .Values.rabbitmq.host }}:{{ .Values.rabbitmq.port }}//"
             - name: DJANGO_SETTINGS_MODULE
               value: backend.settings.common
+            - name: SCHEDULE_TASK_PERIOD
+              value: "{{ .Values.celerybeat.taskPeriod }}"
             - name: PYTHONUNBUFFERED
               value: "1"
           resources:

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -148,6 +148,7 @@ flower:
 
 celerybeat:
   replicaCount: 1
+  taskPeriod: 10800
   image:
     repository: substrafoundation/celerybeat
     tag: latest

--- a/docker/start.py
+++ b/docker/start.py
@@ -93,6 +93,7 @@ def generate_docker_compose_file(conf, launch_settings):
                 'environment': [
                     'PYTHONUNBUFFERED=1',
                     f'CELERY_BROKER_URL={CELERY_BROKER_URL}',
+                    f'SCHEDULE_TASK_PERIOD={3 * 3600}',
                     f'DJANGO_SETTINGS_MODULE=backend.settings.common'],
                 'depends_on': ['postgresql', 'rabbit']
             },


### PR DESCRIPTION
When celerybeat sends periodic tasks, it try to push the celery result to django-db. It will fail as celerybeat is not connected to the posgresql db.

As we do not need this database, we could avoid, for the celerybeat to send the result of celery task.

Moreover, I added a setting to setup the frequency of the periodic task (in case of event hub failure we can increase frequency).