### PR TITLE
Prevent from path traversal when saving models or extracting archives

### DIFF
--- a/backend/substrapp/tests/tests_misc.py
+++ b/backend/substrapp/tests/tests_misc.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 
 from mock import patch
+
+from substrapp.utils import raise_if_path_traversal, uncompress_path
 from substrapp.tasks.utils import get_cpu_sets, get_gpu_sets
 
 from substrapp.ledger_utils import LedgerNotFound, LedgerInvalidResponse
@@ -9,6 +11,11 @@ from substrapp.ledger_utils import get_object_from_ledger, log_fail_tuple, log_s
     log_success_tuple, query_tuples
 
 import docker
+import os
+import shutil
+
+
+DIRECTORY = '/tmp/testmisc/'
 
 
 class MockDevice():
@@ -20,8 +27,38 @@ class MockDevice():
         pass
 
 
+class MockArchive:
+    def __init__(self, traversal=True):
+        if traversal:
+            self.files = ['../../foo.csv', '../bar.csv']
+        else:
+            self.files = ['foo.csv', 'bar.csv']
+
+    def __iter__(self):
+        return iter(self.files)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return True
+
+    def namelist(self):
+        return self.files
+
+    def getnames(self):
+        return self.files
+
+
 class MiscTests(TestCase):
     """Misc tests"""
+
+    def setUp(self):
+        if not os.path.exists(DIRECTORY):
+            os.makedirs(DIRECTORY)
+
+    def tearDown(self):
+        shutil.rmtree(DIRECTORY, ignore_errors=True)
 
     def test_cpu_sets(self):
         cpu_count = 16
@@ -99,3 +136,29 @@ class MiscTests(TestCase):
         with patch('substrapp.ledger_utils.query_ledger') as mquery_ledger:
             mquery_ledger.return_value = None
             query_tuples('testtuple', 'data_owner')
+
+    def test_path_traversal(self):
+        # Zip
+        with patch('substrapp.utils.zipfile.is_zipfile') as mock_is_zipfile, \
+                patch('substrapp.utils.ZipFile') as mock_zipfile:
+            mock_is_zipfile.return_value = True
+            mock_zipfile.return_value = MockArchive()
+
+            self.assertRaises(Exception,
+                              uncompress_path('', DIRECTORY))
+
+        # Tar
+        with patch('substrapp.utils.zipfile.is_zipfile') as mock_is_zipfile, \
+                patch('substrapp.utils.tarfile.is_tarfile') as mock_is_tarfile, \
+                patch('substrapp.utils.tarfile.open') as mock_tarfile:
+            mock_is_zipfile.return_value = False
+            mock_is_tarfile.return_value = True
+            mock_tarfile.return_value = MockArchive()
+
+            self.assertRaises(Exception,
+                              uncompress_path('', DIRECTORY))
+
+        # Models
+        with self.assertRaises(Exception):
+            model_dst_path = os.path.join(DIRECTORY, f'model/../../hackermodel')
+            raise_if_path_traversal([model_dst_path], os.path.join(DIRECTORY, 'model/'))

--- a/backend/substrapp/tests/tests_misc.py
+++ b/backend/substrapp/tests/tests_misc.py
@@ -12,7 +12,6 @@ from substrapp.ledger_utils import get_object_from_ledger, log_fail_tuple, log_s
 
 import docker
 import os
-import shutil
 
 
 DIRECTORY = '/tmp/testmisc/'
@@ -52,13 +51,6 @@ class MockArchive:
 
 class MiscTests(TestCase):
     """Misc tests"""
-
-    def setUp(self):
-        if not os.path.exists(DIRECTORY):
-            os.makedirs(DIRECTORY)
-
-    def tearDown(self):
-        shutil.rmtree(DIRECTORY, ignore_errors=True)
 
     def test_cpu_sets(self):
         cpu_count = 16

--- a/backend/substrapp/utils.py
+++ b/backend/substrapp/utils.py
@@ -111,6 +111,8 @@ def create_directory(directory):
 def raise_if_path_traversal(requested_paths, to_directory):
     # Inspired from https://stackoverflow.com/a/45188896
 
+    # Get real path and ensure there is a suffix /
+    # at the end of the path
     safe_directory = os.path.join(
         os.path.realpath(to_directory),
         ''
@@ -121,9 +123,9 @@ def raise_if_path_traversal(requested_paths, to_directory):
 
     for requested_path in requested_paths:
         real_requested_path = os.path.realpath(requested_path)
-        path_traversal = os.path.commonprefix([real_requested_path, safe_directory]) != safe_directory
+        is_traversal = os.path.commonprefix([real_requested_path, safe_directory]) != safe_directory
 
-        if path_traversal:
+        if is_traversal:
             raise Exception(f'Path Traversal Error : {requested_path} (real : {real_requested_path}) is not safe.')
 
 


### PR DESCRIPTION
Filenames should be validated when storing asset to prevent from path/directory traversal.
Companion PR :  https://github.com/SubstraFoundation/substra/pull/151