### PR TITLE
Allow receiving data as json in multipart requests

### DIFF
--- a/backend/backend/settings/deps/restframework.py
+++ b/backend/backend/settings/deps/restframework.py
@@ -25,6 +25,11 @@ REST_FRAMEWORK = {
         'anon': '120/minute',
         'login': '120/minute',
     },
+    'DEFAULT_PARSER_CLASSES': [
+        'rest_framework.parsers.JSONParser',
+        'rest_framework.parsers.FormParser',
+        'libs.json_multipart_parser.JsonMultiPartParser'
+    ],
 }
 
 SIMPLE_JWT = {

--- a/backend/libs/json_multipart_parser.py
+++ b/backend/libs/json_multipart_parser.py
@@ -1,0 +1,21 @@
+from rest_framework.parsers import MultiPartParser, DataAndFiles
+from rest_framework.settings import api_settings
+from rest_framework.utils import json
+
+
+class JsonMultiPartParser(MultiPartParser):
+    media_type = 'multipart/form-data'
+    strict = api_settings.STRICT_JSON
+
+    def _load_json(self, data):
+        if 'json' not in data:
+            return {}
+
+        parse_constant = json.strict_constant if self.strict else None
+        return json.loads(data['json'], parse_constant=parse_constant)
+
+    def parse(self, stream, media_type, parser_context):
+        data_and_files = super().parse(stream, media_type, parser_context)
+        files = data_and_files.files.dict()
+        data = self._load_json(data_and_files.data)
+        return DataAndFiles(data, files)

--- a/backend/substrapp/serializers/ledger/aggregatetuple/serializer.py
+++ b/backend/substrapp/serializers/ledger/aggregatetuple/serializer.py
@@ -7,11 +7,12 @@ class LedgerAggregateTupleSerializer(serializers.Serializer):
     algo_key = serializers.CharField(min_length=64, max_length=64)
     rank = serializers.IntegerField(allow_null=True, required=False, default=0)
     worker = serializers.CharField()
-    compute_plan_id = serializers.CharField(min_length=64, max_length=64, allow_blank=True, required=False)
+    compute_plan_id = serializers.CharField(min_length=64, max_length=64, allow_blank=True, required=False,
+                                            allow_null=True)
     in_models_keys = serializers.ListField(child=serializers.CharField(min_length=64, max_length=64),
                                            min_length=0,
-                                           required=False)
-    tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False)
+                                           required=False, allow_null=True)
+    tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False, allow_null=True)
 
     def get_args(self, validated_data):
         algo_key = validated_data.get('algo_key')

--- a/backend/substrapp/serializers/ledger/compositetraintuple/serializer.py
+++ b/backend/substrapp/serializers/ledger/compositetraintuple/serializer.py
@@ -8,13 +8,16 @@ class LedgerCompositeTraintupleSerializer(serializers.Serializer):
     algo_key = serializers.CharField(min_length=64, max_length=64)
     data_manager_key = serializers.CharField(min_length=64, max_length=64)
     rank = serializers.IntegerField(allow_null=True, required=False, default=0)
-    compute_plan_id = serializers.CharField(min_length=64, max_length=64, allow_blank=True, required=False)
-    in_head_model_key = serializers.CharField(min_length=64, max_length=64, allow_blank=True, required=False)
-    in_trunk_model_key = serializers.CharField(min_length=64, max_length=64, allow_blank=True, required=False)
+    compute_plan_id = serializers.CharField(min_length=64, max_length=64, allow_blank=True, required=False,
+                                            allow_null=True)
+    in_head_model_key = serializers.CharField(min_length=64, max_length=64, allow_blank=True, required=False,
+                                              allow_null=True)
+    in_trunk_model_key = serializers.CharField(min_length=64, max_length=64, allow_blank=True, required=False,
+                                               allow_null=True)
     out_trunk_model_permissions = PermissionsSerializer()
     train_data_sample_keys = serializers.ListField(child=serializers.CharField(min_length=64, max_length=64),
                                                    min_length=1)
-    tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False)
+    tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False, allow_null=True)
 
     def get_args(self, validated_data):
         algo_key = validated_data.get('algo_key')

--- a/backend/substrapp/serializers/ledger/computeplan/serializer.py
+++ b/backend/substrapp/serializers/ledger/computeplan/serializer.py
@@ -15,7 +15,7 @@ class ComputePlanTraintupleSerializer(serializers.Serializer):
         child=serializers.CharField(min_length=1, max_length=64),
         min_length=0,
         required=False)
-    tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False)
+    tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False, allow_null=True)
 
 
 class ComputePlanTesttupleSerializer(serializers.Serializer):
@@ -26,7 +26,7 @@ class ComputePlanTesttupleSerializer(serializers.Serializer):
         child=serializers.CharField(min_length=64, max_length=64),
         min_length=0,
         required=False)
-    tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False)
+    tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False, allow_null=True)
 
 
 class ComputePlanCompositeTrainTupleSerializer(serializers.Serializer):
