### PR TITLE
Fix model download permissions

### DIFF
--- a/backend/substrapp/ledger_utils.py
+++ b/backend/substrapp/ledger_utils.py
@@ -411,7 +411,6 @@ def log_success_tuple(tuple_type, tuple_key, res):
         extra_kwargs.update({
             'outHeadModel': {
                 'hash': res["end_head_model_file_hash"],
-                'storageAddress': res["end_head_model_file"],
             },
             'outTrunkModel': {
                 'hash': res["end_trunk_model_file_hash"],

--- a/backend/substrapp/tests/query/tests_query_compositetraintuple.py
+++ b/backend/substrapp/tests/query/tests_query_compositetraintuple.py
@@ -10,10 +10,11 @@ from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from substrapp.models import Objective
-from substrapp.utils import get_hash
+from substrapp.models import Objective, Model
+from substrapp.utils import get_hash, compute_hash
+from node.authentication import NodeUser
 
-from ..common import get_sample_objective, AuthenticatedClient
+from ..common import get_sample_objective, AuthenticatedClient, get_sample_model
 
 MEDIA_ROOT = tempfile.mkdtemp()
 
@@ -33,6 +34,8 @@ class CompositeTraintupleQueryTests(APITestCase):
 
         self.train_data_sample_keys = ['5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0b422']
         self.fake_key = '5c1d9cd1c2c1082dde0921b56d11030c81f62fbb51932758b58ac2569dd0a088'
+
+        self.model, _ = get_sample_model()
 
     def tearDown(self):
         shutil.rmtree(MEDIA_ROOT, ignore_errors=True)
@@ -137,3 +140,66 @@ class CompositeTraintupleQueryTests(APITestCase):
         data = {'objective': get_hash(self.objective_description)}
         response = self.client.post(url, data, format='multipart', **extra)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_get_head_model_ok(self):
+        pkhash = compute_hash(self.model.read(), key='key_traintuple')
+        head_model = Model.objects.create(file=self.model, pkhash=pkhash, validated=True)
+        permissions = {
+            "process": {
+                "public": False,
+                "authorizedIDs": ['substra']
+            }
+        }
+        with mock.patch('substrapp.views.utils.get_owner', return_value='foo'), \
+                mock.patch('substrapp.views.utils.get_object_from_ledger') \
+                as mget_object_from_ledger, \
+                mock.patch('substrapp.views.model.type') as mtype:
+            mget_object_from_ledger.return_value = permissions
+            mtype.return_value = NodeUser
+            extra = {
+                'HTTP_ACCEPT': 'application/json;version=0.0',
+            }
+            response = self.client.get(f'/model/{head_model.pkhash}/file/', **extra)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(head_model.pkhash, compute_hash(response.getvalue(), key='key_traintuple'))
+
+    def test_get_head_model_ko_user(self):
+        pkhash = compute_hash(self.model.read(), key='key_traintuple')
+        head_model = Model.objects.create(file=self.model, pkhash=pkhash, validated=True)
+        permissions = {
+            "process": {
+                "public": False,
+                "authorizedIDs": ['substra']
+            }
+        }
+        with mock.patch('substrapp.views.utils.get_owner', return_value='foo'), \
+                mock.patch('substrapp.views.utils.get_object_from_ledger') \
+                as mget_object_from_ledger:
+            mget_object_from_ledger.return_value = permissions
+            extra = {
+                'HTTP_ACCEPT': 'application/json;version=0.0',
+            }
+            response = self.client.get(f'/model/{head_model.pkhash}/file/', **extra)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_get_head_model_ko_wrong_node(self):
+        pkhash = compute_hash(self.model.read(), key='key_traintuple')
+        head_model = Model.objects.create(file=self.model, pkhash=pkhash, validated=True)
+        permissions = {
+            "process": {
+                "public": False,
+                "authorizedIDs": ['owkin']
+            }
+        }
+        with mock.patch('substrapp.views.utils.get_owner', return_value='foo'), \
+                mock.patch('substrapp.views.utils.get_object_from_ledger') \
+                as mget_object_from_ledger, \
+                mock.patch('substrapp.views.model.type') as mtype:
+            mget_object_from_ledger.return_value = permissions
+            mtype.return_value = NodeUser
+
+            extra = {
+                'HTTP_ACCEPT': 'application/json;version=0.0',
+            }
+            response = self.client.get(f'/model/{head_model.pkhash}/file/', **extra)
+            self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/backend/substrapp/tests/views/tests_utils.py
+++ b/backend/substrapp/tests/views/tests_utils.py
@@ -42,7 +42,7 @@ def with_permission_mixin(remote, same_file_property, has_access):
 
                 permission_mixin = PermissionMixin()
                 permission_mixin.get_object = mock.MagicMock(return_value=TestModel())
-                permission_mixin._has_access = mock.MagicMock(return_value=has_access)
+                permission_mixin.has_access = mock.MagicMock(return_value=has_access)
                 permission_mixin.lookup_url_kwarg = 'foo'
                 permission_mixin.kwargs = {'foo': 'bar'}
                 permission_mixin.ledger_query_call = 'foo'

--- a/backend/substrapp/views/model.py
+++ b/backend/substrapp/views/model.py
@@ -129,8 +129,8 @@ class ModelPermissionViewSet(PermissionMixin,
             return False
 
         # user cannot download model, only node can
-        if not isinstance(user, NodeUser):
-            return Response({}, status=status.HTTP_403_FORBIDDEN)
+        if not (type(user) is NodeUser):
+            return False
 
         permissions = asset['process']
         node_id = user.username

--- a/backend/substrapp/views/model.py
+++ b/backend/substrapp/views/model.py
@@ -123,7 +123,7 @@ class ModelPermissionViewSet(PermissionMixin,
     serializer_class = ModelSerializer
     ledger_query_call = 'queryModelPermissions'
 
-    def _has_access(self, user, asset):
+    def has_access(self, user, asset):
         """Returns true if API consumer can access asset data."""
         if user.is_anonymous:  # safeguard, should never happened
             return False

--- a/backend/substrapp/views/utils.py
+++ b/backend/substrapp/views/utils.py
@@ -69,7 +69,7 @@ class PermissionMixin(object):
 
         permission = asset['permissions']['process']
 
-        if isinstance(user, NodeUser):  # for node
+        if type(user) is NodeUser:  # for node
             node_id = user.username
         else:  # for classic user, test on current msp id
             node_id = get_owner()

--- a/backend/substrapp/views/utils.py
+++ b/backend/substrapp/views/utils.py
@@ -62,7 +62,7 @@ class PermissionMixin(object):
     ]
     permission_classes = [IsAuthenticated]
 
-    def _has_access(self, user, asset):
+    def has_access(self, user, asset):
         """Returns true if API consumer can access asset data."""
         if user.is_anonymous:  # safeguard, should never happened
             return False
@@ -85,7 +85,7 @@ class PermissionMixin(object):
         except LedgerError as e:
             return Response({'message': str(e.msg)}, status=e.status)
 
-        if not self._has_access(request.user, asset):
+        if not self.has_access(request.user, asset):
             return Response({'message': 'Unauthorized'},
                             status=status.HTTP_403_FORBIDDEN)
 
@@ -108,7 +108,7 @@ class PermissionMixin(object):
         except LedgerError as e:
             return Response({'message': str(e.msg)}, status=e.status)
 
-        if not self._has_access(request.user, asset):
+        if not self.has_access(request.user, asset):
             return Response({'message': 'Unauthorized'},
                             status=status.HTTP_403_FORBIDDEN)
 


### PR DESCRIPTION
This PR depends on https://github.com/SubstraFoundation/substra-chaincode/pull/79

Companion PR in tests: https://github.com/SubstraFoundation/substra-tests/pull/70

- Adds a new check on permission preventing model downloads from nodes who don't have permissions
- Relies on a new chaincode smartContract to retrieve the permissions associated with a model.

To reproduce the original issue:
- run `test_permissions_denied_model_process` from substra-tests
- get the model url from the traintuple whose algo is `xxxxxxx_test_permissions_denied_model_process - Algo 1` This model should only be processable by MyOrg2MSP.
- curl the URL using the node1 to node2 credentials: `MyOrg1MSP:nodeSecret2w1`

You should get a 200 without the fix and a 403 with the fix.