### PR TITLE
Review logging (dev and prod settings)

### DIFF
--- a/backend/backend/settings/common.py
+++ b/backend/backend/settings/common.py
@@ -95,9 +95,15 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.RemoteUserMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'libs.sql_printing_middleware.SQLPrintingMiddleware',
     'libs.health_check_middleware.HealthCheckMiddleware',
 ]
+
+
+DJANGO_LOG_SQL_QUERIES = to_bool(os.environ.get('DJANGO_LOG_SQL_QUERIES', 'True'))
+if DJANGO_LOG_SQL_QUERIES:
+    MIDDLEWARE.append(
+        'libs.sql_printing_middleware.SQLPrintingMiddleware'
+    )
 
 ROOT_URLCONF = 'backend.urls'
 
@@ -187,6 +193,7 @@ TASK = {
     'CLEAN_EXECUTION_ENVIRONMENT': to_bool(os.environ.get('TASK_CLEAN_EXECUTION_ENVIRONMENT', True)),
     'CACHE_DOCKER_IMAGES': to_bool(os.environ.get('TASK_CACHE_DOCKER_IMAGES', False)),
     'CHAINKEYS_ENABLED': to_bool(os.environ.get('TASK_CHAINKEYS_ENABLED', False)),
+    'LIST_WORKSPACE': to_bool(os.environ.get('TASK_LIST_WORKSPACE', True)),
 }
 
 CELERY_ACCEPT_CONTENT = ['application/json']

--- a/backend/backend/settings/dev.py
+++ b/backend/backend/settings/dev.py
@@ -36,48 +36,49 @@ LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
     'formatters': {
-        'verbose': {
-            'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
-        },
         'simple': {
-            'format': '%(levelname)s - %(asctime)s - %(name)s - %(message)s'
+            'format': '%(levelname)s - %(asctime)s - %(name)s - %(message)s',
         },
-    },
-    'filters': {
-        'require_debug_false': {
-            '()': 'django.utils.log.RequireDebugFalse'
-        }
     },
     'handlers': {
-        'mail_admins': {
-            'level': 'ERROR',
-            'filters': ['require_debug_false'],
-            'class': 'django.utils.log.AdminEmailHandler'
-        },
         'console': {
-            'level': 'DEBUG',
             'class': 'logging.StreamHandler',
-            'formatter': 'simple'
+            'formatter': 'simple',
         },
-        'error_file': {
-            'level': 'INFO',
-            'filename': os.path.join(PROJECT_ROOT, 'backend.log'),
-            'class': 'logging.handlers.RotatingFileHandler',
-            'maxBytes': 1 * 1024 * 1024,
-            'backupCount': 2,
-            'formatter': 'verbose'
-        }
     },
     'loggers': {
-        'django.request': {
-            'handlers': ['mail_admins', 'error_file'],
+        # root logger
+        '': {
+            'level': 'WARNING',
+            'handlers': ['console'],
+            'propagate': True,
+        },
+        # django and its applications
+        'django': {
             'level': 'INFO',
+            'handlers': ['console'],
+            'propagate': False,
+        },
+        'substrapp': {
+            'level': 'DEBUG',
+            'handlers': ['console'],
             'propagate': False,
         },
         'events': {
-            'handlers': ['console'],
             'level': 'DEBUG',
-            'propagate': True,
+            'handlers': ['console'],
+            'propagate': False,
+        },
+        # third-party libraries
+        'hfc': {
+            'level': 'WARNING',
+            'handlers': ['console'],
+            'propagate': False,
+        },
+        'celery': {
+            'level': 'INFO',
+            'handlers': ['console'],
+            'propagate': False,
         },
     }
 }

