### PR TITLE
Add option to enable/disable folder deletion at end of compute plan

### DIFF
--- a/backend/backend/settings/common.py
+++ b/backend/backend/settings/common.py
@@ -209,3 +209,5 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = 10000
 EXPIRY_TOKEN_LIFETIME = timedelta(minutes=int(os.environ.get('EXPIRY_TOKEN_LIFETIME', 24*60)))
 
 GZIP_MODELS = to_bool(os.environ.get('GZIP_MODELS', False))
+
+ENABLE_REMOVE_LOCAL_CP_FOLDERS = to_bool(os.environ.get('ENABLE_REMOVE_LOCAL_CP_FOLDERS', True))

--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -406,6 +406,9 @@ def remove_subtuple_materials(subtuple_directory):
 
 
 def remove_local_folders(compute_plan_id):
+    if not settings.ENABLE_REMOVE_LOCAL_CP_FOLDERS:
+        logger.info(f'Skipping remove local volume of compute plan {compute_plan_id}')
+        return
 
     logger.info(f'Remove local volume of compute plan {compute_plan_id}')
 


### PR DESCRIPTION
Adds a new environment variable, `ENABLE_REMOVE_LOCAL_CP_FOLDERS `, which defaults to True that drives whether local volumes for compute plan will be removed or not.

To test, you can add the following test to substra-tests and run it.
* If you have the option set to true, the test will fail on the second traintuple
* if you have the option set to false, the test will succeed

```python
def test_remove_local_folder(global_execution_env):
    to_replace = """
    tools.algo.execute(TestAlgo())"""

    write_to_local_folder = """
    test_path = "/sandbox/local/foo"
    with open(test_path, 'w') as f:
        f.write('foo')

    tools.algo.execute(TestAlgo())
    """

    read_from_local_folder = """
    test_path = "/sandbox/local/foo"
    with open(test_path, 'r') as f:
        f.read()

    tools.algo.execute(TestAlgo())
    """

    factory, initial_assets, network = global_execution_env
    client = network.clients[0]

    initial_assets = initial_assets.filter_by(client.node_id)
    dataset = initial_assets.datasets[0]

    write_script = sbt.factory.DEFAULT_ALGO_SCRIPT.replace(to_replace, write_to_local_folder)
    read_script = sbt.factory.DEFAULT_ALGO_SCRIPT.replace(to_replace, read_from_local_folder)

    spec = factory.create_algo(py_script=write_script)
    write_algo = client.add_algo(spec)

    spec = factory.create_algo(py_script=read_script)
    read_algo = client.add_algo(spec)

    spec = factory.create_traintuple(
        algo=write_algo,
        dataset=dataset,
        data_samples=dataset.train_data_sample_keys,
        rank=0,
    )
    traintuple = client.add_traintuple(spec).future().wait()

    spec = factory.create_traintuple(
        algo=read_algo,
        dataset=dataset,
        data_samples=dataset.train_data_sample_keys,
        rank=1,
        traintuples=[traintuple],
        compute_plan_id=traintuple.compute_plan_id
    )
    client.add_traintuple(spec).future().wait()
```
