### PR TITLE
Improve Dockerfile caching

### DIFF
--- a/docker/substra-backend/Dockerfile
+++ b/docker/substra-backend/Dockerfile
@@ -11,11 +11,11 @@ COPY ./backend/requirements.txt /usr/src/app/.
 
 RUN pip3 install -r requirements.txt
 
-COPY ./backend/manage.py /usr/src/app/manage.py
 COPY ./backend/libs /usr/src/app/libs
 COPY ./backend/substrapp /usr/src/app/substrapp
-COPY ./backend/events /usr/src/app/events
 COPY ./backend/backend /usr/src/app/backend
 COPY ./backend/node /usr/src/app/node
-COPY ./backend/node-register /usr/src/app/node-register
 COPY ./backend/users /usr/src/app/users
+COPY ./backend/events /usr/src/app/events
+COPY ./backend/node-register /usr/src/app/node-register
+COPY ./backend/manage.py /usr/src/app/manage.py

--- a/docker/substra-backend/Dockerfile
+++ b/docker/substra-backend/Dockerfile
@@ -1,8 +1,9 @@
 FROM python:3.6
 
 RUN apt-get update
-RUN apt-get install -y python3 python3-pip python3-dev build-essential libssl-dev libffi-dev libxml2-dev libxslt1-dev zlib1g-dev g++ gcc gfortran musl-dev postgresql-contrib
+RUN apt-get install -y python3 python3-pip python3-dev build-essential libssl-dev libffi-dev libxml2-dev libxslt1-dev zlib1g-dev
 RUN apt-get install -y git curl netcat
+RUN apt-get install -y g++ gcc gfortran musl-dev postgresql-contrib
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/docker/substra-backend/Dockerfile
+++ b/docker/substra-backend/Dockerfile
@@ -3,7 +3,6 @@ FROM python:3.6
 RUN apt-get update
 RUN apt-get install -y python3 python3-pip python3-dev build-essential libssl-dev libffi-dev libxml2-dev libxslt1-dev zlib1g-dev
 RUN apt-get install -y git curl netcat
-RUN apt-get install -y g++ gcc gfortran musl-dev postgresql-contrib
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
Speed up builds by finding the largest common denominator between Dockerfiles.

Regarding the order of the files copied: make the order the same as with other Dockerfiles (to improve caching, though it is a very minor improvement)
