### PR TITLE
Do not authenticate user for /api-auth-token route

### DIFF
--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -115,6 +115,7 @@ def schema_view(request):
 
 
 class ExpiryObtainAuthToken(ObtainAuthToken):
+    authentication_classes = []
 
     def post(self, request, *args, **kwargs):
         serializer = self.serializer_class(data=request.data,


### PR DESCRIPTION
The route /api-auth-token was behind our authentication backends. Which meant that requesting the route with an invalid token but a valid user/login (which might happen if the token is expired for example, or if you're using a token from a different node) returned a 400 each time.

This PR removes the authentication backend checks and makes sure that only the password/login are considered.