### PR TITLE
Local setup (skaffold): don't assume host DNS propagation

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -40,7 +40,7 @@ deploy:
             fabricConfigmap: network-org-1-hlf-k8s-fabric
           backend:
             settings: dev
-            defaultDomain: http://substra-backend.node-1.com
+            defaultDomain: http://backend-org-1-substra-backend-server.org-1:8000
             ingress:
               enabled: true
               hosts:
@@ -82,7 +82,7 @@ deploy:
             fabricConfigmap: network-org-2-hlf-k8s-fabric
           backend:
             settings: dev
-            defaultDomain: http://substra-backend.node-2.com
+            defaultDomain: http://backend-org-2-substra-backend-server.org-2:8000
             ingress:
               enabled: true
               hosts:


### PR DESCRIPTION
Fixes https://github.com/SubstraFoundation/substra-backend/issues/223

Note: the prefix `http://` is necessary because of the url validation on the chaincode side ([example](https://github.com/SubstraFoundation/substra-chaincode/blob/4744da151530e8ef4b3175690eefd37db5d9b315/chaincode/input.go#L36))
﻿
