### PR TITLE
Add service account for worker

### DIFF
--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-backend
 home: https://substra.org/
-version: 1.0.0-alpha.21
+version: 1.0.0-alpha.22
 description: Main package for Substra
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -27,7 +27,7 @@ spec:
       {{- end }}
       {{- end }}
       {{- if .Values.celeryworker.rbac.enable }}
-      serviceAccountName: {{ template "substra.fullname" . }}
+      serviceAccountName: {{ template "substra.fullname" . }}-worker
       {{- end }}
       containers:
         - name: worker

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -26,6 +26,9 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if .Values.celeryworker.rbac.enable }}
+      serviceAccountName: {{ template "substra.fullname" . }}
+      {{- end }}
       containers:
         - name: worker
           image: "{{ .Values.celeryworker.image.repository }}:{{ .Values.celeryworker.image.tag }}"

--- a/charts/substra-backend/templates/rbac.yaml
+++ b/charts/substra-backend/templates/rbac.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.celeryworker.rbac.enable }} 
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "substra.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ template "substra.name" . }}
+    app.kubernetes.io/part-of: {{ template "substra.name" . }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "substra.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ template "substra.name" . }}
+    app.kubernetes.io/part-of: {{ template "substra.name" . }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list", "create"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "substra.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ template "substra.name" . }}
+    app.kubernetes.io/part-of: {{ template "substra.name" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "substra.fullname" . }}
+roleRef:
+  kind: Role
+  name: {{ template "substra.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/substra-backend/templates/rbac.yaml
+++ b/charts/substra-backend/templates/rbac.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "substra.fullname" . }}
+  name: {{ template "substra.fullname" . }}-worker
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -205,6 +205,10 @@ celeryworker:
 
   affinity: {}
 
+  rbac:
+    enable: False
+  # Add ServiceAccount for celeryworker
+
 extraEnv: []
   # - name: ENV_VARIABLE
   #   value: false


### PR DESCRIPTION
Add ServiceAccount for the worker making it able to list, retrieve and create secrets in his workspace.
This PR could be adapted to add different Kubernetes ressources the worker would need to access.