### PR TITLE
Streamline Model view

### DIFF
--- a/backend/events/apps.py
+++ b/backend/events/apps.py
@@ -188,7 +188,7 @@ def wait():
                                                              'chaincode-updates',
                                                              onEvent=on_event)
 
-                    logger.error(f'Connect to Channel Event Hub')
+                    logger.error('Connect to Channel Event Hub')
                     loop.run_until_complete(stream)
 
                 except RpcError as e:

--- a/backend/substrapp/serializers/__init__.py
+++ b/backend/substrapp/serializers/__init__.py
@@ -2,14 +2,13 @@
 
 from .datasample import DataSampleSerializer
 from .objective import ObjectiveSerializer
-from .model import ModelSerializer
 from .datamanager import DataManagerSerializer
 from .algo import AlgoSerializer
 from .compositealgo import CompositeAlgoSerializer
 from .aggregatealgo import AggregateAlgoSerializer
 from .ledger import *
 
-__all__ = ['DataSampleSerializer', 'ObjectiveSerializer', 'ModelSerializer',
+__all__ = ['DataSampleSerializer', 'ObjectiveSerializer',
            'DataManagerSerializer', 'AlgoSerializer', 'CompositeAlgoSerializer',
            'LedgerObjectiveSerializer', 'LedgerModelSerializer',
            'LedgerDataSampleSerializer', 'LedgerDataSampleUpdateSerializer',

--- a/backend/substrapp/serializers/model.py
+++ b/backend/substrapp/serializers/model.py
@@ -1,9 +1,0 @@
-from libs.serializers import DynamicFieldsModelSerializer
-from substrapp.models import Model
-
-
-class ModelSerializer(DynamicFieldsModelSerializer):
-
-    class Meta:
-        model = Model
-        fields = '__all__'

--- a/backend/substrapp/tasks/utils.py
+++ b/backend/substrapp/tasks/utils.py
@@ -355,7 +355,7 @@ def compute_docker(client, dockerfile_path, image_name, container_name, volumes,
         except docker.errors.BuildError as e:
             # catch build errors and print them for easier debugging of failed build
             lines = [line['stream'].strip() for line in e.build_log if 'stream' in line]
-            lines = [l for l in lines if l]
+            lines = [line for line in lines if line]
             error = '\n'.join(lines)
             logger.error(f'BuildError: {error}')
             raise

--- a/backend/substrapp/tests/tests_misc.py
+++ b/backend/substrapp/tests/tests_misc.py
@@ -152,5 +152,5 @@ class MiscTests(TestCase):
 
         # Models
         with self.assertRaises(Exception):
-            model_dst_path = os.path.join(DIRECTORY, f'model/../../hackermodel')
+            model_dst_path = os.path.join(DIRECTORY, 'model/../../hackermodel')
             raise_if_path_traversal([model_dst_path], os.path.join(DIRECTORY, 'model/'))

--- a/backend/substrapp/tests/tests_password_validation.py
+++ b/backend/substrapp/tests/tests_password_validation.py
@@ -18,7 +18,7 @@ class PasswordValidationTests(TestCase):
         try:
             self.max_len_validator.validate(password_short)
         except Exception:
-            self.fail(f"Password validation should succeed when the password is not too long.")
+            self.fail("Password validation should succeed when the password is not too long.")
 
         # too long password NOT OK
         self.assertRaisesRegexp(ValidationError,
@@ -34,7 +34,7 @@ class PasswordValidationTests(TestCase):
         try:
             self.complexity_validator.validate(password_complex)
         except Exception:
-            self.fail(f"Password validation should succeed when the password is complex enough.")
+            self.fail("Password validation should succeed when the password is complex enough.")
 
         # easy-to-guess password NOT OK
         self.assertRaisesRegexp(ValidationError,

--- a/backend/substrapp/tests/views/test_views_authentication.py
+++ b/backend/substrapp/tests/views/test_views_authentication.py
@@ -149,7 +149,7 @@ class AuthenticationTests(APITestCase):
                                     {'username': 'foo', 'password': 'bar'}, **self.extra)
         self.assertEqual(response.status_code, 200)
 
-        invalid_auth_token_header = f"Token nope"
+        invalid_auth_token_header = 'Token nope'
         self.client.credentials(HTTP_AUTHORIZATION=invalid_auth_token_header)
         response = self.client.post('/api-token-auth/',
                                     {'username': 'foo', 'password': 'bar'}, **self.extra)

--- a/backend/substrapp/views/datasample.py
+++ b/backend/substrapp/views/datasample.py
@@ -149,7 +149,7 @@ class DataSampleViewSet(mixins.CreateModelMixin,
                 }
 
         if not data:
-            raise Exception(f'No data sample provided.')
+            raise Exception('No data sample provided.')
 
         return list(data.values())
 

--- a/backend/substrapp/views/model.py
+++ b/backend/substrapp/views/model.py
@@ -1,6 +1,5 @@
 import tempfile
 import logging
-from django.http import Http404
 from functools import wraps
 from django.conf import settings
 from django.middleware.gzip import GZipMiddleware
@@ -44,39 +43,13 @@ class ModelViewSet(mixins.RetrieveModelMixin,
 
         return instance
 
-    def _retrieve(self, pk):
-        validate_pk(pk)
-
-        data = get_object_from_ledger(pk, self.ledger_query_call)
-        if not data or not data.get('traintuple'):
-            raise Exception('Invalid model: missing traintuple field')
-        if data['traintuple'].get('status') != "done":
-            raise Exception("Invalid model: traintuple must be at status done")
-
-        # Try to get it from local db, else create it in local db
-        try:
-            instance = self.get_object()
-        except Http404:
-            instance = None
-
-        if not instance or not instance.file:
-            instance = self.create_or_update_model(data['traintuple'],
-                                                   data['traintuple']['outModel']['hash'])
-
-            # For security reason, do not give access to local file address
-            # Restrain data to some fields
-            # TODO: do we need to send creation date and/or last modified date ?
-            serializer = self.get_serializer(instance, fields=('owner', 'pkhash'))
-            data.update(serializer.data)
-
-            return data
-
     def retrieve(self, request, *args, **kwargs):
         lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
         pk = self.kwargs[lookup_url_kwarg]
+        validate_pk(pk)
 
         try:
-            data = self._retrieve(pk)
+            data = get_object_from_ledger(pk, self.ledger_query_call)
         except LedgerError as e:
             logger.exception(e)
             return Response({'message': str(e.msg)}, status=e.status)
@@ -105,18 +78,6 @@ class ModelViewSet(mixins.RetrieveModelMixin,
                 return Response({'message': str(e.msg)}, status=e.status)
 
         return Response(models_list, status=status.HTTP_200_OK)
-
-    @action(detail=True)
-    def details(self, request, *args, **kwargs):
-        lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
-        pk = self.kwargs[lookup_url_kwarg]
-
-        try:
-            data = get_object_from_ledger(pk, self.ledger_query_call)
-        except LedgerError as e:
-            return Response({'message': str(e.msg)}, status=e.status)
-
-        return Response(data, status=status.HTTP_200_OK)
 
 
 def gzip_action(func):


### PR DESCRIPTION
Related to #160 
Companion PR : https://github.com/SubstraFoundation/substra-frontend/pull/43

Merge retrieve and details view

This PR doesn't change the `model/<model_hash>/file` path because:
- this path is only use between node
- the ledger call is different that other path : `queryModelPermissions ` and not `queryModelDetails`
- model file are registered in the db (and the ledger via storage address) with the hash of the model. To change it, we will need to change the chaincode.