### PR TITLE
Prod: increase UWSGI timeouts

### DIFF
--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-backend
 home: https://substra.org/
-version: 1.0.0-alpha.29
+version: 1.0.0-alpha.30
 description: Main package for Substra
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/substra-backend/templates/deployment-server.yaml
+++ b/charts/substra-backend/templates/deployment-server.yaml
@@ -34,7 +34,22 @@ spec:
         {{- end }}
         command: ["/bin/bash"]
         {{- if eq .Values.backend.settings "prod" }}
-        args: ["-c", "update-ca-certificates && uwsgi --http :{{ .Values.backend.service.port }} --module backend.wsgi --static-map /static=/usr/src/app/backend/statics --master --processes {{ .Values.backend.uwsgiProcesses }} --threads {{ .Values.backend.uwsgiThreads }} --need-app --env DJANGO_SETTINGS_MODULE=backend.settings.server.{{ .Values.backend.settings }} "]
+        args:
+          - -c
+          - |
+            update-ca-certificates && \
+              uwsgi \
+                --http :{{ .Values.backend.service.port }} \
+                --module backend.wsgi \
+                --static-map /static=/usr/src/app/backend/statics \
+                --master \
+                --processes {{ .Values.backend.uwsgiProcesses }} \
+                --threads {{ .Values.backend.uwsgiThreads }} \
+                --http-timeout 300 \
+                --socket-timeout 300 \
+                --harakiri 300 \
+                --need-app \
+                --env DJANGO_SETTINGS_MODULE=backend.settings.server.{{ .Values.backend.settings }}
         {{- else }}
         args: ["-c", "update-ca-certificates && watchmedo auto-restart --directory=./ --pattern=*.py --recursive -- uwsgi --http :{{ .Values.backend.service.port }} --module backend.wsgi --static-map /static=/usr/src/app/backend/statics --master --processes {{ .Values.backend.uwsgiProcesses }} --threads {{ .Values.backend.uwsgiThreads }} --need-app --env DJANGO_SETTINGS_MODULE=backend.settings.server.{{ .Values.backend.settings }}"]
         {{- end }}

--- a/charts/substra-backend/templates/deployment-server.yaml
+++ b/charts/substra-backend/templates/deployment-server.yaml
@@ -34,22 +34,7 @@ spec:
         {{- end }}
         command: ["/bin/bash"]
         {{- if eq .Values.backend.settings "prod" }}
-        args:
-          - -c
-          - |
-            update-ca-certificates && \
-              uwsgi \
-                --http :{{ .Values.backend.service.port }} \
-                --module backend.wsgi \
-                --static-map /static=/usr/src/app/backend/statics \
-                --master \
-                --processes {{ .Values.backend.uwsgiProcesses }} \
-                --threads {{ .Values.backend.uwsgiThreads }} \
-                --http-timeout 300 \
-                --socket-timeout 300 \
-                --harakiri 300 \
-                --need-app \
-                --env DJANGO_SETTINGS_MODULE=backend.settings.server.{{ .Values.backend.settings }}
+        args: ["-c", "update-ca-certificates && uwsgi --http :{{ .Values.backend.service.port }} --module backend.wsgi --static-map /static=/usr/src/app/backend/statics --master --processes {{ .Values.backend.uwsgiProcesses }} --threads {{ .Values.backend.uwsgiThreads }} --http-timeout 300 --socket-timeout 300 --harakiri 300 --need-app --env DJANGO_SETTINGS_MODULE=backend.settings.server.{{ .Values.backend.settings }} "]
         {{- else }}
         args: ["-c", "update-ca-certificates && watchmedo auto-restart --directory=./ --pattern=*.py --recursive -- uwsgi --http :{{ .Values.backend.service.port }} --module backend.wsgi --static-map /static=/usr/src/app/backend/statics --master --processes {{ .Values.backend.uwsgiProcesses }} --threads {{ .Values.backend.uwsgiThreads }} --need-app --env DJANGO_SETTINGS_MODULE=backend.settings.server.{{ .Values.backend.settings }}"]
         {{- end }}


### PR DESCRIPTION
In production scenarios, incoming requests can take a long time to be processed (due to the blockchain nature of the application).

Reduce the chances of broken pipes by increasing the maximum allowed duration for client HTTP connections.