### PR TITLE
Update compute plan

### DIFF
--- a/backend/substrapp/ledger.py
+++ b/backend/substrapp/ledger.py
@@ -146,3 +146,7 @@ def update_datamanager(args):
 
 def update_datasample(args):
     return _create_asset('updateDataSample', args=args)
+
+
+def update_computeplan(args):
+    return _create_asset('updateComputePlan', args, only_pkhash=False)

--- a/backend/substrapp/serializers/ledger/computeplan/serializer.py
+++ b/backend/substrapp/serializers/ledger/computeplan/serializer.py
@@ -142,3 +142,9 @@ class LedgerComputePlanSerializer(serializers.Serializer):
     def create(self, validated_data):
         args = self.get_args(validated_data)
         return ledger.create_computeplan(args)
+
+    def update(self, compute_plan_id, validated_data):
+        args = self.get_args(validated_data)
+        del args['tag']
+        args['computePlanID'] = compute_plan_id
+        return ledger.update_computeplan(args)

--- a/backend/substrapp/tests/views/tests_views_computeplan.py
+++ b/backend/substrapp/tests/views/tests_views_computeplan.py
@@ -122,3 +122,13 @@ class ComputePlanViewTests(APITestCase):
             response = self.client.post(url, **self.extra)
             r = response.json()
             self.assertEqual(r, cp)
+
+    def test_computeplan_update(self):
+        cp = computeplan[0]
+        compute_plan_id = cp['computePlanID']
+        url = reverse('substrapp:compute_plan-update-ledger', args=[compute_plan_id])
+
+        with mock.patch('substrapp.ledger.update_computeplan', return_value=cp):
+            response = self.client.post(url, **self.extra)
+            r = response.json()
+            self.assertEqual(r, cp)

--- a/backend/substrapp/views/computeplan.py
+++ b/backend/substrapp/views/computeplan.py
@@ -87,3 +87,24 @@ class ComputePlanViewSet(mixins.CreateModelMixin,
         except LedgerError as e:
             return Response({'message': str(e.msg)}, status=e.status)
         return Response(compute_plan, status=status.HTTP_200_OK)
+
+    @action(detail=True, methods=['POST'])
+    def update_ledger(self, request, pk):
+        validate_pk(pk)
+
+        compute_plan_id = pk
+
+        serializer = self.get_serializer(data=dict(request.data))
+        serializer.is_valid(raise_exception=True)
+
+        # update compute plan in ledger
+        try:
+            data = serializer.update(compute_plan_id, serializer.validated_data)
+        except LedgerError as e:
+            error = {'message': str(e.msg), 'computePlanID': compute_plan_id}
+            return Response(error, status=e.status)
+
+        # send successful response
+        headers = self.get_success_headers(data)
+        status = get_success_create_code()
+        return Response(data, status=status, headers=headers)


### PR DESCRIPTION
Update compute plan.

- new route `/compute_plan/<compute_plan_id>/update_ledger`

Companion PRs:
- CLI/SDK: https://github.com/SubstraFoundation/substra/pull/104
- tests: https://github.com/SubstraFoundation/substra-tests/pull/69
- chaincode: https://github.com/SubstraFoundation/substra-chaincode/pull/89

Testing procedure:
- run the compute_plan example from the titanic example
- use the update_compute_plan command from the sdk to add a testtuple to one of the existing traintuples. This testtuple should have the same compute_plan_id as the compute plan and the result of the get compute plan should list the testtuple.