### PR TITLE
Update fabric-sdk and set up new features

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -29,4 +29,4 @@ tldextract==2.2.2
 uwsgi==2.0.18
 zxcvbn==4.4.28
 boto3==1.11.9
-git+git://github.com/hyperledger/fabric-sdk-py.git@df19cf51ff4f21507869184901988c094658367a
+git+git://github.com/hyperledger/fabric-sdk-py.git@5f6407810f07c6901b10cd3b518dd82aed7482fb

--- a/backend/substrapp/tasks/utils.py
+++ b/backend/substrapp/tasks/utils.py
@@ -12,7 +12,7 @@ from substrapp.utils import get_owner, get_remote_file_content, get_and_put_remo
 
 from kubernetes import client, config
 
-CELERYWORKER_IMAGE = os.environ.get('CELERYWORKER_IMAGE')
+CELERYWORKER_IMAGE = os.environ.get('CELERYWORKER_IMAGE', 'substrafoundation/celeryworker:latest')
 DOCKER_LABEL = 'substra_task'
 
 logger = logging.getLogger(__name__)
@@ -61,7 +61,7 @@ def get_cpu_count(client):
 
     task_args = {
         'image': CELERYWORKER_IMAGE,
-        'command': 'python3 -u -c "import os; print(os.cpu_count(), end=\'\')"',
+        'command': 'python3 -u -c "import os; print(os.cpu_count())"',
         'detach': False,
         'stdout': True,
         'stderr': True,
@@ -76,7 +76,7 @@ def get_cpu_count(client):
     cpu_count = os.cpu_count()
 
     try:
-        cpu_count_bytes = client.containers.run(**task_args)
+        cpu_count_bytes = client.containers.run(**task_args).strip()
     except (docker.errors.ContainerError, docker.errors.ImageNotFound, docker.errors.APIError):
         logger.info('[Warning] Cannot get cpu count from remote')
     else:


### PR DESCRIPTION
Fix #77
- Use close grpc channels function from fabric-sdk-py
- Use retry grpc strategy in chaincode invoke
- disable raise exception in case of unavailable broker
- Fix celery image default in case of unset env variable