### PR TITLE
Fix: dataset can be linked with only one objective

### DIFF
--- a/backend/substrapp/management/commands/createdataset.py
+++ b/backend/substrapp/management/commands/createdataset.py
@@ -21,11 +21,11 @@ def path_leaf(path):
 class Command(BaseCommand):
     help = '''  # noqa
     create dataset
-    python ./manage.py createdataset '{"data_manager": {"name": "foo", "data_opener": "./opener.py", "description": "./description.md", "type": "foo", "objective_key": "foo", "permissions": {"public": True, "authorized_ids": []}}, "data_samples": {"paths": ["./data.zip", "./train/data"], "test_only": false}}'
+    python ./manage.py createdataset '{"data_manager": {"name": "foo", "data_opener": "./opener.py", "description": "./description.md", "type": "foo", "objective_key": "", "permissions": {"public": True, "authorized_ids": []}}, "data_samples": {"paths": ["./data.zip", "./train/data"], "test_only": false}}'
     python ./manage.py createdataset dataset.json
     # datamanager.json:
     # objective_key is optional
-    # {"data_manager": {"name": "foo", "data_opener": "./opener.py", "description": "./description.md", "type": "foo", "objective_key": "foo", "permissions": {"public": True, "authorized_ids": []}}, "data_samples": {"paths": ["./data.zip", "./train/data"], "test_only": false}}
+    # {"data_manager": {"name": "foo", "data_opener": "./opener.py", "description": "./description.md", "type": "foo", "objective_key": "", "permissions": {"public": True, "authorized_ids": []}}, "data_samples": {"paths": ["./data.zip", "./train/data"], "test_only": false}}
     '''
 
     def add_arguments(self, parser):

--- a/backend/substrapp/management/commands/createdataset.py
+++ b/backend/substrapp/management/commands/createdataset.py
@@ -21,11 +21,11 @@ def path_leaf(path):
 class Command(BaseCommand):
     help = '''  # noqa
     create dataset
-    python ./manage.py createdataset '{"data_manager": {"name": "foo", "data_opener": "./opener.py", "description": "./description.md", "type": "foo", "objective_keys": [], "permissions": {"public": True, "authorized_ids": []}}, "data_samples": {"paths": ["./data.zip", "./train/data"], "test_only": false}}'
+    python ./manage.py createdataset '{"data_manager": {"name": "foo", "data_opener": "./opener.py", "description": "./description.md", "type": "foo", "objective_key": "foo", "permissions": {"public": True, "authorized_ids": []}}, "data_samples": {"paths": ["./data.zip", "./train/data"], "test_only": false}}'
     python ./manage.py createdataset dataset.json
     # datamanager.json:
-    # objective_keys are optional
-    # {"data_manager": {"name": "foo", "data_opener": "./opener.py", "description": "./description.md", "type": "foo", "objective_keys": [], "permissions": {"public": True, "authorized_ids": []}}, "data_samples": {"paths": ["./data.zip", "./train/data"], "test_only": false}}
+    # objective_key is optional
+    # {"data_manager": {"name": "foo", "data_opener": "./opener.py", "description": "./description.md", "type": "foo", "objective_key": "foo", "permissions": {"public": True, "authorized_ids": []}}, "data_samples": {"paths": ["./data.zip", "./train/data"], "test_only": false}}
     '''
 
     def add_arguments(self, parser):
@@ -102,7 +102,7 @@ class Command(BaseCommand):
                     data={'name': data_manager['name'],
                           'permissions': data_manager['permissions'],
                           'type': data_manager['type'],
-                          'objective_keys': data_manager.get('objective_keys', []),
+                          'objective_key': data_manager.get('objective_key', ''),
                           'instance': instance},
                     context={'request': LocalRequest()})
 

--- a/backend/substrapp/views/datamanager.py
+++ b/backend/substrapp/views/datamanager.py
@@ -50,7 +50,7 @@ class DataManagerViewSet(mixins.CreateModelMixin,
                 'authorized_ids': request.data.getlist('permissions_authorized_ids', []),
             },
             'type': request.data.get('type'),
-            'objective_keys': request.data.getlist('objective_keys'),
+            'objective_key': request.data.get('objective_key', ''),
         }
 
         # create on db


### PR DESCRIPTION
The backend was in the middle of nowhere to set the objective key of a dataset:
- accepting  'objective_keys' from the request and sending this field to the ledger serializer
- ledger serializer looking for an 'objective_key' field

As a dataset can be linked with only one objective, the correct field is 'objective_key'.

Companion PRs:
- [substra](https://github.com/SubstraFoundation/substra/pull/94)
- [tests](https://github.com/SubstraFoundation/substra-tests/pull/66)