### PR TITLE
Update api token strategy

### DIFF
--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -18,12 +18,9 @@ class ExpiryObtainAuthToken(ObtainAuthToken):
         serializer.is_valid(raise_exception=True)
         user = serializer.validated_data['user']
 
-        token, created = Token.objects.get_or_create(user=user)
-
         # token should be new each time, remove the old one
-        if not created:
-            token.delete()
-            token = Token.objects.create(user=token.user)
+        Token.objects.filter(user=user).delete()
+        token = Token.objects.create(user=user)
 
         return Response({
             'token': token.key,

--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -4,7 +4,7 @@ from rest_framework.throttling import AnonRateThrottle
 from rest_framework.authtoken.models import Token
 from rest_framework.response import Response
 
-from libs.expiry_token_authentication import token_expire_handler, expires_at
+from libs.expiry_token_authentication import expires_at
 from libs.user_login_throttle import UserLoginThrottle
 
 
@@ -17,10 +17,13 @@ class ExpiryObtainAuthToken(ObtainAuthToken):
                                            context={'request': request})
         serializer.is_valid(raise_exception=True)
         user = serializer.validated_data['user']
+
         token, created = Token.objects.get_or_create(user=user)
 
-        # token_expire_handler will check, if the token is expired it will generate new one
-        is_expired, token = token_expire_handler(token)
+        # token should be new each time, remove the old one
+        if not created:
+            token.delete()
+            token = Token.objects.create(user=token.user)
 
         return Response({
             'token': token.key,

--- a/backend/substrapp/tests/views/test_views_authentication.py
+++ b/backend/substrapp/tests/views/test_views_authentication.py
@@ -113,7 +113,7 @@ class AuthenticationTests(APITestCase):
                                     {'username': 'foo', 'password': 'bar'}, **self.extra)
         self.assertEqual(response.status_code, 200)
         token = response.json()['token']
-        self.assertTrue(token_old)
+        self.assertTrue(token)
 
         # tokens should be different
         self.assertNotEqual(token_old, token)

--- a/backend/substrapp/tests/views/test_views_authentication.py
+++ b/backend/substrapp/tests/views/test_views_authentication.py
@@ -105,8 +105,41 @@ class AuthenticationTests(APITestCase):
         response = self.client.post('/api-token-auth/',
                                     {'username': 'foo', 'password': 'bar'}, **self.extra)
         self.assertEqual(response.status_code, 200)
+        token_old = response.json()['token']
+        self.assertTrue(token_old)
+
+        # token should be update after a second post
+        response = self.client.post('/api-token-auth/',
+                                    {'username': 'foo', 'password': 'bar'}, **self.extra)
+        self.assertEqual(response.status_code, 200)
         token = response.json()['token']
-        self.assertTrue(token)
+        self.assertTrue(token_old)
+
+        # tokens should be different
+        self.assertNotEqual(token_old, token)
+
+        # test tokens validity
+        invalid_auth_token_header = f"Token {token_old}"
+        self.client.credentials(HTTP_AUTHORIZATION=invalid_auth_token_header)
+
+        with mock.patch('substrapp.views.utils.get_owner', return_value='foo'), \
+                mock.patch('substrapp.views.utils.get_object_from_ledger') \
+                as mget_object_from_ledger:
+            mget_object_from_ledger.return_value = get_sample_algo_metadata()
+            response = self.client.get(self.algo_url, **self.extra)
+
+            self.assertEqual(status.HTTP_401_UNAUTHORIZED, response.status_code)
+
+        valid_auth_token_header = f"Token {token}"
+        self.client.credentials(HTTP_AUTHORIZATION=valid_auth_token_header)
+
+        with mock.patch('substrapp.views.utils.get_owner', return_value='foo'), \
+                mock.patch('substrapp.views.utils.get_object_from_ledger') \
+                as mget_object_from_ledger:
+            mget_object_from_ledger.return_value = get_sample_algo_metadata()
+            response = self.client.get(self.algo_url, **self.extra)
+
+            self.assertEqual(status.HTTP_200_OK, response.status_code)
 
         # usage with an existing token
         # the token should be ignored since the purpose of the view is to authenticate via user/password


### PR DESCRIPTION
- Create a new token for each login (remove the old one)
- Token validity is still 24h