### PR TITLE
dev mode: detach python processes

### DIFF
--- a/charts/substra-backend/templates/deployment-server.yaml
+++ b/charts/substra-backend/templates/deployment-server.yaml
@@ -32,11 +32,15 @@ spec:
         {{- if .Values.backend.image.pullPolicy }}
         imagePullPolicy: "{{ .Values.backend.image.pullPolicy }}"
         {{- end }}
-        command: ["/bin/bash"]
         {{- if eq .Values.backend.settings "prod" }}
+        command: ["/bin/bash"]
         args: ["-c", "uwsgi --http :{{ .Values.backend.service.port }} --module backend.wsgi --static-map /static=/usr/src/app/backend/statics --master --processes {{ .Values.backend.uwsgiProcesses }} --threads {{ .Values.backend.uwsgiThreads }} --need-app --env DJANGO_SETTINGS_MODULE=backend.settings.server.prod "]
         {{- else }}
-        args: ["-c", "python manage.py runserver --noreload 0.0.0.0:{{ .Values.backend.service.port }} --settings=backend.settings.server.{{ .Values.backend.settings }}"]
+        command: ["/bin/bash", "-c"]
+        args:
+        - |
+          python manage.py runserver --noreload 0.0.0.0:{{ .Values.backend.service.port }} --settings=backend.settings.server.{{ .Values.backend.settings }} &
+          sleep infinity
         {{- end }}
         env:
           - name: DJANGO_SETTINGS_MODULE

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -32,8 +32,16 @@ spec:
           {{- if .Values.celeryworker.image.pullPolicy }}
           imagePullPolicy: "{{ .Values.celeryworker.image.pullPolicy }}"
           {{- end }}
+          {{- if eq .Values.backend.settings "prod" }}
           command: ["celery"]
           args: ["-A", "backend", "worker", "-E", "-l", "info", "-n", "{{ .Values.organization.name }}", "-Q", "{{ .Values.organization.name }},{{ .Values.organization.name }}.worker,celery", "--hostname", "{{ .Values.organization.name }}.worker"]
+          {{- else }}
+          command: ["/bin/bash", "-c"]
+          args:
+          - |
+            celery -A backend worker -E -l info -n {{ .Values.organization.name }} -Q {{ .Values.organization.name }},{{ .Values.organization.name }}.worker,celery --hostname {{ .Values.organization.name }}.worker &
+            sleep infinity
+          {{- end }}
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: backend.settings.celery.{{ .Values.backend.settings }}

--- a/docker/celeryworker/Dockerfile
+++ b/docker/celeryworker/Dockerfile
@@ -2,7 +2,7 @@ FROM nvidia/cuda:9.2-base-ubuntu18.04
 
 RUN apt-get update
 RUN apt-get install -y python3.6 python3-pip python3-dev build-essential libssl-dev libffi-dev libxml2-dev libxslt1-dev zlib1g-dev
-RUN apt-get install -y git curl netcat
+RUN apt-get install -y git curl netcat psmisc
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
I'm proposing this change because I've used it locally, and I've found it extremely helpful to speed things up!

---

Local development can be slow even with `skaffold dev`, because every code change leads to an image rebuild and a full re-deploy.

As a result, it can take a considerable amount of time to iteratively make small modifications to python code and test the resulting version (e.g. add a `print` statement, or make some other code changes and test the behavior)

This PR speeds-up local development by enabling new workflow (in **dev only**). Here are the steps:

1. `skaffold run`
2. Modify a python file
3. Kill python processes (on target container)
4. Upload the new code (to target container)
5. Start new python processes (on target container)
6. Go to step 2

**The main point of this PR is to detach the python/celery processes from the init process (PID 1)**. That's is done by using a `&` character. The init process (PID 1) is just a shell that sleeps forever. This enables us to kill processes without having the container restart automatically (from the Docker image, which doesn't have our latest code changes).

## Workflow examples

### Worker

```
POD=$(kubectl get pod -n org-1 | grep worker | awk '{print $1'})
NS=org-1
```

After a code change (corresponds to steps 3-5):

```bash
kubectl exec -n $NS $POD -- killall /usr/bin/python3
kubectl cp -n $NS ~/code/substra-backend/backend/substrapp $POD:/usr/src/app
kubectl exec -n $NS $POD -- celery -A backend worker -E -l info -n MyOrg1 -Q MyOrg1,MyOrg1.worker,celery --hostname MyOrg1.worker
```

### Server

```
POD=$(kubectl get pod -n org-1 | grep server | awk '{print $1'})
NS=org-1
```

After a code change (corresponds to steps 3-5):

```
kubectl exec -n $NS $POD -- killall python
kubectl cp -n $NS ~/code/substra-backend/.venv/lib/python3.6/site-packages/django/middleware $POD:/usr/local/lib/python3.6/site-packages/django/
kubectl exec -n $NS $POD -- python manage.py runserver --noreload 0.0.0.0:8000 --settings=backend.settings.server.dev
```

## Known issues

The only downside I noticed with this approach is that stdout/stderr stops being attached to k8s: `kubectl logs` doesn't work anymore for the "patched" worker/server containers. Logs are instead output to the terminal which started the python processes (step 5). However, I have found it to be a tiny price to pay in exchange for a major speedup in development. Also this only affects the modified containers: all the other logs work as before.