@@ -41,7 +41,7 @@ class ComputePlanCompositeTrainTupleSerializer(serializers.Serializer):
     in_trunk_model_id = serializers.CharField(min_length=1, max_length=64, allow_blank=True, required=False,
                                               allow_null=True)
     out_trunk_model_permissions = PermissionsSerializer()
-    tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False)
+    tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False, allow_null=True)
 
 
 class ComputePlanAggregatetupleSerializer(serializers.Serializer):
@@ -52,7 +52,7 @@ class ComputePlanAggregatetupleSerializer(serializers.Serializer):
         child=serializers.CharField(min_length=1, max_length=64),
         min_length=0,
         required=False)
-    tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False)
+    tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False, allow_null=True)
 
 
 class LedgerComputePlanSerializer(serializers.Serializer):
@@ -60,7 +60,7 @@ class LedgerComputePlanSerializer(serializers.Serializer):
     testtuples = ComputePlanTesttupleSerializer(many=True, required=False)
     composite_traintuples = ComputePlanCompositeTrainTupleSerializer(many=True, required=False)
     aggregatetuples = ComputePlanAggregatetupleSerializer(many=True, required=False)
-    tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False)
+    tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False, allow_null=True)
     clean_models = serializers.BooleanField(required=False)
 
     def get_args(self, data):

--- a/backend/substrapp/serializers/ledger/datamanager/serializer.py
+++ b/backend/substrapp/serializers/ledger/datamanager/serializer.py
@@ -11,7 +11,7 @@ from substrapp.serializers.ledger.utils import PermissionsSerializer
 class LedgerDataManagerSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=100)
     type = serializers.CharField(max_length=30)
-    objective_key = serializers.CharField(max_length=256, allow_blank=True, required=False)
+    objective_key = serializers.CharField(max_length=256, allow_blank=True, required=False, allow_null=True)
     permissions = PermissionsSerializer()
 
     def create(self, validated_data):

--- a/backend/substrapp/serializers/ledger/objective/serializer.py
+++ b/backend/substrapp/serializers/ledger/objective/serializer.py
@@ -13,7 +13,7 @@ class LedgerObjectiveSerializer(serializers.Serializer):
                                                   min_length=0,
                                                   required=False)
     name = serializers.CharField(min_length=1, max_length=100)
-    test_data_manager_key = serializers.CharField(max_length=256, allow_blank=True, required=False)
+    test_data_manager_key = serializers.CharField(max_length=256, allow_blank=True, required=False, allow_null=True)
     permissions = PermissionsSerializer()
     metrics_name = serializers.CharField(min_length=1, max_length=100)
 

--- a/backend/substrapp/serializers/ledger/testtuple/serializer.py
+++ b/backend/substrapp/serializers/ledger/testtuple/serializer.py
@@ -6,11 +6,12 @@ from substrapp import ledger
 class LedgerTestTupleSerializer(serializers.Serializer):
     traintuple_key = serializers.CharField(min_length=64, max_length=64)
     objective_key = serializers.CharField(min_length=64, max_length=64)
-    data_manager_key = serializers.CharField(min_length=64, max_length=64, allow_blank=True, required=False)
+    data_manager_key = serializers.CharField(min_length=64, max_length=64, allow_blank=True, required=False,
+                                             allow_null=True)
     test_data_sample_keys = serializers.ListField(child=serializers.CharField(min_length=64, max_length=64),
                                                   min_length=0,
-                                                  required=False)
-    tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False)
+                                                  required=False, allow_null=True)
+    tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False, allow_null=True)
 
     def get_args(self, validated_data):
         traintuple_key = validated_data.get('traintuple_key')

--- a/backend/substrapp/serializers/ledger/traintuple/serializer.py
+++ b/backend/substrapp/serializers/ledger/traintuple/serializer.py
@@ -7,13 +7,14 @@ class LedgerTrainTupleSerializer(serializers.Serializer):
     algo_key = serializers.CharField(min_length=64, max_length=64)
     data_manager_key = serializers.CharField(min_length=64, max_length=64)
     rank = serializers.IntegerField(allow_null=True, required=False, default=0)
-    compute_plan_id = serializers.CharField(min_length=64, max_length=64, allow_blank=True, required=False)
+    compute_plan_id = serializers.CharField(min_length=64, max_length=64, allow_blank=True, required=False,
+                                            allow_null=True)
     in_models_keys = serializers.ListField(child=serializers.CharField(min_length=64, max_length=64),
                                            min_length=0,
-                                           required=False)
+                                           required=False, allow_null=True)
     train_data_sample_keys = serializers.ListField(child=serializers.CharField(min_length=64, max_length=64),
                                                    min_length=1)
-    tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False)
+    tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False, allow_null=True)
 
     def get_args(self, validated_data):
         algo_key = validated_data.get('algo_key')

--- a/backend/substrapp/tests/query/tests_query_algo.py
+++ b/backend/substrapp/tests/query/tests_query_algo.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import tempfile
+import json
 
 import mock
 
