### PR TITLE
Fix description route

### DIFF
--- a/backend/substrapp/views/aggregatealgo.py
+++ b/backend/substrapp/views/aggregatealgo.py
@@ -203,6 +203,6 @@ class AggregateAlgoPermissionViewSet(PermissionMixin,
     def file(self, request, *args, **kwargs):
         return self.download_file(request, 'file', 'content')
 
-    @action(detail=True)
-    def description(self, request, *args, **kwargs):
+    @action(detail=True, url_path='description', url_name='description')
+    def description_(self, request, *args, **kwargs):
         return self.download_file(request, 'description')

--- a/backend/substrapp/views/algo.py
+++ b/backend/substrapp/views/algo.py
@@ -204,6 +204,6 @@ class AlgoPermissionViewSet(PermissionMixin,
     def file(self, request, *args, **kwargs):
         return self.download_file(request, 'file', 'content')
 
-    @action(detail=True)
-    def description(self, request, *args, **kwargs):
+    @action(detail=True, url_path='description', url_name='description')
+    def description_(self, request, *args, **kwargs):
         return self.download_file(request, 'description')

--- a/backend/substrapp/views/compositealgo.py
+++ b/backend/substrapp/views/compositealgo.py
@@ -203,6 +203,6 @@ class CompositeAlgoPermissionViewSet(PermissionMixin,
     def file(self, request, *args, **kwargs):
         return self.download_file(request, 'file', 'content')
 
-    @action(detail=True)
-    def description(self, request, *args, **kwargs):
+    @action(detail=True, url_path='description', url_name='description')
+    def description_(self, request, *args, **kwargs):
         return self.download_file(request, 'description')

--- a/backend/substrapp/views/datamanager.py
+++ b/backend/substrapp/views/datamanager.py
@@ -250,8 +250,8 @@ class DataManagerPermissionViewSet(PermissionMixin,
     serializer_class = DataManagerSerializer
     ledger_query_call = 'queryDataManager'
 
-    @action(detail=True)
-    def description(self, request, *args, **kwargs):
+    @action(detail=True, url_path='description', url_name='description')
+    def description_(self, request, *args, **kwargs):
         return self.download_file(request, 'description')
 
     @action(detail=True)

--- a/backend/substrapp/views/objective.py
+++ b/backend/substrapp/views/objective.py
@@ -250,8 +250,8 @@ class ObjectivePermissionViewSet(PermissionMixin,
     serializer_class = ObjectiveSerializer
     ledger_query_call = 'queryObjective'
 
-    @action(detail=True)
-    def description(self, request, *args, **kwargs):
+    @action(detail=True, url_path='description', url_name='description')
+    def description_(self, request, *args, **kwargs):
         return self.download_file(request, 'description')
 
     @action(detail=True)


### PR DESCRIPTION
So it appears `description` may be a semi-reserved keyword in DRF.

Trying to access any "description" route made the server break without even entering the view. Everything in the stacktrace was internal to django and DRF.