### PR TITLE
gzip models during download

### DIFF
--- a/backend/substrapp/views/model.py
+++ b/backend/substrapp/views/model.py
@@ -124,9 +124,7 @@ def gzip_action(func):
     @wraps(func)
     def wrapper(self, request, *args, **kwargs):
         resp = func(self, request, *args, **kwargs)
-        if request.method == 'GET':
-            return gz.process_response(request, resp)
-        return resp
+        return gz.process_response(request, resp)
 
     return wrapper
 

--- a/backend/substrapp/views/utils.py
+++ b/backend/substrapp/views/utils.py
@@ -1,7 +1,7 @@
 import os
 
 
-from django.http import FileResponse
+from django.http import FileResponse, HttpResponse
 from rest_framework.authentication import BasicAuthentication, TokenAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -106,11 +106,11 @@ class PermissionMixin(object):
         try:
             asset = get_object_from_ledger(pk, self.ledger_query_call)
         except LedgerError as e:
-            return Response({'message': str(e.msg)}, status=e.status)
+            return HttpResponse({'message': str(e.msg)}, status=e.status)
 
         if not self.has_access(request.user, asset):
-            return Response({'message': 'Unauthorized'},
-                            status=status.HTTP_403_FORBIDDEN)
+            return HttpResponse({'message': 'Unauthorized'},
+                                status=status.HTTP_403_FORBIDDEN)
 
         if not ledger_field:
             ledger_field = django_field


### PR DESCRIPTION
1. Only gzip models, to be conservative. We could decide to gzip more routes (or all the routes) in the future.
2. The middleware takes care of not gzipping small payloads (<200b), not gzipping the payload if the the client doesn't support it, not gzipping if the response is already compressed, etc
3. The client (`requests.get`) already adds `Accept-Encoding: gzip,deflate`, and decompresses accordingly if the response has `Content-Encoding: gzip`. So we don't need to do anything client-side.

You can check that the response is actually encoded by doing a HTTP request manually with curl (and adding `Accept-Encoding: gzip`), or by adding this to `utils.py`

```python
enc = response.headers.get('Content-Encoding', 'unknown')
logger.info(f'Response encoding: {enc}')
```
