### PR TITLE
Throttling

### DIFF
--- a/backend/backend/settings/deps/restframework.py
+++ b/backend/backend/settings/deps/restframework.py
@@ -21,6 +21,13 @@ REST_FRAMEWORK = {
     'ALLOWED_VERSIONS': ('0.0',),
     'DEFAULT_VERSION': '0.0',
     'EXCEPTION_HANDLER': 'substrapp.exceptions.api_exception_handler',
+    'DEFAULT_THROTTLE_CLASSES': [
+        'rest_framework.throttling.AnonRateThrottle',
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': '60/minute',
+        'login': '60/minute',
+    },
 }
 
 SIMPLE_JWT = {

--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -1,13 +1,16 @@
 from rest_framework.authtoken.views import ObtainAuthToken
+from rest_framework.throttling import AnonRateThrottle
 
 from rest_framework.authtoken.models import Token
 from rest_framework.response import Response
 
 from libs.expiry_token_authentication import token_expire_handler, expires_at
+from libs.user_login_throttle import UserLoginThrottle
 
 
 class ExpiryObtainAuthToken(ObtainAuthToken):
     authentication_classes = []
+    throttle_classes = [AnonRateThrottle, UserLoginThrottle]
 
     def post(self, request, *args, **kwargs):
         serializer = self.serializer_class(data=request.data,

--- a/backend/libs/user_login_throttle.py
+++ b/backend/libs/user_login_throttle.py
@@ -1,0 +1,5 @@
+from rest_framework.throttling import UserRateThrottle
+
+
+class UserLoginThrottle(UserRateThrottle):
+    scope = 'login'

--- a/backend/users/views/user.py
+++ b/backend/users/views/user.py
@@ -4,11 +4,13 @@ from django.contrib.auth.models import User
 from rest_framework import status
 from rest_framework.permissions import AllowAny
 from rest_framework.viewsets import GenericViewSet
-from rest_framework.decorators import action
+from rest_framework.decorators import action, throttle_classes
 from rest_framework.response import Response
+from rest_framework.throttling import AnonRateThrottle
 from rest_framework_simplejwt.authentication import AUTH_HEADER_TYPES
 from rest_framework_simplejwt.exceptions import TokenError, InvalidToken, AuthenticationFailed
 
+from libs.user_login_throttle import UserLoginThrottle
 from users.serializers import CustomTokenObtainPairSerializer, CustomTokenRefreshSerializer
 
 import tldextract
@@ -37,6 +39,7 @@ class UserViewSet(GenericViewSet):
         return host
 
     @action(methods=['post'], detail=False)
+    @throttle_classes([AnonRateThrottle, UserLoginThrottle])
     def login(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
 


### PR DESCRIPTION
This PR adds throttling to:
* all endpoints for anonymous users (limited to 60calls/minute globally)
* the 2 login endpoints (for both sdk and frontend) for anonymous and logged in users alike.

This PR has been tested against substra-tests, all e2e tests work normally (as expected).

In order to make sure the throttling works as expected, here is a test script:
```python
import requests
import time

credentials = {'username': 'node-1', 'password': 'p@$swr0d44'}


def req(url, token=None, data=None):
    url = f'http://substra-backend.node-1.com{url}'
    headers = {
        'Accept': 'application/json;version=0.0'
    }
    if token:
        headers['Authorization'] = f"Token {token}"

    return requests.post(url, data=data, headers=headers)


def test_throttle(url, token=None):
    for i in range(60):
        r = req(url, token)
        assert r.status_code == 400, f'round {i}: got {r.status_code}'

    r = req(url, token)
    assert r.status_code == 429, f'round 61: got {r.status_code}'


def test_throttle_with_buffer(url, token=None):
    mode = 'Authenticated' if token else 'Anonymous'
    print(f'{mode} - {url}')
    print('  waiting 60s... ', end='', flush=True)
    time.sleep(60)
    print('done')
    print('  testing... ', end='', flush=True)
    test_throttle(url, token=token)
    print('done')


r = req('/api-token-auth/', data=credentials)
token = r.json()['token']

# anonymous
test_throttle_with_buffer('/api-token-auth/')

# authenticated
test_throttle_with_buffer('/api-token-auth/', token=token)
test_throttle_with_buffer('/objective/', token=token)

```

The expected output is:
```sh
➜ python throttle_test.py
Anonymous - /api-token-auth/
  waiting 60s... done
  testing... done
Authenticated - /api-token-auth/
  waiting 60s... done
  testing... done
Authenticated - /objective/
  waiting 60s... done
  testing... Traceback (most recent call last):
  File "throttle_test.py", line 46, in <module>
    test_throttle_with_buffer('/objective/', token=token)
  File "throttle_test.py", line 34, in test_throttle_with_buffer
    test_throttle(url, token=token)
  File "throttle_test.py", line 24, in test_throttle
    assert r.status_code == 429, f'round 61: got {r.status_code}'
AssertionError: round 61: got 400
```

The stacktrace at the end is normal, as there should be no throttling for authenticated calls on endpoints other than login.

Also, there is no need to test protected views for throttling since permissions are check before throttles.