### PR TITLE
Enable browsable API in dev mode only

### DIFF
--- a/backend/backend/settings/deps/restframework.py
+++ b/backend/backend/settings/deps/restframework.py
@@ -6,12 +6,10 @@ REST_FRAMEWORK = {
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
         #  'rest_framework.renderers.AdminRenderer',
-        'rest_framework.renderers.BrowsableAPIRenderer',
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': [
         'users.authentication.SecureJWTAuthentication',  # for front/sdk/cli
         'libs.expiry_token_authentication.ExpiryTokenAuthentication',  # for front/sdk/cli
-        'libs.session_authentication.CustomSessionAuthentication',  # for web browsable api
     ],
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated',

--- a/backend/backend/settings/dev.py
+++ b/backend/backend/settings/dev.py
@@ -9,10 +9,10 @@ DEBUG = True
 # LEDGER_CALL_RETRY = False  # uncomment to overwrite the ledger setting value
 
 # Enable Browsable API
-REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] = REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] + (
+REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] += (
     'rest_framework.renderers.BrowsableAPIRenderer',
 )
-REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] + [
+REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] += [
     'libs.session_authentication.CustomSessionAuthentication',
 ]
 

--- a/backend/backend/settings/dev.py
+++ b/backend/backend/settings/dev.py
@@ -8,6 +8,14 @@ from .deps.restframework import *
 DEBUG = True
 # LEDGER_CALL_RETRY = False  # uncomment to overwrite the ledger setting value
 
+# Enable Browsable API
+REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] = REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'] + (
+    'rest_framework.renderers.BrowsableAPIRenderer',
+)
+REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] + [
+    'libs.session_authentication.CustomSessionAuthentication',
+]
+
 # Database
 # https://docs.djangoproject.com/en/2.0/ref/settings/#databases
 

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -17,6 +17,8 @@ from django.conf.urls import url
 from django.conf import settings
 from django.conf.urls.static import static
 from django.urls import include
+from rest_framework.settings import api_settings
+from rest_framework.renderers import BrowsableAPIRenderer
 
 from backend.views import obtain_auth_token
 
@@ -30,8 +32,11 @@ urlpatterns = [
         url(r'^', include((router.urls, 'substrapp'))),
         url(r'^', include((node_router.urls, 'node'))),
         url(r'^', include((user_router.urls, 'user'))),  # for secure jwt authent
-        url(r'^api-auth/', include('rest_framework.urls')),  # for session authent
         url(r'^api-token-auth/', obtain_auth_token)  # for expiry token authent
     ])),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT) \
   + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+# only allow session authentication is the browsable API is enabled
+if BrowsableAPIRenderer in api_settings.DEFAULT_RENDERER_CLASSES:
+    urlpatterns += [url(r'^api-auth/', include('rest_framework.urls'))]

--- a/backend/substrapp/views/utils.py
+++ b/backend/substrapp/views/utils.py
@@ -2,11 +2,11 @@ import os
 
 
 from django.http import FileResponse, HttpResponse
-from rest_framework.authentication import BasicAuthentication, TokenAuthentication
+from rest_framework.authentication import BasicAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.settings import api_settings
 
-from libs.session_authentication import CustomSessionAuthentication
 from node.authentication import NodeUser
 from substrapp.ledger_utils import get_object_from_ledger, LedgerError
 from substrapp.utils import NodeError, get_remote_file, get_owner, get_remote_file_content
@@ -16,8 +16,6 @@ from django.conf import settings
 from rest_framework import status
 from requests.auth import HTTPBasicAuth
 from wsgiref.util import is_hop_by_hop
-
-from users.authentication import SecureJWTAuthentication
 
 from substrapp import exceptions
 
@@ -54,12 +52,7 @@ def node_has_process_permission(asset):
 
 
 class PermissionMixin(object):
-    authentication_classes = [
-        BasicAuthentication,  # for node to node
-        SecureJWTAuthentication,  # for user from front/sdk/cli
-        TokenAuthentication,  # for user from front/sdk/cli
-        CustomSessionAuthentication,  # for user on drf web browsable api
-    ]
+    authentication_classes = api_settings.DEFAULT_AUTHENTICATION_CLASSES + [BasicAuthentication]
     permission_classes = [IsAuthenticated]
 
     def has_access(self, user, asset):


### PR DESCRIPTION
This has been tested against substra-tests in dev mode with success.

I tried running it against skaffold modified as follows to emulate a prod mode. I only had one test failing: test_execution_retry_on_fail. But it looks like it is a known bug not linked to these changes: https://github.com/SubstraFoundation/substra-tests/issues/48

```diff
diff --git a/skaffold.yaml b/skaffold.yaml
index d79ccb9d..6951f670 100644
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -39,7 +39,7 @@ deploy:
           secrets:
             fabricConfigmap: network-org-1-hlf-k8s-fabric
           backend:
-            settings: dev
+            settings: prod
             defaultDomain: http://substra-backend.node-1.com
             ingress:
               enabled: true
@@ -81,7 +81,7 @@ deploy:
           secrets:
             fabricConfigmap: network-org-2-hlf-k8s-fabric
           backend:
-            settings: dev
+            settings: prod
             defaultDomain: http://substra-backend.node-2.com
             ingress:
               enabled: true
```

The frontend isn't working with this pseudo-prod mode, but I've checked that it's also an issue with the master branch, so not introduced here. To be more precise, I can login using the frontend, but then calls to /objective, /data_manager or /algo all fail with the following error:
```json
{
  "detail": "Given token not valid for any token type",
  "code": "token_not_valid",
  "messages": [
    {
      "token_class": "AccessToken",
      "token_type": "access",
      "message": "Token is invalid or expired"
    }
  ]
}
```