@@ -56,10 +57,14 @@ class AlgoQueryTests(APITestCase):
         data = {
             'file': self.algo,
             'description': self.data_description,  # fake it
-            'name': 'super top algo',
-            'objective_key': get_hash(self.objective_description),
-            'permissions_public': True,
-            'permissions_authorized_ids': [],
+            'json': json.dumps({
+                'name': 'super top algo',
+                'objective_key': get_hash(self.objective_description),
+                'permissions': {
+                    'public': True,
+                    'authorized_ids': [],
+                },
+            }),
         }
 
         return expected_hash, data
@@ -70,10 +75,14 @@ class AlgoQueryTests(APITestCase):
         data = {
             'file': self.algo_zip,
             'description': self.data_description,  # fake it
-            'name': 'super top algo',
-            'objective_key': get_hash(self.objective_description),
-            'permissions_public': True,
-            'permissions_authorized_ids': [],
+            'json': json.dumps({
+                'name': 'super top algo',
+                'objective_key': get_hash(self.objective_description),
+                'permissions': {
+                    'public': True,
+                    'authorized_ids': [],
+                },
+            })
         }
 
         return expected_hash, data
@@ -139,10 +148,14 @@ class AlgoQueryTests(APITestCase):
         data = {
             'file': self.algo,
             'description': self.data_description,
-            'name': 'super top algo',
-            'objective_key': 'non existing objectivexxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
-            'permissions_public': True,
-            'permissions_authorized_ids': [],
+            'json': json.dumps({
+                'name': 'super top algo',
+                'objective_key': 'non existing objectivexxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+                'permissions': {
+                    'public': True,
+                    'authorized_ids': [],
+                },
+            }),
         }
         extra = {
             'HTTP_ACCEPT': 'application/json;version=0.0',
@@ -163,17 +176,21 @@ class AlgoQueryTests(APITestCase):
             data = {
                 'name': 'super top algo',
                 'objective_key': get_hash(self.objective_description),
-                'permissions_public': True,
-                'permissions_authorized_ids': [],
+                'permissions': {
+                    'public': True,
+                    'authorized_ids': [],
+                },
             }
-            response = self.client.post(url, data, format='multipart', **extra)
+            response = self.client.post(url, data, format='json', **extra)
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
             # missing ledger field
             data = {
                 'file': self.algo,
                 'description': self.data_description,
-                'objective_key': get_hash(self.objective_description),
+                'json': json.dumps({
+                    'objective_key': get_hash(self.objective_description),
+                })
             }
             response = self.client.post(url, data, format='multipart', **extra)
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/backend/substrapp/tests/query/tests_query_compositetraintuple.py
+++ b/backend/substrapp/tests/query/tests_query_compositetraintuple.py
@@ -57,8 +57,10 @@ class CompositeTraintupleQueryTests(APITestCase):
             'compute_plan_id': self.fake_key,
             'in_head_model_key': self.fake_key,
             'in_trunk_model_key': self.fake_key,
-            'out_trunk_model_permissions_public': False,
-            'out_trunk_model_permissions_authorized_ids': ["Node-1", "Node-2"],
+            'out_trunk_model_permissions': {
+                'public': False,
+                'authorized_ids': ["Node-1", "Node-2"],
+            },
         }
 
         extra = {
@@ -72,7 +74,7 @@ class CompositeTraintupleQueryTests(APITestCase):
             mquery_ledger.return_value = {'key': raw_pkhash}
             minvoke_ledger.return_value = {'pkhash': raw_pkhash}
 
-            response = self.client.post(url, data, format='multipart', **extra)
+            response = self.client.post(url, data, format='json', **extra)
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @override_settings(LEDGER_SYNC_ENABLED=False)
@@ -99,8 +101,10 @@ class CompositeTraintupleQueryTests(APITestCase):
             'compute_plan_id': self.fake_key,
             'in_head_model_key': self.fake_key,
             'in_trunk_model_key': self.fake_key,
-            'out_trunk_model_permissions_public': False,
-            'out_trunk_model_permissions_authorized_ids': ["Node-1", "Node-2"],
+            'out_trunk_model_permissions': {
+                'public': False,
+                'authorized_ids': ["Node-1", "Node-2"],
+            },
         }
 
         extra = {
@@ -114,7 +118,7 @@ class CompositeTraintupleQueryTests(APITestCase):
             mquery_ledger.return_value = {'key': raw_pkhash}
             minvoke_ledger.return_value = None
 
-            response = self.client.post(url, data, format='multipart', **extra)
+            response = self.client.post(url, data, format='json', **extra)
 
             self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
 

--- a/backend/substrapp/tests/query/tests_query_datamanager.py
+++ b/backend/substrapp/tests/query/tests_query_datamanager.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import tempfile
+import json
 
 import mock
 
@@ -38,11 +39,15 @@ class DataManagerQueryTests(APITestCase):
     def get_default_datamanager_data(self):
         expected_hash = get_hash(self.data_data_opener)
         data = {
-            'name': 'slide opener',
-            'type': 'images',
-            'permissions_public': True,
-            'permissions_authorized_ids': [],
-            'objective_key': '',
+            'json': json.dumps({
+                'name': 'slide opener',
+                'type': 'images',
+                'permissions': {
+                    'public': True,
+                    'authorized_ids': [],
+                },
+                'objective_key': '',
+            }),
             'description': self.data_description,
             'data_opener': self.data_data_opener
         }

--- a/backend/substrapp/tests/query/tests_query_datasample.py
+++ b/backend/substrapp/tests/query/tests_query_datasample.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 import zipfile
 from unittest.mock import MagicMock
+import json
 
 import mock
 from django.core.files import File
@@ -66,8 +67,10 @@ class DataSampleQueryTests(APITestCase):
         self.data_file.file.seek(0)
         data = {
             'file': self.data_file,
-            'data_manager_keys': [get_hash(self.data_data_opener)],
-            'test_only': True,
+            'json': json.dumps({
+                'data_manager_keys': [get_hash(self.data_data_opener)],
+                'test_only': True,
+            }),
         }
 
         return expected_hash, data
@@ -111,8 +114,10 @@ class DataSampleQueryTests(APITestCase):
         data = {
             file_mock.name: file_mock,
             file_mock2.name: file_mock2,
-            'data_manager_keys': [get_hash(self.data_data_opener), get_hash(self.data_data_opener2)],
-            'test_only': True,
+            'json': json.dumps({
+                'data_manager_keys': [get_hash(self.data_data_opener), get_hash(self.data_data_opener2)],
+                'test_only': True,
+            }),
         }
         extra = {
             'HTTP_ACCEPT': 'application/json;version=0.0',
@@ -164,7 +169,7 @@ class DataSampleQueryTests(APITestCase):
             'HTTP_ACCEPT': 'application/json;version=0.0',
         }
 
-        response = self.client.post(url, data, format='multipart', **extra)
+        response = self.client.post(url, data, format='json', **extra)
         r = response.json()
         self.assertEqual(
             r['message'],
@@ -204,8 +209,10 @@ class DataSampleQueryTests(APITestCase):
 
         data = {
             'file': file_mock,
-            'data_manager_keys': [get_hash(self.data_data_opener)],
-            'test_only': True,
+            'json': json.dumps({
+                'data_manager_keys': [get_hash(self.data_data_opener)],
+                'test_only': True,
+            })
         }
         extra = {
             'HTTP_ACCEPT': 'application/json;version=0.0',
@@ -230,8 +237,10 @@ class DataSampleQueryTests(APITestCase):
 
         data = {
             'file': file_mock,
-            'data_manager_keys': [get_hash(self.data_data_opener)],
-            'test_only': True,
+            'json': json.dumps({
+                'data_manager_keys': [get_hash(self.data_data_opener)],
+                'test_only': True,
+            })
         }
         extra = {
             'HTTP_ACCEPT': 'application/json;version=0.0',
@@ -254,8 +263,10 @@ class DataSampleQueryTests(APITestCase):
 
         data = {
             'file': file_mock,
-            'data_manager_keys': [get_hash(self.data_data_opener)],
-            'test_only': True,
+            'json': json.dumps({
+                'data_manager_keys': [get_hash(self.data_data_opener)],
+                'test_only': True,
+            })
         }
         extra = {
             'HTTP_ACCEPT': 'application/json;version=0.0',
@@ -288,8 +299,10 @@ class DataSampleQueryTests(APITestCase):
         data = {
             file_mock.name: file_mock,
             file_mock2.name: file_mock2,
-            'data_manager_keys': [get_hash(self.data_data_opener)],
-            'test_only': True,
+            'json': json.dumps({
+                'data_manager_keys': [get_hash(self.data_data_opener)],
+                'test_only': True,
+            })
         }
         extra = {
             'HTTP_ACCEPT': 'application/json;version=0.0',
@@ -324,8 +337,10 @@ class DataSampleQueryTests(APITestCase):
         data = {
             file_mock.name: file_mock,
             file_mock2.name: file_mock2,
-            'data_manager_keys': [get_hash(self.data_data_opener)],
-            'test_only': True,
+            'json': json.dumps({
+                'data_manager_keys': [get_hash(self.data_data_opener)],
+                'test_only': True,
+            }),
         }
         extra = {
             'HTTP_ACCEPT': 'application/json;version=0.0',
@@ -360,8 +375,10 @@ class DataSampleQueryTests(APITestCase):
 
         data = {
             'file': file_mock,
-            'data_manager_keys': [get_hash(self.data_data_opener)],
-            'test_only': True,
+            'json': json.dumps({
+                'data_manager_keys': [get_hash(self.data_data_opener)],
+                'test_only': True,
+            })
         }
         extra = {
             'HTTP_ACCEPT': 'application/json;version=0.0',
@@ -387,8 +404,10 @@ class DataSampleQueryTests(APITestCase):
 
         data = {
             'file': file_mock,
-            'data_manager_keys': [get_hash(self.data_data_opener)],
-            'test_only': True,
+            'json': json.dumps({
+                'data_manager_keys': [get_hash(self.data_data_opener)],
+                'test_only': True,
+            }),
         }
         extra = {
             'HTTP_ACCEPT': 'application/json;version=0.0',
@@ -419,8 +438,10 @@ class DataSampleQueryTests(APITestCase):
 
         data = {
             'file': file_mock,
-            'data_manager_keys': [get_hash(self.data_data_opener)],
-            'test_only': True,
+            'json': json.dumps({
+                'data_manager_keys': [get_hash(self.data_data_opener)],
+                'test_only': True,
+            })
         }
         extra = {
             'HTTP_ACCEPT': 'application/json;version=0.0',
@@ -469,7 +490,7 @@ class DataSampleQueryTests(APITestCase):
             minvoke_ledger.return_value = {'keys': [
                 d.pkhash]}
 
-            response = self.client.post(url, data, format='multipart', **extra)
+            response = self.client.post(url, data, format='json', **extra)
             r = response.json()
             self.assertEqual(r['keys'], [d.pkhash])
             self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/backend/substrapp/tests/query/tests_query_objective.py
+++ b/backend/substrapp/tests/query/tests_query_objective.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import tempfile
+import json
 
 import mock
 
@@ -56,14 +57,18 @@ class ObjectiveQueryTests(APITestCase):
 
         expected_hash = get_hash(self.objective_description)
         data = {
-            'name': 'tough objective',
-            'test_data_manager_key': get_hash(self.data_data_opener),
-            'test_data_sample_keys': self.test_data_sample_keys,
             'description': self.objective_description,
             'metrics': self.objective_metrics,
-            'permissions_public': True,
-            'permissions_authorized_ids': [],
-            'metrics_name': 'accuracy'
+            'json': json.dumps({
+                'name': 'tough objective',
+                'test_data_manager_key': get_hash(self.data_data_opener),
+                'test_data_sample_keys': self.test_data_sample_keys,
+                'permissions': {
+                    'public': True,
+                    'authorized_ids': [],
+                },
+                'metrics_name': 'accuracy'
+            }),
         }
         return expected_hash, data
 

--- a/backend/substrapp/tests/query/tests_query_tuples.py
+++ b/backend/substrapp/tests/query/tests_query_tuples.py
@@ -64,7 +64,7 @@ class TraintupleQueryTests(APITestCase):
             mquery_ledger.return_value = {'key': raw_pkhash}
             minvoke_ledger.return_value = {'pkhash': raw_pkhash}
 
-            response = self.client.post(url, data, format='multipart', **extra)
+            response = self.client.post(url, data, format='json', **extra)
 
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -102,7 +102,7 @@ class TraintupleQueryTests(APITestCase):
             mquery_ledger.return_value = {'key': raw_pkhash}
             minvoke_ledger.return_value = None
 
-            response = self.client.post(url, data, format='multipart', **extra)
+            response = self.client.post(url, data, format='json', **extra)
 
             self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
 
@@ -118,7 +118,7 @@ class TraintupleQueryTests(APITestCase):
             'HTTP_ACCEPT': 'application/json;version=0.0',
         }
 
-        response = self.client.post(url, data, format='multipart', **extra)
+        response = self.client.post(url, data, format='json', **extra)
         r = response.json()
         self.assertIn('This field may not be null.', r['algo_key'])
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -126,7 +126,7 @@ class TraintupleQueryTests(APITestCase):
         Objective.objects.create(description=self.objective_description,
                                  metrics=self.objective_metrics)
         data = {'objective': get_hash(self.objective_description)}
-        response = self.client.post(url, data, format='multipart', **extra)
+        response = self.client.post(url, data, format='json', **extra)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
@@ -172,7 +172,7 @@ class TesttupleQueryTests(APITestCase):
             mquery_ledger.return_value = {'key': raw_pkhash}
             minvoke_ledger.return_value = {'pkhash': raw_pkhash}
 
-            response = self.client.post(url, data, format='multipart', **extra)
+            response = self.client.post(url, data, format='json', **extra)
 
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -207,7 +207,7 @@ class TesttupleQueryTests(APITestCase):
             mquery_ledger.return_value = {'key': raw_pkhash}
             minvoke_ledger.return_value = None
 
-            response = self.client.post(url, data, format='multipart', **extra)
+            response = self.client.post(url, data, format='json', **extra)
 
             self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
 
@@ -222,7 +222,7 @@ class TesttupleQueryTests(APITestCase):
             'HTTP_ACCEPT': 'application/json;version=0.0',
         }
 
-        response = self.client.post(url, data, format='multipart', **extra)
+        response = self.client.post(url, data, format='json', **extra)
         r = response.json()
         self.assertIn('This field may not be null.', r['traintuple_key'])
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/backend/substrapp/tests/views/tests_views_algo.py
+++ b/backend/substrapp/tests/views/tests_views_algo.py
@@ -2,6 +2,7 @@ import copy
 import os
 import shutil
 import logging
+import json
 
 import mock
 import urllib.parse
@@ -198,13 +199,19 @@ class AlgoViewTests(APITestCase):
 
         pkhash = get_hash(algo_path)
 
-        data = {'name': 'Logistic regression',
-                'file': open(algo_path, 'rb'),
-                'description': open(description_path, 'rb'),
+        data = {
+            'json': json.dumps({
+                'name': 'Logistic regression',
                 'objective_key': get_hash(os.path.join(
                     dir_path, '../../../../fixtures/chunantes/objectives/objective0/description.md')),
-                'permissions_public': True,
-                'permissions_authorized_ids': []}
+                'permissions': {
+                    'public': True,
+                    'authorized_ids': [],
+                }
+            }),
+            'file': open(algo_path, 'rb'),
+            'description': open(description_path, 'rb'),
+        }
 
         with mock.patch.object(LedgerAlgoSerializer, 'create') as mcreate:
 

--- a/backend/substrapp/tests/views/tests_views_compositealgo.py
+++ b/backend/substrapp/tests/views/tests_views_compositealgo.py
@@ -2,6 +2,7 @@ import copy
 import os
 import shutil
 import logging
+import json
 
 import mock
 
@@ -212,13 +213,19 @@ class CompositeAlgoViewTests(APITestCase):
 
         pkhash = get_hash(composite_algo_path)
 
-        data = {'name': 'Composite Algo',
-                'file': open(composite_algo_path, 'rb'),
-                'description': open(description_path, 'rb'),
+        data = {
+            'json': json.dumps({
+                'name': 'Composite Algo',
                 'objective_key': get_hash(os.path.join(
                     dir_path, '../../../../fixtures/chunantes/objectives/objective0/description.md')),
-                'permissions_public': True,
-                'permissions_authorized_ids': []}
+                'permissions': {
+                    'public': True,
+                    'authorized_ids': [],
+                },
+            }),
+            'file': open(composite_algo_path, 'rb'),
+            'description': open(description_path, 'rb'),
+        }
 
         with mock.patch.object(LedgerCompositeAlgoSerializer, 'create') as mcreate:
 

--- a/backend/substrapp/tests/views/tests_views_datasample.py
+++ b/backend/substrapp/tests/views/tests_views_datasample.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import logging
+import json
 
 import mock
 
@@ -70,8 +71,10 @@ class DataSampleViewTests(APITestCase):
             'files': [path_leaf(data_path1), path_leaf(data_path2)],
             path_leaf(data_path1): open(data_path1, 'rb'),
             path_leaf(data_path2): open(data_path2, 'rb'),
-            'data_manager_keys': data_manager_keys,
-            'test_only': False
+            'json': json.dumps({
+                'data_manager_keys': data_manager_keys,
+                'test_only': False
+            })
         }
 
         with mock.patch.object(DataManager.objects, 'filter') as mdatamanager, \
@@ -101,8 +104,10 @@ class DataSampleViewTests(APITestCase):
 
         data = {
             'file': open(data_path, 'rb'),
-            'data_manager_keys': data_manager_keys,
-            'test_only': False
+            'json': json.dumps({
+                'data_manager_keys': data_manager_keys,
+                'test_only': False
+            })
         }
 
         with mock.patch.object(DataManager.objects, 'filter') as mdatamanager, \
@@ -147,7 +152,7 @@ class DataSampleViewTests(APITestCase):
 
             mdatamanager.return_value = FakeFilterDataManager(1)
             mcreate.return_value = {'keys': [pkhash]}
-            response = self.client.post(url, data=data, format='multipart', **self.extra)
+            response = self.client.post(url, data=data, format='json', **self.extra)
 
         self.assertEqual(response.data[0]['pkhash'], pkhash)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -180,7 +185,7 @@ class DataSampleViewTests(APITestCase):
 
             mdatamanager.return_value = FakeFilterDataManager(1)
             mcreate.return_value = {'keys': [pkhash]}
-            response = self.client.post(url, data=data, format='multipart', **self.extra)
+            response = self.client.post(url, data=data, format='json', **self.extra)
 
         self.assertEqual(response.data[0]['pkhash'], pkhash)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/backend/substrapp/tests/views/tests_views_objective.py
+++ b/backend/substrapp/tests/views/tests_views_objective.py
@@ -3,6 +3,7 @@ import shutil
 import logging
 import zipfile
 import copy
+import json
 
 import mock
 
@@ -214,14 +215,18 @@ class ObjectiveViewTests(APITestCase):
             dir_path, '../../../../fixtures/owkin/datamanagers/datamanager0/opener.py'))
 
         data = {
-            'name': 'Simplified skin lesion classification',
+            'json': json.dumps({
+                'name': 'Simplified skin lesion classification',
+                'metrics_name': 'macro-average recall',
+                'permissions': {
+                    'public': True,
+                    'authorized_ids': [],
+                },
+                'test_data_sample_keys': self.test_data_sample_keys,
+                'test_data_manager_key': test_data_manager_key,
+            }),
             'description': open(description_path, 'rb'),
-            'metrics_name': 'macro-average recall',
             'metrics': open(metrics_path, 'rb'),
-            'permissions_public': True,
-            'permissions_authorized_ids': [],
-            'test_data_sample_keys': self.test_data_sample_keys,
-            'test_data_manager_key': test_data_manager_key
         }
 
         with mock.patch.object(LedgerObjectiveSerializer, 'create') as mcreate:

--- a/backend/substrapp/views/aggregatealgo.py
+++ b/backend/substrapp/views/aggregatealgo.py
@@ -43,13 +43,7 @@ class AggregateAlgoViewSet(mixins.CreateModelMixin,
 
         ledger_data = {
             'name': request.data.get('name'),
-            # XXX workaround because input is a QueryDict and not a JSON object. This
-            #     is due to the fact that we are sending file object and body in a
-            #     single HTTP request
-            'permissions': {
-                'public': request.data.get('permissions_public'),
-                'authorized_ids': request.data.getlist('permissions_authorized_ids', []),
-            },
+            'permissions': request.data.get('permissions'),
         }
 
         # init ledger serializer

--- a/backend/substrapp/views/aggregatetuple.py
+++ b/backend/substrapp/views/aggregatetuple.py
@@ -35,7 +35,7 @@ class AggregateTupleViewSet(mixins.CreateModelMixin,
             'algo_key': request.data.get('algo_key'),
             'rank': request.data.get('rank'),
             'compute_plan_id': request.data.get('compute_plan_id', ''),
-            'in_models_keys': request.data.getlist('in_models_keys'),
+            'in_models_keys': request.data.get('in_models_keys'),
             'worker': request.data.get('worker'),
             'tag': request.data.get('tag', '')
         }

--- a/backend/substrapp/views/algo.py
+++ b/backend/substrapp/views/algo.py
@@ -43,13 +43,7 @@ class AlgoViewSet(mixins.CreateModelMixin,
 
         ledger_data = {
             'name': request.data.get('name'),
-            # XXX workaround because input is a QueryDict and not a JSON object. This
-            #     is due to the fact that we are sending file object and body in a
-            #     single HTTP request
-            'permissions': {
-                'public': request.data.get('permissions_public'),
-                'authorized_ids': request.data.getlist('permissions_authorized_ids', []),
-            },
+            'permissions': request.data.get('permissions'),
         }
 
         # init ledger serializer

--- a/backend/substrapp/views/compositealgo.py
+++ b/backend/substrapp/views/compositealgo.py
@@ -43,13 +43,7 @@ class CompositeAlgoViewSet(mixins.CreateModelMixin,
 
         ledger_data = {
             'name': request.data.get('name'),
-            # XXX workaround because input is a QueryDict and not a JSON object. This
-            #     is due to the fact that we are sending file object and body in a
-            #     single HTTP request
-            'permissions': {
-                'public': request.data.get('permissions_public'),
-                'authorized_ids': request.data.getlist('permissions_authorized_ids', []),
-            },
+            'permissions': request.data.get('permissions'),
         }
 
         # init ledger serializer

--- a/backend/substrapp/views/compositetraintuple.py
+++ b/backend/substrapp/views/compositetraintuple.py
@@ -38,11 +38,8 @@ class CompositeTraintupleViewSet(mixins.CreateModelMixin,
             'compute_plan_id': request.data.get('compute_plan_id', ''),
             'in_head_model_key': request.data.get('in_head_model_key', ''),
             'in_trunk_model_key': request.data.get('in_trunk_model_key', ''),
-            'out_trunk_model_permissions': {
-                'public': False,
-                'authorized_ids': request.data.getlist('out_trunk_model_permissions_authorized_ids', []),
-            },
-            'train_data_sample_keys': request.data.getlist('train_data_sample_keys'),
+            'out_trunk_model_permissions': request.data.get('out_trunk_model_permissions'),
+            'train_data_sample_keys': request.data.get('train_data_sample_keys'),
             'tag': request.data.get('tag', '')
         }
 

--- a/backend/substrapp/views/datamanager.py
+++ b/backend/substrapp/views/datamanager.py
@@ -42,13 +42,7 @@ class DataManagerViewSet(mixins.CreateModelMixin,
         # create on ledger + db
         ledger_data = {
             'name': request.data.get('name'),
-            # XXX workaround because input is a QueryDict and not a JSON object. This
-            #     is due to the fact that we are sending file object and body in a
-            #     single HTTP request
-            'permissions': {
-                'public': request.data.get('permissions_public'),
-                'authorized_ids': request.data.getlist('permissions_authorized_ids', []),
-            },
+            'permissions': request.data.get('permissions'),
             'type': request.data.get('type'),
             'objective_key': request.data.get('objective_key', ''),
         }

--- a/backend/substrapp/views/datasample.py
+++ b/backend/substrapp/views/datasample.py
@@ -107,8 +107,8 @@ class DataSampleViewSet(mixins.CreateModelMixin,
                 }
 
         else:  # files must be available on local filesystem
-            path = request.POST.get('path')
-            paths = request.POST.getlist('paths')
+            path = request.data.get('path')
+            paths = request.data.get('paths') or []
 
             if path and paths:
                 raise Exception('Cannot use path and paths together.')
@@ -194,7 +194,7 @@ class DataSampleViewSet(mixins.CreateModelMixin,
 
     def create(self, request, *args, **kwargs):
         test_only = request.data.get('test_only', False)
-        data_manager_keys = request.data.getlist('data_manager_keys', [])
+        data_manager_keys = request.data.get('data_manager_keys') or []
 
         try:
             data, st = self._create(request, data_manager_keys, test_only)
@@ -219,17 +219,11 @@ class DataSampleViewSet(mixins.CreateModelMixin,
         return Response(data, status=status.HTTP_200_OK)
 
     def validate_bulk_update(self, data):
-        try:
-            data_manager_keys = data.getlist('data_manager_keys')
-        except KeyError:
-            data_manager_keys = []
+        data_manager_keys = data.get('data_manager_keys')
         if not data_manager_keys:
             raise Exception('Please pass a non empty data_manager_keys key param')
 
-        try:
-            data_sample_keys = data.getlist('data_sample_keys')
-        except KeyError:
-            data_sample_keys = []
+        data_sample_keys = data.get('data_sample_keys')
         if not data_sample_keys:
             raise Exception('Please pass a non empty data_sample_keys key param')
 

--- a/backend/substrapp/views/objective.py
+++ b/backend/substrapp/views/objective.py
@@ -58,16 +58,10 @@ class ObjectiveViewSet(mixins.CreateModelMixin,
 
         # init ledger serializer
         ledger_data = {
-            'test_data_sample_keys': request.data.getlist('test_data_sample_keys', []),
+            'test_data_sample_keys': request.data.get('test_data_sample_keys') or [],
             'test_data_manager_key': request.data.get('test_data_manager_key', ''),
             'name': request.data.get('name'),
-            # XXX workaround because input is a QueryDict and not a JSON object. This
-            #     is due to the fact that we are sending file object and body in a
-            #     single HTTP request
-            'permissions': {
-                'public': request.data.get('permissions_public'),
-                'authorized_ids': request.data.getlist('permissions_authorized_ids', []),
-            },
+            'permissions': request.data.get('permissions'),
             'metrics_name': request.data.get('metrics_name'),
         }
         ledger_data.update({'instance': instance})

--- a/backend/substrapp/views/testtuple.py
+++ b/backend/substrapp/views/testtuple.py
@@ -35,7 +35,7 @@ class TestTupleViewSet(mixins.CreateModelMixin,
             'objective_key': request.data.get('objective_key'),
             'traintuple_key': request.data.get('traintuple_key'),
             'data_manager_key': request.data.get('data_manager_key', ''),
-            'test_data_sample_keys': request.data.getlist('test_data_sample_keys'),
+            'test_data_sample_keys': request.data.get('test_data_sample_keys'),
             'tag': request.data.get('tag', '')
         }
 

--- a/backend/substrapp/views/traintuple.py
+++ b/backend/substrapp/views/traintuple.py
@@ -36,9 +36,9 @@ class TrainTupleViewSet(mixins.CreateModelMixin,
             'data_manager_key': request.data.get('data_manager_key'),
             'rank': request.data.get('rank'),
             'compute_plan_id': request.data.get('compute_plan_id', ''),
-            'in_models_keys': request.data.getlist('in_models_keys'),
+            'in_models_keys': request.data.get('in_models_keys'),
             # list of train data keys (which are stored in the train worker node)
-            'train_data_sample_keys': request.data.getlist('train_data_sample_keys'),
+            'train_data_sample_keys': request.data.get('train_data_sample_keys'),
             'tag': request.data.get('tag', '')
         }
 


### PR DESCRIPTION
Companion PR: https://github.com/SubstraFoundation/substra/pull/162

# Current situation

Until now, when sending files alongside data in a request, the data was encoded as form data. This prevented us from sending complex data structures, and for example forced us to send these permissions:
```json
{
  "public": True,
  "authorized_ids": []
}
```

as:
```
permissions_public = True,
permissions_authorized_ids = True
```

And then forced us to parse the upload to recreate the dict on the server side before passing it to the serializer.

# Proposed solution

In order to send files and data in one call, we can serialize all data in json format and pass it as the value of a "json" formdata. 

A new request parser is then written that inherits from the DRF's multipart parser that automatically handles the deserialization of the "json" formdata.

This change is almost transparent for the rest of the codebase, with 2 exceptions:
 * some views were expecting request.data to be a querydict and used request.data.getlist. Since request.data is now a dict, we have to use get() and provide a default list.
* serializers defined their optional values (such as tag) with `requested=False` (when the tag key is not present in the request) and with `allow_empty=True` (when tag is an empty string). They didn't need to have `allow_null=True` because null values were automagically stripped. Now they need to.

The biggest impact was for the tests as they needed to be updated so that they'd use this new json serialization.
