### PR TITLE
Don't swallow celery logs

### DIFF
--- a/backend/backend/settings/dev.py
+++ b/backend/backend/settings/dev.py
@@ -86,7 +86,7 @@ LOGGING = {
         'celery': {
             'level': 'INFO',
             'handlers': ['console'],
-            'propagate': True,
+            'propagate': True,  # without this, celery logs aren't displayed at all
         },
     }
 }

--- a/backend/backend/settings/dev.py
+++ b/backend/backend/settings/dev.py
@@ -86,7 +86,7 @@ LOGGING = {
         'celery': {
             'level': 'INFO',
             'handlers': ['console'],
-            'propagate': False,
+            'propagate': True,
         },
     }
 }

--- a/backend/backend/settings/prod.py
+++ b/backend/backend/settings/prod.py
@@ -109,7 +109,7 @@ LOGGING = {
         'celery': {
             'level': 'INFO',
             'handlers': ['console'],
-            'propagate': False,
+            'propagate': True,
         },
     },
 }

--- a/backend/backend/settings/prod.py
+++ b/backend/backend/settings/prod.py
@@ -109,7 +109,7 @@ LOGGING = {
         'celery': {
             'level': 'INFO',
             'handlers': ['console'],
-            'propagate': True,
+            'propagate': True,  # without this, celery logs aren't displayed at all
         },
     },
 }


### PR DESCRIPTION
Fixes https://github.com/SubstraFoundation/substra-backend/issues/214

This PR adds the following logs:

- Task reception/start

```
Received task: substrapp.tasks.tasks.prepare_tuple[974631f5db396abcfb51776042e6ef7be32212adf8983114215cbdb1ed9c611d  
Received task: substrapp.tasks.tasks.compute_task[ccda03f7-3234-4f2d-af4f-c66f00c882fa  
```

- Task retry + exception causing the retry

```
Task substrapp.tasks.tasks.compute_task[ccda03f7-3234-4f2d-af4f-c66f00c882fa retry: Retry in 0s: ContainerError('Command \'train\' in image \'substra/algo_a709ebd2\' returned non-zero exit status 1: b\'substratools.utils - [Traceback]
```

- Task success

```
Task substrapp.tasks.tasks.prepare_tuple[974631f5db396abcfb51776042e6ef7be32212adf8983114215cbdb1ed9c611d succeeded in 0.11992721299975528s: None
Task substrapp.tasks.tasks.compute_task[c3bc972f-809f-415d-ab0b-8edf275acc52 succeeded in 1.6799143690004712s: {'worker': 'MyOrg1.worker', 'queue': 'MyOrg1.worker', 'computePlanID': None, 'result': {'end_model_file_hash': '894124a01bb7fa40be51a4d5d351cc0849d1f1399fe5824a35d105b8fada98c4', 'end_model_file': 'http://substra-backend.node-1.com/model/894124a01bb7fa40be51a4d5d351cc0849d1f1399fe5824a35d105b8fada98c4/file/'}}
```

### Caveats

The "task success" log prints out the full task result, which could contain sensitive information  (is this what `disable worker printing tuple workerspace` refers to in https://github.com/SubstraFoundation/substra-backend/pull/124 ?)

An alternative solution would be to write custom log messages instead of relying on celery logs (see attached issue)
