### PR TITLE
Add prod profile to skaffold

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -108,3 +108,13 @@ deploy:
           users:
             - name: "node-2"
               secret: "p@$swr0d45"
+
+profiles:
+  - name: prod
+    patches:
+      - op: replace
+        path: /deploy/helm/releases/0/overrides/backend/settings
+        value: prod
+      - op: replace
+        path: /deploy/helm/releases/1/overrides/backend/settings
+        value: prod


### PR DESCRIPTION
With this little change you can now launch the backend with the prod settings with:

```sh
skaffold dev -p prod
```

You can make sure this works by executing the command above, opening a shell in one of the server or worker containers and running `printenv | grep prod` in it. 