### PR TITLE
Add pod affinity to backend worker

### DIFF
--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-backend
 home: https://substra.org/
-version: 1.0.0-alpha.27
+version: 1.0.0-alpha.28
 description: Main package for Substra
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -20,6 +20,16 @@ spec:
         app.kubernetes.io/name: {{ template "substra.name" . }}-worker
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app.kubernetes.io/name
+                operator: In
+                values:
+                - {{ template "substra.name" . }}-server
+            topologyKey: kubernetes.io/hostname
       {{- with $.Values.celeryworker.image.pullSecrets }}
       imagePullSecrets:
       {{- range . }}

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -20,6 +20,8 @@ spec:
         app.kubernetes.io/name: {{ template "substra.name" . }}-worker
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      # Run the worker on the same pod as the server.
+      # That's necessary because the worker and the server use the same PV.
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
This way we can force the worker to be scheduled on the same node as the backend in a multi node setup.
This is required in a multi node environment because the backend and worker needs to share files using the host filesystem.

This PR has not been tested against a local environment.