### PR TITLE
Kubernetes tasks

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,7 +12,7 @@ docker==4.1.0
 GPUtil==1.4.0
 ipython==7.11.1
 ipython-genutils==0.2.0
-kubernetes==10.0.1
+kubernetes==11.0.0
 mock==3.0.5
 psycopg2-binary==2.8.4
 raven==6.10.0

--- a/backend/substrapp/tasks/utils.py
+++ b/backend/substrapp/tasks/utils.py
@@ -345,7 +345,7 @@ def build_docker_image(dockerfile_path, image_name):
         ],
         volume_mounts=[
             {'name': 'dockerfile', 'mountPath': f"{os.getenv('MEDIA_ROOT')}subtuple", 'readOnly': True},
-            {'name': 'cache', 'mountPath': '/cache', 'readOnly': False}
+            {'name': 'cache', 'mountPath': '/cache', 'readOnly': True}
         ]
     )
 

--- a/charts/substra-backend/requirements.lock
+++ b/charts/substra-backend/requirements.lock
@@ -1,9 +1,12 @@
 dependencies:
 - name: rabbitmq
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.17.0
+  version: 6.17.5
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 7.0.2
-digest: sha256:1cef96f1de860834dd670b0b512ecc65597e6131a4dde6f8e393af871d46b97e
-generated: "2020-02-06T15:35:42.601552+01:00"
+- name: docker-registry
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 1.9.2
+digest: sha256:37bcdeea25f9e78e1b07be2389ab5fc39741a608bffc10971d5cd89b9d817f4e
+generated: "2020-04-29T14:26:40.469294+02:00"

--- a/charts/substra-backend/requirements.yaml
+++ b/charts/substra-backend/requirements.yaml
@@ -7,3 +7,7 @@ dependencies:
     repository: https://kubernetes-charts.storage.googleapis.com/
     version: ~7.0.0
     condition: postgresql.enabled
+  - name: docker-registry
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    version: 1.9.2
+    condition: docker-registry.enabled

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -82,6 +82,14 @@ spec:
             - name: REQUESTS_CA_BUNDLE
               value: /etc/ssl/certs/ca-certificates.crt
             {{- end }}
+            - name: DOCKERFILES_PVC
+              value: {{ include "substra.fullname" $ }}-subtuple
+            - name: REGISTRY
+              value: {{ .Release.Name }}-docker-registry
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: DOCKER_CACHE_PVC
+              value: {{ include "substra.fullname" $ }}-docker-cache
           {{- with .Values.extraEnv }}
 {{ toYaml . | indent 12 }}
           {{- end }}

--- a/charts/substra-backend/templates/job-kaniko-warmer.yaml
+++ b/charts/substra-backend/templates/job-kaniko-warmer.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "substra.fullname" . }}-kaniko-cache-warmer
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ template "substra.name" . }}-kaniko-cache-warmer
+    app.kubernetes.io/part-of: {{ template "substra.name" . }}
+spec:
+  template:
+    spec:
+      containers:
+      - name: kaniko-cache-warmer
+        image: gcr.io/kaniko-project/warmer:latest
+        args:
+        - "--cache-dir=/cache"
+        {{- range .Values.prePulledImages }}
+        - "--image={{ . }}"
+        {{- end }}
+        volumeMounts:
+        - name: kaniko-cache
+          mountPath: /cache
+          readOnly: False
+      restartPolicy: Never
+      volumes:
+      - name: kaniko-cache
+        persistentVolumeClaim:
+          claimName: {{ include "substra.fullname" $ }}-docker-cache
+  backoffLimit: 4

--- a/charts/substra-backend/templates/storage.yaml
+++ b/charts/substra-backend/templates/storage.yaml
@@ -86,3 +86,51 @@ spec:
   hostPath:
     path: {{ $.Values.persistence.hostPath }}/servermedias
     type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "substra.fullname" $ }}-docker-cache
+  labels:
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/name: {{ template "substra.name" $ }}-docker-cache
+    app.kubernetes.io/part-of: {{ template "substra.name" $ }}-docker-cache
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: {{ $.Release.Service }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+      helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+      app.kubernetes.io/name: {{ template "substra.name" $ }}-docker-cache
+      app.kubernetes.io/part-of: {{ template "substra.name" $ }}-docker-cache
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ template "substra.fullname" $ }}-docker-cache
+  labels:
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/name: {{ template "substra.name" $ }}-docker-cache
+    app.kubernetes.io/part-of: {{ template "substra.name" $ }}-docker-cache
+spec:
+  storageClassName: ""
+  persistentVolumeReclaimPolicy: Recycle
+  claimRef:
+    name: {{ template "substra.fullname" $ }}-docker-cache
+    namespace: {{ .Release.Namespace }}
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: {{ .Values.persistence.hostPath }}/cache
+    type: DirectoryOrCreate

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -172,6 +172,12 @@ rabbitmq:
   persistence:
     enabled: false
 
+docker-registry:
+  enabled: true
+  storage: filesystem
+  persistence:
+    enabled: false
+
 flower:
   enabled: true
   host: flower

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -178,6 +178,9 @@ docker-registry:
   persistence:
     enabled: false
 
+prePulledImages:
+- substrafoundation/substra-tools:0.5.0
+
 flower:
   enabled: true
   host: flower

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -114,6 +114,15 @@ deploy:
           celeryworker.image: substrafoundation/celeryworker
           flower.image: substrafoundation/flower
         overrides:
+          docker-registry:
+            ingress:
+              enabled: true
+              hosts:
+                - substra-registry.node-1.com
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/client-body-buffer-size: 100m
+                nginx.ingress.kubernetes.io/proxy-body-size: 100m
           secrets:
             fabricConfigmap: network-org-1-hlf-k8s-fabric
           backend:
@@ -162,6 +171,15 @@ deploy:
           celeryworker.image: substrafoundation/celeryworker
           flower.image: substrafoundation/flower
         overrides:
+          docker-registry:
+            ingress:
+              enabled: true
+              hosts:
+                - substra-registry.node-2.com
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/client-body-buffer-size: 100m
+                nginx.ingress.kubernetes.io/proxy-body-size: 100m
           secrets:
             fabricConfigmap: network-org-2-hlf-k8s-fabric
           backend:


### PR DESCRIPTION
The goal of this PR is to enable the usage of Kubernetes to run tasks instead of using the docker host.

In order to achieve this goal we will have to go through the following steps:
- [x] Build images using kaniko
- [x] Add cache warmer for kaniko
- [ ] Run images using kubernetes API
- [ ] Improve security of the docker registry

The way this is expected to work is first building the archive corresponding to the tuple if it is not already present in the registry and push the task Dockerfile to the private docker registry.

Then we run the tasks pulling from the internal registry.

For this I made available new endpoints in the skaffold.yaml file that needs to be added to the user `/ect/hosts` file. 
- substra-registry.node-1.com
- substra-registry.node-2.com

This is necessary for the host docker being able to pull from these images registry.
It is also necessary to add these endpoints to the host docker config as trusted insecure images registry.


