### PR TITLE
fix docker image task name

### DIFF
--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -591,13 +591,14 @@ def do_task(subtuple, tuple_type):
 
 def _do_task(client, subtuple_directory, tuple_type, subtuple, compute_plan_id, rank, org_name):
 
+    algo_hash = subtuple['algo']['hash']
     model_folder = '/sandbox/model'
     model_path = path.join(subtuple_directory, 'model')
     data_path = path.join(subtuple_directory, 'data')
     pred_path = path.join(subtuple_directory, 'pred')
     opener_file = path.join(subtuple_directory, 'opener/opener.py')
     algo_path = path.join(subtuple_directory)
-    algo_docker = f'substra/algo_{subtuple["key"][0:8]}'.lower()  # tag must be lowercase for docker
+    algo_docker = f'substra/algo_{algo_hash[0:8]}'.lower()  # tag must be lowercase for docker
     algo_docker_name = f'{tuple_type}_{subtuple["key"][0:8]}'
     output_head_model_filename = 'head_model'
     output_trunk_model_filename = 'trunk_model'

--- a/backend/substrapp/tests/tests_tasks.py
+++ b/backend/substrapp/tests/tests_tasks.py
@@ -430,7 +430,7 @@ class TasksTests(APITestCase):
                 self.MEDIA_ROOT = MEDIA_ROOT
 
         subtuple_key = 'test_owkin'
-        subtuple = {'key': subtuple_key, 'inModels': None}
+        subtuple = {'key': subtuple_key, 'inModels': None, 'algo': {'hash': 'myhash'}}
         subtuple_directory = build_subtuple_folders(subtuple)
 
         with mock.patch('substrapp.tasks.tasks.settings') as msettings, \


### PR DESCRIPTION
This aims to fix a bug while running a compute plan, multiples docker images were created with different names and not removed due to a simple rule: if it's a compute plan do not remove the image.

The fix make sure that docker images depends on algo key rather than tuple key.