### PR TITLE
Fix the fact that the requests module does not use the system CA bundle

### DIFF
--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-backend
 home: https://substra.org/
-version: 1.0.0-alpha.24
+version: 1.0.0-alpha.25
 description: Main package for Substra
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/substra-backend/templates/deployment-server.yaml
+++ b/charts/substra-backend/templates/deployment-server.yaml
@@ -67,6 +67,10 @@ spec:
             value: "1"
           - name: GZIP_MODELS
             value: {{ .Values.backend.gzipModels | quote }}
+            {{- if .Values.privateCa.enabled }}
+            - name: REQUESTS_CA_BUNDLE
+              value: /etc/ssl/certs/ca-certificates.crt
+            {{- end }}
         {{- with .Values.extraEnv }}
 {{ toYaml . | indent 10 }}
         {{- end }}

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -62,6 +62,10 @@ spec:
               value: "1"
             - name: "CELERYWORKER_IMAGE"
               value: "{{ .Values.celeryworker.image.repository }}:{{ .Values.celeryworker.image.tag }}"
+            {{- if .Values.privateCa.enabled }}
+            - name: REQUESTS_CA_BUNDLE
+              value: /etc/ssl/certs/ca-certificates.crt
+            {{- end }}
           {{- with .Values.extraEnv }}
 {{ toYaml . | indent 12 }}
           {{- end }}


### PR DESCRIPTION
Without this env variable the requests python module will not use the private CA as by default this module use the root CA bundle provided by the module [certifi](https://pypi.org/project/certifi/) and not the OS trusted root CA bundle.