--- a/backend/backend/settings/prod.py
+++ b/backend/backend/settings/prod.py
@@ -48,12 +48,7 @@ LOGGING = {
     },
     'formatters': {
         'verbose': {
-            'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
-        },
-        'generic': {
-            'format': '%(asctime)s [%(process)d] [%(levelname)s] %(message)s',
-            'datefmt': '%Y-%m-%d %H:%M:%S',
-            '()': 'logging.Formatter',
+            'format': '%(levelname)s %(asctime)s %(name)s %(process)d %(thread)d %(message)s'
         },
     },
     'handlers': {
@@ -63,41 +58,54 @@ LOGGING = {
             'tags': {'custom-tag': 'x'},
         },
         'console': {
-            'level': 'DEBUG',
+            'level': 'INFO',
             'class': 'logging.StreamHandler',
             'formatter': 'verbose'
         },
-        'error_file': {
-            'class': 'logging.FileHandler',
-            'formatter': 'generic',
-            'filename': '/var/log/substra-backend.error.log',
-        },
-        'access_file': {
-            'class': 'logging.FileHandler',
-            'formatter': 'generic',
-            'filename': '/var/log/substra-backend.access.log',
-        },
     },
     'loggers': {
-        'django': {
-            'level': 'INFO',
+        # root logger
+        '': {
+            'level': 'WARNING',
             'handlers': ['console'],
             'propagate': True,
         },
-        'raven': {
-            'level': 'DEBUG',
+        # django and its applications
+        'django': {
+            'level': 'INFO',
             'handlers': ['console'],
             'propagate': False,
         },
-        'sentry.errors': {
-            'level': 'DEBUG',
+        'substrapp': {
+            'level': 'INFO',
             'handlers': ['console'],
             'propagate': False,
         },
         'events': {
+            'level': 'INFO',
             'handlers': ['console'],
-            'level': 'DEBUG',
-            'propagate': True,
+            'propagate': False,
+        },
+        # third-party libraries
+        'sentry.errors': {
+            'level': 'INFO',
+            'handlers': ['console'],
+            'propagate': False,
+        },
+        'raven': {
+            'level': 'INFO',
+            'handlers': ['console'],
+            'propagate': False,
+        },
+        'hfc': {
+            'level': 'WARNING',
+            'handlers': ['console'],
+            'propagate': False,
+        },
+        'celery': {
+            'level': 'INFO',
+            'handlers': ['console'],
+            'propagate': False,
         },
     },
 }

--- a/backend/substrapp/ledger_utils.py
+++ b/backend/substrapp/ledger_utils.py
@@ -189,7 +189,7 @@ def get_query_endorsing_peers(current_peer, all_peers):
     )
 
 
-def call_ledger(call_type, fcn, args=None, kwargs=None):
+def _call_ledger(call_type, fcn, args=None, kwargs=None):
 
     with get_hfc() as (loop, client):
         if not args:
@@ -270,6 +270,22 @@ def call_ledger(call_type, fcn, args=None, kwargs=None):
         _raise_for_status(response)
 
         return response
+
+
+def call_ledger(call_type, fcn, *args, **kwargs):
+    """Call ledger and log each request."""
+    ts = time.time()
+    error = None
+    try:
+        return _call_ledger(call_type, fcn, *args, **kwargs)
+    except Exception as e:
+        error = e.__class__.__name__
+        raise
+    finally:
+        # add a log even if the function raises an exception
+        te = time.time()
+        elaps = (te - ts) * 1000
+        logger.info(f'smartcontract {call_type}:{fcn}; elaps={elaps:.2f}ms; error={error}')
 
 
 def _invoke_ledger(fcn, args=None, cc_pattern=None, sync=False, only_pkhash=True):

--- a/backend/substrapp/tasks/utils.py
+++ b/backend/substrapp/tasks/utils.py
@@ -182,6 +182,8 @@ def container_format_log(container_name, container_logs):
 
 
 def list_files(startpath):
+    if not settings.TASK['LIST_WORKSPACE']:
+        return
     if os.path.exists(startpath):
 
         for root, dirs, files in os.walk(startpath, followlinks=True):
@@ -192,7 +194,7 @@ def list_files(startpath):
             for f in files:
                 logger.info(f'{subindent}{f}')
 
-        logging.info('\n')
+        logger.info('\n')
     else:
         logger.info(f'{startpath} does not exist.')
 

--- a/backend/substrapp/utils.py
+++ b/backend/substrapp/utils.py
@@ -17,6 +17,8 @@ from checksumdir import dirhash
 from django.conf import settings
 from rest_framework import status
 
+logger = logging.getLogger(__name__)
+
 
 class JsonException(Exception):
     def __init__(self, msg):
@@ -31,7 +33,7 @@ def get_dir_hash(archive_object):
             archive_object.seek(0)
             uncompress_content(content, temp_dir)
         except Exception as e:
-            logging.error(e)
+            logger.error(e)
             raise e
         else:
             return dirhash(temp_dir, 'sha256')
@@ -43,7 +45,7 @@ def store_datasamples_archive(archive_object):
         content = archive_object.read()
         archive_object.seek(0)
     except Exception as e:
-        logging.error(e)
+        logger.error(e)
         raise e
 
     # Temporary directory for uncompress
@@ -54,7 +56,7 @@ def store_datasamples_archive(archive_object):
         uncompress_content(content, tmp_datasamples_path)
     except Exception as e:
         shutil.rmtree(tmp_datasamples_path, ignore_errors=True)
-        logging.error(e)
+        logger.error(e)
         raise e
     else:
         # return the directory hash of the uncompressed file and the path of
@@ -177,7 +179,7 @@ def get_remote_file_content(url, auth, content_hash, salt=None):
     response = get_remote_file(url, auth)
 
     if response.status_code != status.HTTP_200_OK:
-        logging.error(response.text)
+        logger.error(response.text)
         raise NodeError(f'Url: {url} returned status code: {response.status_code}')
 
     computed_hash = compute_hash(response.content, key=salt)

--- a/backend/substrapp/views/datasample.py
+++ b/backend/substrapp/views/datasample.py
@@ -22,7 +22,7 @@ from substrapp.views.utils import find_primary_key_error, LedgerException, Valid
     get_success_create_code
 from substrapp.ledger_utils import query_ledger, LedgerError, LedgerTimeout, LedgerConflict
 
-logger = logging.getLogger('django.request')
+logger = logging.getLogger(__name__)
 
 
 class DataSampleViewSet(mixins.CreateModelMixin,

--- a/backend/substrapp/views/filters_utils.py
+++ b/backend/substrapp/views/filters_utils.py
@@ -4,6 +4,8 @@ from urllib.parse import unquote
 from substrapp.ledger_utils import query_ledger
 from substrapp import exceptions
 
+logger = logging.getLogger(__name__)
+
 
 FILTER_QUERIES = {
     'dataset': 'queryDataManagers',
@@ -103,7 +105,7 @@ def filter_list(object_type, data, query_params):
     except Exception:
         # TODO add better filters parsing to avoid this catch all
         message = f'Malformed search filters: invalid syntax: {query_params}'
-        logging.exception(message)
+        logger.exception(message)
         raise exceptions.BadRequestError(message)
 
     object_list = []

--- a/backend/substrapp/views/model.py
+++ b/backend/substrapp/views/model.py
@@ -14,6 +14,8 @@ from substrapp.ledger_utils import query_ledger, get_object_from_ledger, LedgerE
 from substrapp.views.utils import CustomFileResponse, validate_pk, get_remote_asset, PermissionMixin
 from substrapp.views.filters_utils import filter_list
 
+logger = logging.getLogger(__name__)
+
 
 class ModelViewSet(mixins.RetrieveModelMixin,
                    mixins.ListModelMixin,
@@ -74,10 +76,10 @@ class ModelViewSet(mixins.RetrieveModelMixin,
         try:
             data = self._retrieve(pk)
         except LedgerError as e:
-            logging.exception(e)
+            logger.exception(e)
             return Response({'message': str(e.msg)}, status=e.status)
         except Exception as e:
-            logging.exception(e)
+            logger.exception(e)
             return Response({'message': str(e)}, status.HTTP_400_BAD_REQUEST)
         else:
             return Response(data, status=status.HTTP_200_OK)


### PR DESCRIPTION
- add a log for each request done to the ledger
- no more calls to root logger (`logging.info(...)`), use a module logger instead: it will allow better logging configuration and tuning
- review dev settings for log configuration:
  - remove mail and file handlers: they are not used in dev mode
  - add substrapp logger
  - set custom configuration for external library when needed (hfc,
  celery, ...)
  - ensure all emitted logs to the console have the same formatters (in all services)
- review prod settings for log configuration
  - remove unused handlers and formatters
  - update default formatter
- add settings/env variables to:
  - disable SQL query logs
  - disable worker printing tuple workerspace