### PR TITLE
K8s tasks

### DIFF
--- a/backend/backend/settings/common.py
+++ b/backend/backend/settings/common.py
@@ -199,6 +199,7 @@ TASK = {
     'CHAINKEYS_ENABLED': to_bool(os.environ.get('TASK_CHAINKEYS_ENABLED', False)),
     'LIST_WORKSPACE': to_bool(os.environ.get('TASK_LIST_WORKSPACE', True)),
     'COMPUTE_BACKEND': os.environ.get('COMPUTE_BACKEND', 'k8s'),  # 'docker' or 'k8s'
+    'BUILD_IMAGE': to_bool(os.environ.get('BUILD_IMAGE', True)),
 }
 
 CELERY_ACCEPT_CONTENT = ['application/json']

--- a/backend/backend/settings/common.py
+++ b/backend/backend/settings/common.py
@@ -198,6 +198,7 @@ TASK = {
     'CACHE_DOCKER_IMAGES': to_bool(os.environ.get('TASK_CACHE_DOCKER_IMAGES', False)),
     'CHAINKEYS_ENABLED': to_bool(os.environ.get('TASK_CHAINKEYS_ENABLED', False)),
     'LIST_WORKSPACE': to_bool(os.environ.get('TASK_LIST_WORKSPACE', True)),
+    'COMPUTE_BACKEND': os.environ.get('COMPUTE_BACKEND', 'k8s'),  # 'docker' or 'k8s'
 }
 
 CELERY_ACCEPT_CONTENT = ['application/json']

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,7 +12,7 @@ docker==4.1.0
 GPUtil==1.4.0
 ipython==7.11.1
 ipython-genutils==0.2.0
-kubernetes==10.0.1
+kubernetes==11.0.0
 mock==3.0.5
 psycopg2-binary==2.8.4
 raven==6.10.0

--- a/backend/substrapp/tasks/docker_backend.py
+++ b/backend/substrapp/tasks/docker_backend.py
@@ -183,7 +183,7 @@ def docker_remove_image(image_name):
 
 
 def docker_compute(image_name, job_name, cpu_set, memory_limit_mb, command, volumes, task_label,
-                   capture_logs, environment, gpu_set, remove_image, subtuple_key=None):
+                   capture_logs, environment, gpu_set, remove_image, subtuple_directory):
 
     docker_client = docker.from_env()
 

--- a/backend/substrapp/tasks/docker_backend.py
+++ b/backend/substrapp/tasks/docker_backend.py
@@ -183,7 +183,7 @@ def docker_remove_image(image_name):
 
 
 def docker_compute(image_name, job_name, cpu_set, memory_limit_mb, command, volumes, task_label,
-                   capture_logs, environment, gpu_set, remove_image):
+                   capture_logs, environment, gpu_set, remove_image, subtuple_key=None):
 
     docker_client = docker.from_env()
 

--- a/backend/substrapp/tasks/docker_backend.py
+++ b/backend/substrapp/tasks/docker_backend.py
@@ -1,0 +1,233 @@
+import docker
+import time
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+def docker_memory_limit(celery_worker_concurrency, celeryworker_image):
+    docker_client = docker.from_env()
+    # Get memory limit from docker container through the API
+    # Because the docker execution may be remote
+
+    cmd = f'python3 -u -c "import os; print(int(os.sysconf("SC_PAGE_SIZE") '\
+          f'* os.sysconf("SC_PHYS_PAGES") / (1024. ** 2)) // {celery_worker_concurrency}), end=\'\')"'
+
+    task_args = {
+        'image': celeryworker_image,
+        'command': cmd,
+        'detach': False,
+        'stdout': True,
+        'stderr': True,
+        'auto_remove': False,
+        'remove': True,
+        'network_disabled': True,
+        'network_mode': 'none',
+        'privileged': False,
+        'cap_drop': ['ALL'],
+    }
+
+    memory_limit_bytes = docker_client.containers.run(**task_args)
+
+    return int(memory_limit_bytes)
+
+
+def docker_cpu_count(celeryworker_image):
+    docker_client = docker.from_env()
+    # Get CPU count from docker container through the API
+    # Because the docker execution may be remote
+
+    task_args = {
+        'image': celeryworker_image,
+        'command': 'python3 -u -c "import os; print(os.cpu_count())"',
+        'detach': False,
+        'stdout': True,
+        'stderr': True,
+        'auto_remove': False,
+        'remove': True,
+        'network_disabled': True,
+        'network_mode': 'none',
+        'privileged': False,
+        'cap_drop': ['ALL'],
+    }
+
+    cpu_count_bytes = docker_client.containers.run(**task_args).strip()
+
+    return cpu_count_bytes
+
+
+def docker_gpu_list(celeryworker_image):
+    docker_client = docker.from_env()
+    # Get GPU list from docker container through the API
+    # Because the docker execution may be remote
+
+    cmd = 'python3 -u -c "import GPUtil as gputil;import json;'\
+          'print(json.dumps([str(gpu.id) for gpu in gputil.getGPUs()]), end=\'\')"'
+
+    task_args = {
+        'image': celeryworker_image,
+        'command': cmd,
+        'detach': False,
+        'stdout': True,
+        'stderr': True,
+        'auto_remove': False,
+        'remove': True,
+        'network_disabled': True,
+        'network_mode': 'none',
+        'privileged': False,
+        'cap_drop': ['ALL'],
+        'environment': {'CUDA_DEVICE_ORDER': 'PCI_BUS_ID',
+                        'NVIDIA_VISIBLE_DEVICES': 'all'},
+        'runtime': 'nvidia'
+    }
+
+    gpu_list_bytes = docker_client.containers.run(**task_args)
+
+    return gpu_list_bytes
+
+
+def docker_cpu_used(task_label):
+    docker_client = docker.from_env()
+    # Get CPU used from docker container through the API
+    # Because the docker execution may be remote
+
+    filters = {'status': 'running',
+               'label': [task_label]}
+
+    containers = [container.attrs
+                  for container in docker_client.containers.list(filters=filters)]
+
+    used_cpu_sets = [container['HostConfig']['CpusetCpus']
+                     for container in containers
+                     if container['HostConfig']['CpusetCpus']]
+
+    return used_cpu_sets
+
+
+def docker_gpu_used(task_label):
+    docker_client = docker.from_env()
+    # Get GPU used from docker container through the API
+    # Because the docker execution may be remote
+
+    filters = {'status': 'running',
+               'label': [task_label]}
+
+    containers = [container.attrs
+                  for container in docker_client.containers.list(filters=filters)]
+
+    env_containers = [container['Config']['Env']
+                      for container in containers]
+
+    used_gpu_sets = []
+
+    for env_list in env_containers:
+        nvidia_env_var = [s.split('=')[1]
+                          for s in env_list if "NVIDIA_VISIBLE_DEVICES" in s]
+
+        used_gpu_sets.extend(nvidia_env_var)
+
+    return used_gpu_sets
+
+
+def container_format_log(container_name, container_logs):
+    logs = [f'[{container_name}] {log}' for log in container_logs.decode().split('\n')]
+    for log in logs:
+        logger.info(log)
+
+
+def docker_build_image(path, tag, rm):
+    docker_client = docker.from_env()
+    return docker_client.images.build(path=path, tag=tag, rm=rm)
+
+
+def docker_get_image(image_name):
+    docker_client = docker.from_env()
+    return docker_client.images.get(image_name)
+
+
+def docker_get_or_create_local_volume(volume_id):
+
+    docker_client = docker.from_env()
+
+    try:
+        docker_client.volumes.get(volume_id=volume_id)
+    except docker.errors.NotFound:
+        docker_client.volumes.create(name=volume_id)
+
+
+def docker_remove_local_volume(volume_id):
+
+    docker_client = docker.from_env()
+
+    try:
+        local_volume = docker_client.volumes.get(volume_id=volume_id)
+        local_volume.remove(force=True)
+    except docker.errors.NotFound:
+        pass
+    except Exception:
+        logger.error(f'Cannot remove volume {volume_id}', exc_info=True)
+
+
+def docker_remove_image(image_name):
+    docker_client = docker.from_env()
+    try:
+        if docker_client.images.get(image_name):
+            logger.info(f'Remove docker image {image_name}')
+            docker_client.images.remove(image_name, force=True)
+
+    except docker.errors.ImageNotFound:
+        pass
+    except docker.errors.APIError as e:
+        logger.exception(e)
+
+
+def docker_compute(image_name, job_name, cpu_set, memory_limit_mb, command, volumes, task_label,
+                   capture_logs, environment, gpu_set, remove_image):
+
+    docker_client = docker.from_env()
+
+    task_args = {
+        'image': image_name,
+        'name': job_name,
+        'cpuset_cpus': cpu_set,
+        'mem_limit': memory_limit_mb,
+        'command': command,
+        'volumes': volumes,
+        'shm_size': '8G',
+        'labels': [task_label],
+        'detach': False,
+        'stdout': capture_logs,
+        'stderr': capture_logs,
+        'auto_remove': False,
+        'remove': False,
+        'network_disabled': True,
+        'network_mode': 'none',
+        'privileged': False,
+        'cap_drop': ['ALL'],
+        'environment': environment
+    }
+
+    if gpu_set is not None:
+        task_args['environment'].update({'NVIDIA_VISIBLE_DEVICES': gpu_set})
+        task_args['runtime'] = 'nvidia'
+
+    try:
+        ts = time.time()
+        docker_client.containers.run(**task_args)
+    finally:
+        # we need to remove the containers to be able to remove the local
+        # volume in case of compute plan
+        container = docker_client.containers.get(job_name)
+        if capture_logs:
+            container_format_log(
+                job_name,
+                container.logs()
+            )
+        container.remove()
+
+        # Remove images
+        if remove_image:
+            docker_client.images.remove(image_name, force=True)
+
+        elaps = (time.time() - ts) * 1000
+        logger.info(f'docker_client.images.run - elaps={elaps:.2f}ms')

--- a/backend/substrapp/tasks/docker_backend.py
+++ b/backend/substrapp/tasks/docker_backend.py
@@ -1,5 +1,6 @@
 import docker
-import time
+
+from substrapp.utils import timeit
 
 import logging
 logger = logging.getLogger(__name__)
@@ -182,8 +183,9 @@ def docker_remove_image(image_name):
         logger.exception(e)
 
 
+@timeit
 def docker_compute(image_name, job_name, cpu_set, memory_limit_mb, command, volumes, task_label,
-                   capture_logs, environment, gpu_set, remove_image, subtuple_directory):
+                   capture_logs, environment, gpu_set, remove_image, subtuple_key):
 
     docker_client = docker.from_env()
 
@@ -213,7 +215,6 @@ def docker_compute(image_name, job_name, cpu_set, memory_limit_mb, command, volu
         task_args['runtime'] = 'nvidia'
 
     try:
-        ts = time.time()
         docker_client.containers.run(**task_args)
     finally:
         # we need to remove the containers to be able to remove the local
@@ -229,6 +230,3 @@ def docker_compute(image_name, job_name, cpu_set, memory_limit_mb, command, volu
         # Remove images
         if remove_image:
             docker_client.images.remove(image_name, force=True)
-
-        elaps = (time.time() - ts) * 1000
-        logger.info(f'docker_client.images.run - elaps={elaps:.2f}ms')

--- a/backend/substrapp/tasks/docker_backend.py
+++ b/backend/substrapp/tasks/docker_backend.py
@@ -10,8 +10,9 @@ def docker_memory_limit(celery_worker_concurrency, celeryworker_image):
     # Get memory limit from docker container through the API
     # Because the docker execution may be remote
 
-    cmd = f'python3 -u -c "import os; print(int(os.sysconf("SC_PAGE_SIZE") '\
-          f'* os.sysconf("SC_PHYS_PAGES") / (1024. ** 2)) // {celery_worker_concurrency}), end=\'\')"'
+    memory_value = "int(os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES') / (1024. ** 2))"
+
+    cmd = f'python3 -u -c "import os; print({memory_value} // {celery_worker_concurrency}, end=\'\', flush=True)"'
 
     task_args = {
         'image': celeryworker_image,

--- a/backend/substrapp/tasks/docker_backend.py
+++ b/backend/substrapp/tasks/docker_backend.py
@@ -211,6 +211,7 @@ def docker_compute(image_name, job_name, cpu_set, memory_limit_mb, command, volu
     }
 
     if gpu_set is not None:
+        task_args['environment'].update({'CUDA_DEVICE_ORDER': 'PCI_BUS_ID'})
         task_args['environment'].update({'NVIDIA_VISIBLE_DEVICES': gpu_set})
         task_args['runtime'] = 'nvidia'
 

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -603,6 +603,25 @@ def _k8s_compute(name, task_args, subtuple_key):
         security_context=security_context
     )
 
+    pod_affinity = kubernetes.client.V1Affinity(
+        pod_affinity=kubernetes.client.V1PodAffinity(
+            required_during_scheduling_ignored_during_execution=[
+                kubernetes.client.V1PodAffinityTerm(
+                    label_selector=kubernetes.client.V1LabelSelector(
+                        match_expressions=[
+                            kubernetes.client.V1LabelSelectorRequirement(
+                                key="app.kubernetes.io/component",
+                                operator="In",
+                                values=["substra-worker"]
+                            )
+                        ]
+                    ),
+                    topology_key="kubernetes.io/hostname"
+                )
+            ]
+        )
+    )
+
     template = kubernetes.client.V1PodTemplateSpec(
         metadata=kubernetes.client.V1ObjectMeta(name=name,
                                                 labels={'app': name,
@@ -610,6 +629,7 @@ def _k8s_compute(name, task_args, subtuple_key):
                                                 ),
         spec=kubernetes.client.V1PodSpec(
             restart_policy='Never',
+            affinity=pod_affinity,
             containers=[container_compute],
             volumes=volumes
         )

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -76,7 +76,13 @@ def k8s_cpu_used(task_label):
 
     node = k8s_client.read_node(NODE_NAME)
 
-    cpu_used = math.ceil(float(node.status.capacity['cpu']) - float(node.status.allocatable['cpu']))
+    cpu_allocable = node.status.allocatable['cpu']
+
+    # convert XXXXm cpu to X.XXX cpu
+    if 'm' in cpu_allocable:
+        cpu_allocable = float(cpu_allocable.replace('m', '')) / 1000.0
+
+    cpu_used = math.ceil(float(node.status.capacity['cpu']) - float(cpu_allocable))
     return list(range(cpu_used))
 
 

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -299,7 +299,7 @@ def k8s_build_image(path, tag, rm):
 
     spec = kubernetes.client.V1JobSpec(
         template=template,
-        backoff_limit=4
+        backoff_limit=2
     )
 
     job = kubernetes.client.V1Job(
@@ -554,7 +554,7 @@ def create_compute_job(name, task_args, subtuple_key):
 
     spec = kubernetes.client.V1JobSpec(
         template=template,
-        backoff_limit=4
+        backoff_limit=0
     )
 
     job = kubernetes.client.V1Job(
@@ -681,7 +681,7 @@ def clean_outputs(subtuple_key):
 
     spec = kubernetes.client.V1JobSpec(
         template=template,
-        backoff_limit=4
+        backoff_limit=0
     )
 
     job = kubernetes.client.V1Job(

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -179,7 +179,6 @@ def k8s_build_image(path, tag, rm):
     k8s_client = kubernetes.client.BatchV1Api()
 
     dockerfile_fullpath = os.path.join(path, 'Dockerfile')
-    dockerfile_mount_subpath = os.path.basename(path)
     dockerfile_mount_path = os.path.join(os.path.realpath(os.getenv('MEDIA_ROOT')), 'subtuple')
 
     container = kubernetes.client.V1Container(
@@ -195,7 +194,6 @@ def k8s_build_image(path, tag, rm):
         volume_mounts=[
             {'name': 'dockerfile',
              'mountPath': dockerfile_mount_path,
-             'subPath': dockerfile_mount_subpath,
              'readOnly': True},
 
             {'name': 'cache',

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -547,7 +547,9 @@ def _k8s_compute(name, task_args, subtuple_key):
         args=task_args['command'].split(" ") if task_args['command'] is not None else None,
         volume_mounts=volume_mounts,
         # resources=resources,
-        security_context=security_context
+        security_context=security_context,
+        env=[kubernetes.client.V1EnvVar(name=env_name, value=env_value)
+             for env_name, env_value in task_args['environment'].items()]
     )
 
     pod_affinity = kubernetes.client.V1Affinity(

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -126,17 +126,20 @@ def watch_pod(name):
     k8s_client = kubernetes.client.CoreV1Api()
 
     finished = False
+    trials = 0
+    while (not finished) and (trials < 5):
+        try:
+            api_response = k8s_client.read_namespaced_pod_status(
+                name=name,
+                namespace=NAMESPACE,
+                pretty=True
+            )
 
-    while not finished:
-        api_response = k8s_client.read_namespaced_pod_status(
-            name=name,
-            namespace=NAMESPACE,
-            pretty=True
-        )
-
-        if api_response.status.container_statuses:
-            for container in api_response.status.container_statuses:
-                finished = True if container.state.terminated is not None else False
+            if api_response.status.container_statuses:
+                for container in api_response.status.container_statuses:
+                    finished = True if container.state.terminated is not None else False
+        except Exception:
+            trials += 1
 
 
 def get_pod_name(name):

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -696,10 +696,12 @@ def copy_chainkeys_to_output_pvc(chainkeys_directory, subtuple_directory):
     container = kubernetes.client.V1Container(
         name=job_name,
         image='busybox',
-        args=['cp',
-              '-Rv',
-              '/chainkeys_worker/*',
-              '/chainkeys_for_job/'],
+        args=[
+            'cp',
+            '-Rv',
+            '/chainkeys_worker/.',  # do not use wildcard
+            '/chainkeys_for_job/',
+        ],
         volume_mounts=[
             {'name': 'computeplan',
              'mountPath': '/chainkeys_worker',

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -179,14 +179,17 @@ def get_pod_logs(name, container):
     kubernetes.config.load_incluster_config()
     k8s_client = kubernetes.client.CoreV1Api()
 
-    logs = f'No pod {name}'
+    logs = f'No logs for pod {name}'
 
     if pod_exists(name):
-        logs = k8s_client.read_namespaced_pod_log(
-            name=name,
-            namespace=NAMESPACE,
-            container=container
-        )
+        try:
+            logs = k8s_client.read_namespaced_pod_log(
+                name=name,
+                namespace=NAMESPACE,
+                container=container
+            )
+        except Exception:
+            pass
 
     return logs
 

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -515,22 +515,24 @@ def _k8s_compute(name, task_args, subtuple_key):
     # Resources
 
     # Set minimal requests
-    r_requests = {
-        'cpu': 1,
-        'memory': '2000m'
-    }
 
-    r_limits = {
-        'cpu': len(task_args['cpu_set']),
-        'memory': task_args['mem_limit']
-    }
+    # r_requests = {
+    #     'cpu': 1,
+    #     'memory': '2000m'
+    # }
 
-    if task_args['gpu_set'] is not None:
-        r_limits['nvidia.com/gpu'] = len(task_args['gpu_set'])
+    # # Disable for now, we let kubernetes decide
+    # r_limits = {
+    #     'cpu': len(task_args['cpu_set']),
+    #     'memory': task_args['mem_limit']
+    # }
 
-    resources = kubernetes.client.V1ResourceRequirements(
-        limits=r_limits, requests=r_requests
-    )
+    # if task_args['gpu_set'] is not None:
+    #     r_limits['nvidia.com/gpu'] = len(task_args['gpu_set'])
+
+    # resources = kubernetes.client.V1ResourceRequirements(
+    #     limits=r_limits, requests=r_requests
+    # )
 
     # security
     security_context = kubernetes.client.V1SecurityContext(
@@ -544,7 +546,7 @@ def _k8s_compute(name, task_args, subtuple_key):
         image=task_args['image'],
         args=task_args['command'].split(" ") if task_args['command'] is not None else None,
         volume_mounts=volume_mounts,
-        resources=resources,
+        # resources=resources,
         security_context=security_context
     )
 

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -659,7 +659,7 @@ def clean_outputs(subtuple_key):
               f'/clean/{subtuple_key}'],
         volume_mounts=[
             {'name': 'outputs',
-             'mountPath': f'/clean',
+             'mountPath': '/clean',
              'subPath': subtuple_key},
 
         ]

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -1,0 +1,233 @@
+import docker
+import time
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+def k8s_memory_limit(celery_worker_concurrency, celeryworker_image):
+    docker_client = docker.from_env()
+    # Get memory limit from docker container through the API
+    # Because the docker execution may be remote
+
+    cmd = f'python3 -u -c "import os; print(int(os.sysconf("SC_PAGE_SIZE") '\
+          f'* os.sysconf("SC_PHYS_PAGES") / (1024. ** 2)) // {celery_worker_concurrency}), end=\'\')"'
+
+    task_args = {
+        'image': celeryworker_image,
+        'command': cmd,
+        'detach': False,
+        'stdout': True,
+        'stderr': True,
+        'auto_remove': False,
+        'remove': True,
+        'network_disabled': True,
+        'network_mode': 'none',
+        'privileged': False,
+        'cap_drop': ['ALL'],
+    }
+
+    memory_limit_bytes = docker_client.containers.run(**task_args)
+
+    return int(memory_limit_bytes)
+
+
+def k8s_cpu_count(celeryworker_image):
+    docker_client = docker.from_env()
+    # Get CPU count from docker container through the API
+    # Because the docker execution may be remote
+
+    task_args = {
+        'image': celeryworker_image,
+        'command': 'python3 -u -c "import os; print(os.cpu_count())"',
+        'detach': False,
+        'stdout': True,
+        'stderr': True,
+        'auto_remove': False,
+        'remove': True,
+        'network_disabled': True,
+        'network_mode': 'none',
+        'privileged': False,
+        'cap_drop': ['ALL'],
+    }
+
+    cpu_count_bytes = docker_client.containers.run(**task_args).strip()
+
+    return cpu_count_bytes
+
+
+def k8s_gpu_list(celeryworker_image):
+    docker_client = docker.from_env()
+    # Get GPU list from docker container through the API
+    # Because the docker execution may be remote
+
+    cmd = 'python3 -u -c "import GPUtil as gputil;import json;'\
+          'print(json.dumps([str(gpu.id) for gpu in gputil.getGPUs()]), end=\'\')"'
+
+    task_args = {
+        'image': celeryworker_image,
+        'command': cmd,
+        'detach': False,
+        'stdout': True,
+        'stderr': True,
+        'auto_remove': False,
+        'remove': True,
+        'network_disabled': True,
+        'network_mode': 'none',
+        'privileged': False,
+        'cap_drop': ['ALL'],
+        'environment': {'CUDA_DEVICE_ORDER': 'PCI_BUS_ID',
+                        'NVIDIA_VISIBLE_DEVICES': 'all'},
+        'runtime': 'nvidia'
+    }
+
+    gpu_list_bytes = docker_client.containers.run(**task_args)
+
+    return gpu_list_bytes
+
+
+def k8s_cpu_used(task_label):
+    docker_client = docker.from_env()
+    # Get CPU used from docker container through the API
+    # Because the docker execution may be remote
+
+    filters = {'status': 'running',
+               'label': [task_label]}
+
+    containers = [container.attrs
+                  for container in docker_client.containers.list(filters=filters)]
+
+    used_cpu_sets = [container['HostConfig']['CpusetCpus']
+                     for container in containers
+                     if container['HostConfig']['CpusetCpus']]
+
+    return used_cpu_sets
+
+
+def k8s_gpu_used(task_label):
+    docker_client = docker.from_env()
+    # Get GPU used from docker container through the API
+    # Because the docker execution may be remote
+
+    filters = {'status': 'running',
+               'label': [task_label]}
+
+    containers = [container.attrs
+                  for container in docker_client.containers.list(filters=filters)]
+
+    env_containers = [container['Config']['Env']
+                      for container in containers]
+
+    used_gpu_sets = []
+
+    for env_list in env_containers:
+        nvidia_env_var = [s.split('=')[1]
+                          for s in env_list if "NVIDIA_VISIBLE_DEVICES" in s]
+
+        used_gpu_sets.extend(nvidia_env_var)
+
+    return used_gpu_sets
+
+
+def container_format_log(container_name, container_logs):
+    logs = [f'[{container_name}] {log}' for log in container_logs.decode().split('\n')]
+    for log in logs:
+        logger.info(log)
+
+
+def k8s_build_image(path, tag, rm):
+    docker_client = docker.from_env()
+    return docker_client.images.build(path=path, tag=tag, rm=rm)
+
+
+def k8s_get_image(image_name):
+    docker_client = docker.from_env()
+    return docker_client.images.get(image_name)
+
+
+def k8s_get_or_create_local_volume(volume_id):
+
+    docker_client = docker.from_env()
+
+    try:
+        docker_client.volumes.get(volume_id=volume_id)
+    except docker.errors.NotFound:
+        docker_client.volumes.create(name=volume_id)
+
+
+def k8s_remove_local_volume(volume_id):
+
+    docker_client = docker.from_env()
+
+    try:
+        local_volume = docker_client.volumes.get(volume_id=volume_id)
+        local_volume.remove(force=True)
+    except docker.errors.NotFound:
+        pass
+    except Exception:
+        logger.error(f'Cannot remove volume {volume_id}', exc_info=True)
+
+
+def k8s_remove_image(image_name):
+    docker_client = docker.from_env()
+    try:
+        if docker_client.images.get(image_name):
+            logger.info(f'Remove docker image {image_name}')
+            docker_client.images.remove(image_name, force=True)
+
+    except docker.errors.ImageNotFound:
+        pass
+    except docker.errors.APIError as e:
+        logger.exception(e)
+
+
+def k8s_compute(image_name, job_name, cpu_set, memory_limit_mb, command, volumes, task_label,
+                capture_logs, environment, gpu_set, remove_image):
+
+    docker_client = docker.from_env()
+
+    task_args = {
+        'image': image_name,
+        'name': job_name,
+        'cpuset_cpus': cpu_set,
+        'mem_limit': memory_limit_mb,
+        'command': command,
+        'volumes': volumes,
+        'shm_size': '8G',
+        'labels': [task_label],
+        'detach': False,
+        'stdout': capture_logs,
+        'stderr': capture_logs,
+        'auto_remove': False,
+        'remove': False,
+        'network_disabled': True,
+        'network_mode': 'none',
+        'privileged': False,
+        'cap_drop': ['ALL'],
+        'environment': environment
+    }
+
+    if gpu_set is not None:
+        task_args['environment'].update({'NVIDIA_VISIBLE_DEVICES': gpu_set})
+        task_args['runtime'] = 'nvidia'
+
+    try:
+        ts = time.time()
+        docker_client.containers.run(**task_args)
+    finally:
+        # we need to remove the containers to be able to remove the local
+        # volume in case of compute plan
+        container = docker_client.containers.get(job_name)
+        if capture_logs:
+            container_format_log(
+                job_name,
+                container.logs()
+            )
+        container.remove()
+
+        # Remove images
+        if remove_image:
+            docker_client.images.remove(image_name, force=True)
+
+        elaps = (time.time() - ts) * 1000
+        logger.info(f'docker_client.images.run - elaps={elaps:.2f}ms')

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -697,7 +697,7 @@ def copy_chainkeys_to_output_pvc(chainkeys_directory, subtuple_directory):
         name=job_name,
         image='busybox',
         args=['cp',
-              '-R',
+              '-Rv',
               '/chainkeys_worker/*',
               '/chainkeys_for_job/'],
         volume_mounts=[
@@ -741,6 +741,12 @@ def copy_chainkeys_to_output_pvc(chainkeys_directory, subtuple_directory):
     except Exception as e:
         logger.error(f'Cleaning failed, error: {e}')
     finally:
+        container_format_log(
+            job_name,
+            get_pod_logs(name=get_pod_name(job_name),
+                         container=job_name)
+        )
+
         k8s_client.delete_namespaced_pod(
             name=job_name,
             namespace=NAMESPACE,

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -71,6 +71,7 @@ def k8s_memory_limit(celery_worker_concurrency, celeryworker_image):
 
     return int(memory_limit_bytes)
 
+
 def k8s_cpu_count(celeryworker_image):
     docker_client = docker.from_env()
     # Get CPU count from docker container through the API

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -49,8 +49,9 @@ def k8s_memory_limit(celery_worker_concurrency, celeryworker_image):
     # Get memory limit from docker container through the API
     # Because the docker execution may be remote
 
-    cmd = f'python3 -u -c "import os; print(int(os.sysconf("SC_PAGE_SIZE") '\
-          f'* os.sysconf("SC_PHYS_PAGES") / (1024. ** 2)) // {celery_worker_concurrency}), end=\'\')"'
+    memory_value = "int(os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES') / (1024. ** 2))"
+
+    cmd = f'python3 -u -c "import os; print({memory_value} // {celery_worker_concurrency}, end=\'\', flush=True)"'
 
     task_args = {
         'image': celeryworker_image,
@@ -69,7 +70,6 @@ def k8s_memory_limit(celery_worker_concurrency, celeryworker_image):
     memory_limit_bytes = docker_client.containers.run(**task_args)
 
     return int(memory_limit_bytes)
-
 
 def k8s_cpu_count(celeryworker_image):
     docker_client = docker.from_env()

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -53,7 +53,13 @@ def k8s_cpu_count(celeryworker_image):
 
     node = k8s_client.read_node(NODE_NAME)
 
-    return max(1, math.floor(float(node.status.capacity['cpu'])))
+    cpu_allocatable = node.status.allocatable['cpu']
+
+    # convert XXXXm cpu to X.XXX cpu
+    if 'm' in cpu_allocatable:
+        cpu_allocatable = float(cpu_allocatable.replace('m', '')) / 1000.0
+
+    return max(1, math.floor(float(cpu_allocatable)))
 
 
 def k8s_gpu_list(celeryworker_image):
@@ -510,7 +516,7 @@ def _k8s_compute(name, task_args, subtuple_key):
 
     # Set minimal requests
     r_requests = {
-        'cpu': 2,
+        'cpu': 1,
         'memory': '2000m'
     }
 

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -29,98 +29,6 @@ class BuildError(Exception):
     pass
 
 
-def watch_job(name):
-    kubernetes.config.load_incluster_config()
-    api = kubernetes.client.BatchV1Api()
-
-    job = None
-    finished = False
-
-    while not finished:
-        job = api.read_namespaced_job(name, NAMESPACE)
-
-        if job.status.succeeded == job.spec.completions:
-            finished = True
-            logger.info(f'The job {NAMESPACE}/{name} succeeded')
-
-        elif job.status.failed == job.spec.backoff_limit:
-            logger.error(f'The job {NAMESPACE}/{name} failed')
-            raise
-
-        time.sleep(5)
-
-    return job
-
-
-def job_exists(name):
-    kubernetes.config.load_incluster_config()
-    api = kubernetes.client.BatchV1Api()
-
-    try:
-        api.read_namespaced_job(name, NAMESPACE)
-    except Exception:
-        return False
-    else:
-        return True
-
-
-def wait_for_job_deletion(name):
-
-    while job_exists(name):
-        time.sleep(5)
-
-
-def get_pod_name(name):
-
-    kubernetes.config.load_incluster_config()
-    k8s_client = kubernetes.client.CoreV1Api()
-
-    pod = None
-
-    while pod is None:
-        api_response = k8s_client.list_namespaced_pod(
-            NAMESPACE,
-            label_selector=f'app={name}'
-        )
-        if api_response.items:
-            pod = api_response.items.pop()
-
-        time.sleep(5)
-
-    return pod.metadata.name
-
-
-def pod_exists(name):
-    kubernetes.config.load_incluster_config()
-    k8s_client = kubernetes.client.CoreV1Api()
-
-    try:
-        k8s_client.read_namespaced_pod(
-            name=name,
-            namespace=NAMESPACE)
-    except Exception:
-        return False
-    else:
-        return True
-
-
-def get_pod_logs(name, container):
-
-    kubernetes.config.load_incluster_config()
-    k8s_client = kubernetes.client.CoreV1Api()
-
-    logs = f'No pod {name}'
-
-    if pod_exists(name):
-        logs = k8s_client.read_namespaced_pod_log(
-            name=name,
-            namespace=NAMESPACE,
-            container=container
-        )
-
-    return logs
-
-
 def k8s_memory_limit(celery_worker_concurrency, celeryworker_image):
     docker_client = docker.from_env()
     # Get memory limit from docker container through the API
@@ -233,6 +141,98 @@ def k8s_gpu_used(task_label):
     return used_gpu_sets
 
 
+def watch_job(name):
+    kubernetes.config.load_incluster_config()
+    k8s_client = kubernetes.client.BatchV1Api()
+
+    job = None
+    finished = False
+
+    while not finished:
+        job = k8s_client.read_namespaced_job(name, NAMESPACE)
+
+        if job.status.succeeded and job.status.succeeded >= job.spec.completions:
+            finished = True
+            logger.info(f'The job {NAMESPACE}/{name} succeeded')
+
+        elif job.status.failed and job.status.failed >= job.spec.backoff_limit:
+            logger.error(f'The job {NAMESPACE}/{name} failed')
+            raise Exception(f'The job {NAMESPACE}/{name} failed')
+
+        time.sleep(2)
+
+    return job
+
+
+def job_exists(name):
+    kubernetes.config.load_incluster_config()
+    k8s_client = kubernetes.client.BatchV1Api()
+
+    try:
+        k8s_client.read_namespaced_job(name, NAMESPACE)
+    except Exception:
+        return False
+    else:
+        return True
+
+
+def wait_for_job_deletion(name):
+
+    while job_exists(name):
+        time.sleep(2)
+
+
+def get_pod_name(name):
+
+    kubernetes.config.load_incluster_config()
+    k8s_client = kubernetes.client.CoreV1Api()
+
+    pod = None
+
+    while pod is None:
+        api_response = k8s_client.list_namespaced_pod(
+            NAMESPACE,
+            label_selector=f'app={name}'
+        )
+        if api_response.items:
+            pod = api_response.items.pop()
+
+        time.sleep(2)
+
+    return pod.metadata.name
+
+
+def pod_exists(name):
+    kubernetes.config.load_incluster_config()
+    k8s_client = kubernetes.client.CoreV1Api()
+
+    try:
+        k8s_client.read_namespaced_pod(
+            name=name,
+            namespace=NAMESPACE)
+    except Exception:
+        return False
+    else:
+        return True
+
+
+def get_pod_logs(name, container):
+
+    kubernetes.config.load_incluster_config()
+    k8s_client = kubernetes.client.CoreV1Api()
+
+    logs = f'No pod {name}'
+
+    if pod_exists(name):
+        logs = k8s_client.read_namespaced_pod_log(
+            name=name,
+            namespace=NAMESPACE,
+            container=container
+        )
+
+    return logs
+
+
 def container_format_log(container_name, container_logs):
 
     if isinstance(container_logs, bytes):
@@ -338,61 +338,28 @@ def k8s_get_image(image_name):
     return response.json()
 
 
-def k8s_delete_image(image_name):
-
-    response = requests.get(
-        f'http://{REGISTRY}:5000/v2/{image_name}/manifests/latest',
-        headers={'Accept': 'application/vnd.docker.distribution.manifest.v2+json'}
-    )
-
-    if response.status_code != requests.status_codes.codes.ok:
-        raise ImageNotFound(f'Error when querying docker-registry, status code: {response.status_code}')
-
-    digest = response.headers['Docker-Content-Digest']
-
-    response = requests.delete(
-        f'http://{REGISTRY}:5000/v2/{image_name}/manifests/{digest}',
-        headers={'Accept': 'application/vnd.docker.distribution.manifest.v2+json'}
-    )
-    if response.status_code != requests.status_codes.codes.accepted:
-        raise ImageNotFound(f'Error when querying docker-registry, status code: {response.status_code}')
-
-    return response
-
-
-def k8s_get_or_create_local_volume(volume_id):
-
-    docker_client = docker.from_env()
-
-    try:
-        docker_client.volumes.get(volume_id=volume_id)
-    except docker.errors.NotFound:
-        docker_client.volumes.create(name=volume_id)
-
-
-def k8s_remove_local_volume(volume_id):
-
-    docker_client = docker.from_env()
-
-    try:
-        local_volume = docker_client.volumes.get(volume_id=volume_id)
-        local_volume.remove(force=True)
-    except docker.errors.NotFound:
-        pass
-    except Exception:
-        logger.error(f'Cannot remove volume {volume_id}', exc_info=True)
-
-
 def k8s_remove_image(image_name):
-    docker_client = docker.from_env()
-    try:
-        if docker_client.images.get(image_name):
-            logger.info(f'Remove docker image {image_name}')
-            docker_client.images.remove(image_name, force=True)
 
-    except docker.errors.ImageNotFound:
-        pass
-    except docker.errors.APIError as e:
+    try:
+        response = requests.get(
+            f'http://{REGISTRY}:5000/v2/{image_name}/manifests/latest',
+            headers={'Accept': 'application/vnd.docker.distribution.manifest.v2+json'}
+        )
+
+        if response.status_code != requests.status_codes.codes.ok:
+            # raise ImageNotFound(f'Error when querying docker-registry, status code: {response.status_code}')
+            return
+
+        digest = response.headers['Docker-Content-Digest']
+
+        response = requests.delete(
+            f'http://{REGISTRY}:5000/v2/{image_name}/manifests/{digest}',
+            headers={'Accept': 'application/vnd.docker.distribution.manifest.v2+json'}
+        )
+        if response.status_code != requests.status_codes.codes.accepted:
+            # raise ImageNotFound(f'Error when querying docker-registry, status code: {response.status_code}')
+            return
+    except Exception as e:
         logger.exception(e)
 
 
@@ -426,13 +393,11 @@ def k8s_compute(image_name, job_name, cpu_set, memory_limit_mb, command, volumes
         task_args['environment'].update({'NVIDIA_VISIBLE_DEVICES': gpu_set})
         task_args['runtime'] = 'nvidia'
 
-    k8s_job_name = job_name.replace("_", "-")
-
     try:
         ts = time.time()
 
-        create_compute_job(k8s_job_name, task_args, subtuple_key)
-        watch_job(k8s_job_name)
+        create_compute_job(job_name, task_args, subtuple_key)
+        watch_job(job_name)
         copy_outputs(subtuple_directory)
     except Exception as e:
         logger.exception(e)
@@ -441,20 +406,17 @@ def k8s_compute(image_name, job_name, cpu_set, memory_limit_mb, command, volumes
 
         if capture_logs:
             container_format_log(
-                k8s_job_name,
-                get_pod_logs(name=get_pod_name(k8s_job_name),
-                             container=k8s_job_name)
+                job_name,
+                get_pod_logs(name=get_pod_name(job_name),
+                             container=job_name)
             )
 
-        delete_compute_job(k8s_job_name)
-        try:
-            clean_outputs(subtuple_key)
-        except Exception as e:
-            logger.exception(e)
+        delete_compute_job(job_name)
+        clean_outputs(subtuple_key)
 
         # Remove images
         if remove_image:
-            k8s_delete_image(image_name)
+            k8s_remove_image(image_name)
 
         elaps = (time.time() - ts) * 1000
         logger.info(f'k8s_client.images.run - elaps={elaps:.2f}ms')
@@ -467,6 +429,20 @@ def generate_volumes(volume_binds, name, subtuple_key):
     for path, bind in volume_binds.items():
 
         volume_processed = False
+
+        # Handle local volume
+        if 'local-' in path:
+            volume_mounts.append({
+                'name': 'local',
+                'mountPath': bind['bind'],
+                'subPath': path
+            })
+            volumes.append(
+                {'name': 'local',
+                 'persistentVolumeClaim': {'claimName': K8S_PVC['LOCAL_PVC']}}
+            )
+
+            volume_processed = True
 
         # Handle outputs paths which need to be writable
         for subpath in ['/pred', '/output_model', '/perf', '/export']:
@@ -496,7 +472,11 @@ def generate_volumes(volume_binds, name, subtuple_key):
             subpath = path.split(f'/{volume_name}/')[-1]
 
             pvc_name = [key for key in K8S_PVC.keys()
-                        if volume_name in key.lower()].pop()
+                        if volume_name in key.lower()]
+            if pvc_name:
+                pvc_name = pvc_name.pop()
+            else:
+                raise Exception(f'PVC for {volume_name} not found')
 
             volume_mounts.append({
                 'name': volume_name,
@@ -524,6 +504,69 @@ def copy_outputs(subtuple_directory):
         if os.path.exists(content_path):
             logger.info(f'Copy {content_path} to {content_dst_path}')
             copy_tree(content_path, content_dst_path)
+
+
+def clean_outputs(subtuple_key):
+
+    kubernetes.config.load_incluster_config()
+    k8s_client = kubernetes.client.BatchV1Api()
+    job_name = f'clean-outputs-{subtuple_key[:10]}'
+
+    container = kubernetes.client.V1Container(
+        name=job_name,
+        image='busybox',
+        args=['rm',
+              '-rf',
+              f'/clean/{subtuple_key}'],
+        volume_mounts=[
+            {'name': 'outputs',
+             'mountPath': '/clean',
+             'subPath': subtuple_key},
+
+        ]
+    )
+
+    template = kubernetes.client.V1PodTemplateSpec(
+        metadata=kubernetes.client.V1ObjectMeta(labels={'app': job_name}),
+        spec=kubernetes.client.V1PodSpec(
+            restart_policy='Never',
+            containers=[container],
+            volumes=[
+                {
+                    'name': 'outputs',
+                    'persistentVolumeClaim': {'claimName': K8S_PVC['OUTPUTS_PVC']}
+                },
+            ]
+        )
+    )
+
+    spec = kubernetes.client.V1JobSpec(
+        template=template,
+        backoff_limit=0
+    )
+
+    job = kubernetes.client.V1Job(
+        api_version='batch/v1',
+        kind='Job',
+        metadata=kubernetes.client.V1ObjectMeta(name=job_name),
+        spec=spec
+    )
+
+    k8s_client.create_namespaced_job(body=job, namespace=NAMESPACE)
+
+    try:
+        watch_job(job_name)
+    except Exception as e:
+        logger.error(f'Cleaning failed, error: {e}')
+    finally:
+        k8s_client.delete_namespaced_job(
+            name=job_name,
+            namespace=NAMESPACE,
+            body=kubernetes.client.V1DeleteOptions(
+                propagation_policy='Foreground',
+                grace_period_seconds=5
+            )
+        )
 
 
 def create_compute_job(name, task_args, subtuple_key):
@@ -586,81 +629,27 @@ def delete_compute_job(name):
     logger.info(f'Compute Job {name} deleted.')
 
 
-def create_volume(name):
-    kubernetes.config.load_incluster_config()
-    k8s_client = kubernetes.client.CoreV1Api()
-
-    pvc = kubernetes.client.V1PersistentVolumeClaim(
-        api_version="v1",
-        kind="PersistentVolumeClaim",
-        metadata=kubernetes.client.V1ObjectMeta(name=name),
-        spec=kubernetes.client.V1PersistentVolumeClaimSpec(
-            access_modes=["ReadWriteOnce"],
-            resources={
-                "requests": {"storage": "10Gi"}
-            },
-        )
-    )
-
-    k8s_client.create_namespaced_persistent_volume_claim(NAMESPACE, body=pvc)
-
-    logger.info(f'PVC {name} created.')
+def k8s_get_or_create_local_volume(volume_id):
+    pvc = K8S_PVC['LOCAL_PVC']
+    logger.info(f'{volume_id} will be created in the PVC {pvc}')
 
 
-def pvc_exists(name):
-    kubernetes.config.load_incluster_config()
-    k8s_client = kubernetes.client.CoreV1Api()
-
-    try:
-        k8s_client.read_namespaced_persistent_volume_claim(
-            name=name,
-            namespace=NAMESPACE)
-    except Exception:
-        return False
-    else:
-        return True
-
-
-def wait_for_pvc_deletion(name):
-    while pvc_exists(name):
-        time.sleep(5)
-
-
-def delete_volume(name):
-
-    if pvc_exists(name):
-        kubernetes.config.load_incluster_config()
-        k8s_client = kubernetes.client.CoreV1Api()
-
-        k8s_client.delete_namespaced_persistent_volume_claim(
-            name=name,
-            namespace=NAMESPACE,
-            body=kubernetes.client.V1DeleteOptions(
-                propagation_policy='Foreground',
-                grace_period_seconds=0
-            )
-        )
-
-    wait_for_pvc_deletion(name)
-    logger.info(f'PVC {name} deleted.')
-
-
-def clean_outputs(subtuple_key):
+def k8s_remove_local_volume(volume_id):
 
     kubernetes.config.load_incluster_config()
     k8s_client = kubernetes.client.BatchV1Api()
-    job_name = f'clean-outputs-{subtuple_key[:10]}'
+    job_name = f'clean-outputs-{volume_id[:20]}'
 
     container = kubernetes.client.V1Container(
         name=job_name,
         image='busybox',
         args=['rm',
               '-rf',
-              f'/clean/{subtuple_key}'],
+              f'/clean/{volume_id}'],
         volume_mounts=[
-            {'name': 'outputs',
+            {'name': 'local',
              'mountPath': '/clean',
-             'subPath': subtuple_key},
+             'subPath': volume_id},
 
         ]
     )
@@ -672,8 +661,8 @@ def clean_outputs(subtuple_key):
             containers=[container],
             volumes=[
                 {
-                    'name': 'outputs',
-                    'persistentVolumeClaim': {'claimName': K8S_PVC['OUTPUTS_PVC']}
+                    'name': 'local',
+                    'persistentVolumeClaim': {'claimName': K8S_PVC['LOCAL_PVC']}
                 },
             ]
         )

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -5,8 +5,8 @@ import requests
 import os
 import logging
 
-from substrapp.utils import get_remote_file
-from kubernetes.stream import stream
+from distutils.dir_util import copy_tree
+
 
 logger = logging.getLogger(__name__)
 
@@ -90,32 +90,6 @@ def get_pod_name(name):
     return pod.metadata.name
 
 
-def watch_pod(name):
-    kubernetes.config.load_incluster_config()
-    k8s_client = kubernetes.client.CoreV1Api()
-
-    api_response = k8s_client.read_namespaced_pod(
-        name=name,
-        namespace=NAMESPACE,
-        pretty=True
-    )
-
-    finished = False
-
-    while not finished:
-        api_response = k8s_client.read_namespaced_pod_status(
-            name=name,
-            namespace=NAMESPACE,
-            pretty=True
-        )
-
-        if api_response.status.container_statuses:
-            for container in api_response.status.container_statuses:
-                finished = True if container.state.terminated is not None else False
-
-        time.sleep(5)
-
-
 def pod_exists(name):
     kubernetes.config.load_incluster_config()
     k8s_client = kubernetes.client.CoreV1Api()
@@ -128,11 +102,6 @@ def pod_exists(name):
         return False
     else:
         return True
-
-
-def wait_for_pod_deletion(name):
-    while pod_exists(name):
-        time.sleep(5)
 
 
 def get_pod_logs(name, container):
@@ -235,21 +204,8 @@ def k8s_gpu_list(celeryworker_image):
 
 
 def k8s_cpu_used(task_label):
-    docker_client = docker.from_env()
-    # Get CPU used from docker container through the API
-    # Because the docker execution may be remote
-
-    filters = {'status': 'running',
-               'label': [task_label]}
-
-    containers = [container.attrs
-                  for container in docker_client.containers.list(filters=filters)]
-
-    used_cpu_sets = [container['HostConfig']['CpusetCpus']
-                     for container in containers
-                     if container['HostConfig']['CpusetCpus']]
-
-    return used_cpu_sets
+    # CPU used is handle by kubernetes
+    return []
 
 
 def k8s_gpu_used(task_label):
@@ -294,6 +250,8 @@ def k8s_build_image(path, tag, rm):
     k8s_client = kubernetes.client.BatchV1Api()
 
     job_name = f'kaniko-{tag.split("/")[-1].replace("_", "-")}'
+
+    logger.info(f'The job {NAMESPACE}/{job_name} started')
 
     dockerfile_fullpath = os.path.join(path, 'Dockerfile')
 
@@ -441,26 +399,26 @@ def k8s_remove_image(image_name):
 def k8s_compute(image_name, job_name, cpu_set, memory_limit_mb, command, volumes, task_label,
                 capture_logs, environment, gpu_set, remove_image, subtuple_directory):
 
-    # docker_client = docker.from_env()
+    subtuple_key = subtuple_directory.split('/')[-1]
 
     task_args = {
         'image': f'{REGISTRY_HOST}/{image_name}',
         'name': job_name,
-        'cpuset_cpus': cpu_set,
-        'mem_limit': memory_limit_mb,
+        # 'cpuset_cpus': cpu_set,
+        # 'mem_limit': memory_limit_mb,
         'command': command,
         'volumes': volumes,
-        'shm_size': '8G',
-        'labels': [task_label],
-        'detach': False,
-        'stdout': capture_logs,
-        'stderr': capture_logs,
-        'auto_remove': False,
-        'remove': False,
-        'network_disabled': True,
-        'network_mode': 'none',
-        'privileged': False,
-        'cap_drop': ['ALL'],
+        # 'shm_size': '8G',
+        # 'labels': [task_label],
+        # 'detach': False,
+        # 'stdout': capture_logs,
+        # 'stderr': capture_logs,
+        # 'auto_remove': False,
+        # 'remove': False,
+        # 'network_disabled': True,
+        # 'network_mode': 'none',
+        # 'privileged': False,
+        # 'cap_drop': ['ALL'],
         'environment': environment
     }
 
@@ -473,14 +431,12 @@ def k8s_compute(image_name, job_name, cpu_set, memory_limit_mb, command, volumes
     try:
         ts = time.time()
 
-        create_volume(k8s_job_name)
-        create_nginx(k8s_job_name)
-        create_compute_job(k8s_job_name, task_args)
+        create_compute_job(k8s_job_name, task_args, subtuple_key)
         watch_job(k8s_job_name)
-
-        # Fetch model and pred files
-        fetch_outputs(f'nginx-{k8s_job_name}', subtuple_directory,
-                      generate_filepaths(f'nginx-{k8s_job_name}'))
+        copy_outputs(subtuple_directory)
+    except Exception as e:
+        logger.exception(e)
+        raise
     finally:
 
         if capture_logs:
@@ -491,8 +447,10 @@ def k8s_compute(image_name, job_name, cpu_set, memory_limit_mb, command, volumes
             )
 
         delete_compute_job(k8s_job_name)
-        delete_nginx(k8s_job_name)
-        delete_volume(k8s_job_name)
+        try:
+            clean_outputs(subtuple_key)
+        except Exception as e:
+            logger.exception(e)
 
         # Remove images
         if remove_image:
@@ -502,88 +460,39 @@ def k8s_compute(image_name, job_name, cpu_set, memory_limit_mb, command, volumes
         logger.info(f'k8s_client.images.run - elaps={elaps:.2f}ms')
 
 
-def generate_filepaths(name):
-
-    base_nginx = '/usr/share/nginx/html'
-
-    volume_binds = [
-        'output_model',
-        'pred',
-        'perf'
-    ]
-
-    filepaths = []
-    kubernetes.config.load_incluster_config()
-    k8s_client = kubernetes.client.CoreV1Api()
-
-    for bind in volume_binds:
-        path = os.path.join(base_nginx, bind)
-        exec_command = [
-            '/bin/sh',
-            '-c',
-            f'ls {path}']
-
-        api_response = stream(
-            k8s_client.connect_get_namespaced_pod_exec,
-            name,
-            NAMESPACE,
-            command=exec_command,
-            stderr=True, stdin=True,
-            stdout=True, tty=True
-        )
-
-        if api_response:
-            files = [
-                os.path.join(bind, file)
-                for file in api_response.strip().split("\n")
-            ]
-
-            filepaths.extend(files)
-
-    return filepaths
-
-
-def generate_volumes(volume_binds, name):
+def generate_volumes(volume_binds, name, subtuple_key):
     volume_mounts = []
     volumes = []
 
     for path, bind in volume_binds.items():
-        # /HOST/PATH/servermedias/...
-        if '/servermedias/' in path:
-            volume_name = 'servermedias'
-        # /HOST/PATH/medias/volume_name/...
-        else:
-            volume_name = path.split('/medias/')[-1].split('/')[0]
 
-        if '/pred' in path and bind['mode'] == 'rw':
-            volume_mounts.append({
-                'name': name,
-                'mountPath': bind['bind'],
-                'subPath': 'pred'
-            })
-            # Volume will be added later, see volumes_rw
-        elif '/output_model' in path and bind['mode'] == 'rw':
-            volume_mounts.append({
-                'name': name,
-                'mountPath': bind['bind'],
-                'subPath': 'output_model'
-            })
-            # Volume will be added later, see
-        elif '/perf' in path and bind['mode'] == 'rw':
-            volume_mounts.append({
-                'name': name,
-                'mountPath': bind['bind'],
-                'subPath': 'perf'
-            })
-            # Volume will be added later, see volumes_rw
-        elif '/export' in path and bind['mode'] == 'rw':
-            volume_mounts.append({
-                'name': name,
-                'mountPath': bind['bind'],
-                'subPath': 'export'
-            })
-            # Volume will be added later, see volumes_rw
-        else:
+        volume_processed = False
+
+        # Handle outputs paths which need to be writable
+        for subpath in ['/pred', '/output_model', '/perf', '/export']:
+            if subpath in path and bind['mode'] == 'rw':
+                volume_mounts.append({
+                    'name': 'outputs',
+                    'mountPath': bind['bind'],
+                    'subPath': f'{subtuple_key}{subpath}'
+                })
+                volumes.append(
+                    {'name': 'outputs',
+                     'persistentVolumeClaim': {'claimName': K8S_PVC['OUTPUTS_PVC']}}
+                )
+
+                volume_processed = True
+
+        if not volume_processed:
+            # Handle read-only paths
+
+            # /HOST/PATH/servermedias/...
+            if '/servermedias/' in path:
+                volume_name = 'servermedias'
+            # /HOST/PATH/medias/volume_name/...
+            else:
+                volume_name = path.split('/medias/')[-1].split('/')[0]
+
             subpath = path.split(f'/{volume_name}/')[-1]
 
             pvc_name = [key for key in K8S_PVC.keys()
@@ -600,7 +509,6 @@ def generate_volumes(volume_binds, name):
             volumes.append({
                 'name': volume_name,
                 'persistentVolumeClaim': {'claimName': K8S_PVC[pvc_name]}
-
             })
 
     # Unique volumes
@@ -609,30 +517,22 @@ def generate_volumes(volume_binds, name):
     return volume_mounts, volumes
 
 
-def fetch_outputs(service_name, subtuple_directory, filepaths):
-    for filepath in filepaths:
-        content_dst_path = os.path.join(subtuple_directory, filepath)
-        logger.info(f'Fetch http://{service_name}/{filepath} to {content_dst_path}')
-        get_remote_file(
-            url=f'http://{service_name}/{filepath}',
-            auth=None,
-            content_dst_path=content_dst_path,
-            stream=True)
+def copy_outputs(subtuple_directory):
+    for output_folder in ['output_model', 'pred', 'perf', 'export']:
+        content_dst_path = os.path.join(subtuple_directory, output_folder)
+        content_path = content_dst_path.replace('subtuple', 'outputs')
+        if os.path.exists(content_path):
+            logger.info(f'Copy {content_path} to {content_dst_path}')
+            copy_tree(content_path, content_dst_path)
 
 
-def create_compute_job(name, task_args):
+def create_compute_job(name, task_args, subtuple_key):
 
     kubernetes.config.load_incluster_config()
     k8s_client = kubernetes.client.BatchV1Api()
 
-    volumes_rw = [
-        {'name': name,
-         'persistentVolumeClaim': {'claimName': name}},
-    ]
+    volume_mounts, volumes = generate_volumes(task_args['volumes'], name, subtuple_key)
 
-    volume_mounts, volumes = generate_volumes(task_args['volumes'], name)
-
-    # Should be in a job as it will end
     container_compute = kubernetes.client.V1Container(
         name=name,
         image=task_args['image'],
@@ -643,13 +543,12 @@ def create_compute_job(name, task_args):
         # )
     )
 
-    # Create and configurate a spec section
     template = kubernetes.client.V1PodTemplateSpec(
         metadata=kubernetes.client.V1ObjectMeta(labels={'app': name}),
         spec=kubernetes.client.V1PodSpec(
             restart_policy='Never',
             containers=[container_compute],
-            volumes=volumes + volumes_rw
+            volumes=volumes
         )
     )
 
@@ -668,73 +567,6 @@ def create_compute_job(name, task_args):
     k8s_client.create_namespaced_job(body=job, namespace=NAMESPACE)
 
 
-def create_nginx(name):
-    create_nginx_pod(name)
-    create_nginx_service(name)
-
-
-def delete_nginx(name):
-    delete_pod(f'nginx-{name}')
-    delete_nginx_service(name)
-
-
-def create_nginx_pod(name):
-
-    kubernetes.config.load_incluster_config()
-    k8s_client = kubernetes.client.CoreV1Api()
-
-    volumes_rw = [
-        {'name': name,
-         'persistentVolumeClaim': {'claimName': name}},
-
-    ]
-
-    container_nginx = kubernetes.client.V1Container(
-        name=f'nginx-{name}',
-        image='nginx:1.17.10',
-        ports=[kubernetes.client.V1ContainerPort(container_port=80)],
-        volume_mounts=[
-            {'name': name,
-             'mountPath': '/usr/share/nginx/html/output_model',
-             'subPath': 'output_model',
-             'readOnly': True},
-            {'name': name,
-             'mountPath': '/usr/share/nginx/html/pred',
-             'subPath': 'pred',
-             'readOnly': True},
-            {'name': name,
-             'mountPath': '/usr/share/nginx/html/perf',
-             'subPath': 'perf',
-             'readOnly': True},
-        ]
-        # resources=kubernetes.client.V1ResourceRequirements(
-        #     requests={'cpu': '100m', 'memory': '200Mi'},
-        #     limits={'cpu': '500m', 'memory': '500Mi'}
-        # )
-    )
-
-    spec = kubernetes.client.V1PodSpec(
-        containers=[container_nginx],
-        volumes=volumes_rw
-    )
-
-    # Instantiate the pod object
-    pod = kubernetes.client.V1Pod(
-        api_version="v1",
-        kind="Pod",
-        metadata=kubernetes.client.V1ObjectMeta(name=f'nginx-{name}', labels={'app': f'nginx-{name}'}),
-        spec=spec
-    )
-
-    # Create pod
-    k8s_client.create_namespaced_pod(
-        body=pod,
-        namespace=NAMESPACE
-    )
-
-    print(f"Pod {name} created.")
-
-
 def delete_compute_job(name):
 
     if job_exists(name):
@@ -746,92 +578,12 @@ def delete_compute_job(name):
             namespace=NAMESPACE,
             body=kubernetes.client.V1DeleteOptions(
                 propagation_policy='Foreground',
-                grace_period_seconds=5
+                grace_period_seconds=0
             )
         )
 
     wait_for_job_deletion(name)
     logger.info(f'Compute Job {name} deleted.')
-
-
-def delete_pod(name):
-
-    if pod_exists(name):
-        kubernetes.config.load_incluster_config()
-        k8s_client = kubernetes.client.CoreV1Api()
-
-        api_response = k8s_client.delete_namespaced_pod(
-            name=name,
-            namespace=NAMESPACE,
-            body=kubernetes.client.V1DeleteOptions(
-                propagation_policy='Foreground',
-                grace_period_seconds=5
-            )
-        )
-
-    wait_for_pod_deletion(name)
-    logger.info(f"Pod {name} deleted.")
-
-    if api_response.status == 'Failure':
-        raise Exception(f'Failed to delete Pod {name}.')
-
-
-def create_nginx_service(name):
-    kubernetes.config.load_incluster_config()
-    k8s_client = kubernetes.client.CoreV1Api()
-
-    service = kubernetes.client.V1Service(
-        api_version="v1",
-        kind="Service",
-        metadata=kubernetes.client.V1ObjectMeta(name=f'nginx-{name}'),
-        spec=kubernetes.client.V1ServiceSpec(
-            type="ClusterIP",
-            ports=[kubernetes.client.V1ServicePort(name="http", protocol="TCP", port=80, target_port=80)],
-            selector={'app': f'nginx-{name}'}
-        )
-    )
-
-    k8s_client.create_namespaced_service(namespace=NAMESPACE, body=service)
-
-    logger.info(f'Service nginx-{name} created.')
-
-
-def service_exists(name):
-    kubernetes.config.load_incluster_config()
-    k8s_client = kubernetes.client.CoreV1Api()
-
-    try:
-        k8s_client.read_namespaced_service(
-            name=name,
-            namespace=NAMESPACE)
-    except Exception:
-        return False
-    else:
-        return True
-
-
-def wait_for_service_deletion(name):
-    while service_exists(name):
-        time.sleep(5)
-
-
-def delete_nginx_service(name):
-
-    if service_exists(name):
-        kubernetes.config.load_incluster_config()
-        k8s_client = kubernetes.client.CoreV1Api()
-
-        k8s_client.delete_namespaced_service(
-            name=name,
-            namespace=NAMESPACE,
-            body=kubernetes.client.V1DeleteOptions(
-                propagation_policy='Foreground',
-                grace_period_seconds=5
-            )
-        )
-
-    wait_for_service_deletion(name)
-    logger.info(f'Service nginx-{name} deleted.')
 
 
 def create_volume(name):
@@ -885,9 +637,72 @@ def delete_volume(name):
             namespace=NAMESPACE,
             body=kubernetes.client.V1DeleteOptions(
                 propagation_policy='Foreground',
-                grace_period_seconds=5
+                grace_period_seconds=0
             )
         )
 
     wait_for_pvc_deletion(name)
     logger.info(f'PVC {name} deleted.')
+
+
+def clean_outputs(subtuple_key):
+
+    kubernetes.config.load_incluster_config()
+    k8s_client = kubernetes.client.BatchV1Api()
+    job_name = f'clean-outputs-{subtuple_key[:10]}'
+
+    container = kubernetes.client.V1Container(
+        name=job_name,
+        image='busybox',
+        args=['rm',
+              '-rf',
+              f'/clean/{subtuple_key}'],
+        volume_mounts=[
+            {'name': 'outputs',
+             'mountPath': f'/clean',
+             'subPath': subtuple_key},
+
+        ]
+    )
+
+    template = kubernetes.client.V1PodTemplateSpec(
+        metadata=kubernetes.client.V1ObjectMeta(labels={'app': job_name}),
+        spec=kubernetes.client.V1PodSpec(
+            restart_policy='Never',
+            containers=[container],
+            volumes=[
+                {
+                    'name': 'outputs',
+                    'persistentVolumeClaim': {'claimName': K8S_PVC['OUTPUTS_PVC']}
+                },
+            ]
+        )
+    )
+
+    spec = kubernetes.client.V1JobSpec(
+        template=template,
+        backoff_limit=4
+    )
+
+    job = kubernetes.client.V1Job(
+        api_version='batch/v1',
+        kind='Job',
+        metadata=kubernetes.client.V1ObjectMeta(name=job_name),
+        spec=spec
+    )
+
+    k8s_client.create_namespaced_job(body=job, namespace=NAMESPACE)
+
+    try:
+        watch_job(job_name)
+    except Exception as e:
+        logger.error(f'Cleaning failed, error: {e}')
+    finally:
+        k8s_client.delete_namespaced_job(
+            name=job_name,
+            namespace=NAMESPACE,
+            body=kubernetes.client.V1DeleteOptions(
+                propagation_policy='Foreground',
+                grace_period_seconds=5
+            )
+        )

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -180,7 +180,8 @@ def k8s_build_image(path, tag, rm):
     k8s_client = kubernetes.client.BatchV1Api()
 
     dockerfile_fullpath = os.path.join(path, 'Dockerfile')
-    dockerfile_mount_subpath = os.path.basename(path)
+
+    dockerfile_mount_subpath = path.split('/subtuple/')[-1]
 
     container = kubernetes.client.V1Container(
         name="kaniko",

--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -654,7 +654,7 @@ def _do_task(subtuple_directory, tuple_type, subtuple, compute_plan_id, rank, or
         if tag and TAG_VALUE_FOR_TRANSFER_BUCKET in tag:
             environment['TESTTUPLE_TAG'] = TAG_VALUE_FOR_TRANSFER_BUCKET
 
-    job_name = f'{tuple_type}_{subtuple["key"][0:8]}_{TUPLE_COMMANDS[tuple_type]}'
+    job_name = f'{tuple_type}-{subtuple["key"][0:8]}-{TUPLE_COMMANDS[tuple_type]}'.lower()
     command = generate_command(tuple_type, subtuple, rank)
 
     compute_job(
@@ -683,7 +683,7 @@ def _do_task(subtuple_directory, tuple_type, subtuple, compute_plan_id, rank, or
         compute_job(
             dockerfile_path=f'{subtuple_directory}/metrics',
             image_name=f'substra/metrics_{subtuple["key"][0:8]}'.lower(),
-            job_name=f'{tuple_type}_{subtuple["key"][0:8]}_eval',
+            job_name=f'{tuple_type}-{subtuple["key"][0:8]}-eval'.lower(),
             volumes=common_volumes,
             command=f'--output-perf-path {OUTPUT_PERF_PATH}',
             remove_image=not(settings.TASK['CACHE_DOCKER_IMAGES']),

--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -48,6 +48,7 @@ TUPLE_COMMANDS = {
 
 MODEL_FOLDER = '/sandbox/model'
 OUTPUT_MODEL_FOLDER = '/sandbox/output_model'
+OUTPUT_PERF_PATH = '/sandbox/perf/perf.json'
 OUTPUT_HEAD_MODEL_FILENAME = 'head_model'
 OUTPUT_TRUNK_MODEL_FILENAME = 'trunk_model'
 
@@ -395,7 +396,7 @@ def build_subtuple_folders(subtuple):
     subtuple_directory = get_subtuple_directory(subtuple)
     create_directory(subtuple_directory)
 
-    for folder in ['opener', 'data', 'model', 'output_model', 'pred', 'metrics', 'export']:
+    for folder in ['opener', 'data', 'model', 'output_model', 'pred', 'perf', 'metrics', 'export']:
         create_directory(path.join(subtuple_directory, folder))
 
     return subtuple_directory
@@ -675,12 +676,16 @@ def _do_task(subtuple_directory, tuple_type, subtuple, compute_plan_id, rank, or
     # Evaluation
     if tuple_type == TESTTUPLE_TYPE:
 
+        # We set pred folder to ro during evalutation
+        pred_path = path.join(subtuple_directory, 'pred')
+        common_volumes[pred_path]['mode'] = 'ro'
+
         compute_job(
             dockerfile_path=f'{subtuple_directory}/metrics',
             image_name=f'substra/metrics_{subtuple["key"][0:8]}'.lower(),
             job_name=f'{tuple_type}_{subtuple["key"][0:8]}_eval',
             volumes=common_volumes,
-            command=None,
+            command=f'--output-perf-path {OUTPUT_PERF_PATH}',
             remove_image=not(settings.TASK['CACHE_DOCKER_IMAGES']),
             remove_container=settings.TASK['CLEAN_EXECUTION_ENVIRONMENT'],
             capture_logs=settings.TASK['CAPTURE_LOGS'],
@@ -689,15 +694,16 @@ def _do_task(subtuple_directory, tuple_type, subtuple, compute_plan_id, rank, or
 
         pred_path = path.join(subtuple_directory, 'pred')
         export_path = path.join(subtuple_directory, 'export')
+        perf_path = path.join(subtuple_directory, 'perf')
 
         # load performance
-        with open(path.join(pred_path, 'perf.json'), 'r') as perf_file:
+        with open(path.join(perf_path, 'perf.json'), 'r') as perf_file:
             perf = json.load(perf_file)
 
         result['global_perf'] = perf['all']
 
         if tag and TAG_VALUE_FOR_TRANSFER_BUCKET in tag:
-            transfer_to_bucket(subtuple['key'], [pred_path, export_path])
+            transfer_to_bucket(subtuple['key'], [pred_path, perf_path, export_path])
 
     return result
 
@@ -708,6 +714,7 @@ def prepare_volumes(subtuple_directory, tuple_type, compute_plan_id, compute_pla
     output_model_path = path.join(subtuple_directory, 'output_model')
     pred_path = path.join(subtuple_directory, 'pred')
     export_path = path.join(subtuple_directory, 'export')
+    perf_path = path.join(subtuple_directory, 'perf')
     opener_path = path.join(subtuple_directory, 'opener')
 
     symlinks_volume = {}
@@ -730,11 +737,11 @@ def prepare_volumes(subtuple_directory, tuple_type, compute_plan_id, compute_pla
     if tuple_type == TESTTUPLE_TYPE:
         volumes[pred_path] = {'bind': '/sandbox/pred', 'mode': 'rw'}
         volumes[export_path] = {'bind': '/sandbox/export', 'mode': 'rw'}
+        volumes[perf_path] = {'bind': '/sandbox/perf', 'mode': 'rw'}
 
     model_volume = {
         model_path: {'bind': MODEL_FOLDER, 'mode': 'ro'},
         output_model_path: {'bind': OUTPUT_MODEL_FOLDER, 'mode': 'rw'}
-
     }
 
     # local volume for train like tuples in compute plan

--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -47,6 +47,7 @@ TUPLE_COMMANDS = {
 }
 
 MODEL_FOLDER = '/sandbox/model'
+OUTPUT_MODEL_FOLDER = '/sandbox/output_model'
 OUTPUT_HEAD_MODEL_FILENAME = 'head_model'
 OUTPUT_TRUNK_MODEL_FILENAME = 'trunk_model'
 
@@ -349,7 +350,7 @@ def prepare_opener(directory, tuple_):
     if get_hash(datamanager.data_opener.path) != data_opener_hash:
         raise Exception('DataOpener Hash in Subtuple is not the same as in local db')
 
-    opener_dst_path = path.join(directory, 'opener/opener.py')
+    opener_dst_path = path.join(directory, 'opener/__init__.py')
     if not os.path.exists(opener_dst_path):
         os.symlink(datamanager.data_opener.path, opener_dst_path)
     else:
@@ -394,7 +395,7 @@ def build_subtuple_folders(subtuple):
     subtuple_directory = get_subtuple_directory(subtuple)
     create_directory(subtuple_directory)
 
-    for folder in ['opener', 'data', 'model', 'pred', 'metrics', 'export']:
+    for folder in ['opener', 'data', 'model', 'output_model', 'pred', 'metrics', 'export']:
         create_directory(path.join(subtuple_directory, folder))
 
     return subtuple_directory
@@ -704,8 +705,10 @@ def _do_task(subtuple_directory, tuple_type, subtuple, compute_plan_id, rank, or
 def prepare_volumes(subtuple_directory, tuple_type, compute_plan_id, compute_plan_tag):
 
     model_path = path.join(subtuple_directory, 'model')
+    output_model_path = path.join(subtuple_directory, 'output_model')
     pred_path = path.join(subtuple_directory, 'pred')
     export_path = path.join(subtuple_directory, 'export')
+    opener_path = path.join(subtuple_directory, 'opener')
 
     symlinks_volume = {}
     data_path = path.join(subtuple_directory, 'data')
@@ -719,10 +722,9 @@ def prepare_volumes(subtuple_directory, tuple_type, compute_plan_id, compute_pla
             if real_path != os.path.join(subtuple_directory, subtuple_folder, subitem):
                 symlinks_volume[real_path] = {'bind': f'{real_path}', 'mode': 'ro'}
 
-    opener_file = path.join(subtuple_directory, 'opener/opener.py')
     volumes = {
         data_path: {'bind': '/sandbox/data', 'mode': 'ro'},
-        opener_file: {'bind': '/sandbox/opener/__init__.py', 'mode': 'ro'}
+        opener_path: {'bind': '/sandbox/opener', 'mode': 'ro'}
     }
 
     if tuple_type == TESTTUPLE_TYPE:
@@ -730,7 +732,9 @@ def prepare_volumes(subtuple_directory, tuple_type, compute_plan_id, compute_pla
         volumes[export_path] = {'bind': '/sandbox/export', 'mode': 'rw'}
 
     model_volume = {
-        model_path: {'bind': MODEL_FOLDER, 'mode': 'rw'}
+        model_path: {'bind': MODEL_FOLDER, 'mode': 'ro'},
+        output_model_path: {'bind': OUTPUT_MODEL_FOLDER, 'mode': 'rw'}
+
     }
 
     # local volume for train like tuples in compute plan
@@ -826,6 +830,8 @@ def generate_command(tuple_type, subtuple, rank):
             in_traintuple_keys = [subtuple_model["traintupleKey"] for subtuple_model in subtuple['inModels']]
             command = f"{command} {' '.join(in_traintuple_keys)}"
 
+        command = f"{command} --output-model-path {OUTPUT_MODEL_FOLDER}/model"
+
         if rank is not None:
             command = f"{command} --rank {rank}"
 
@@ -842,7 +848,7 @@ def generate_command(tuple_type, subtuple, rank):
 
     elif tuple_type == COMPOSITE_TRAINTUPLE_TYPE:
 
-        command = f"{command} --output-models-path {MODEL_FOLDER}"
+        command = f"{command} --output-models-path {OUTPUT_MODEL_FOLDER}"
         command = f"{command} --output-head-model-filename {OUTPUT_HEAD_MODEL_FILENAME}"
         command = f"{command} --output-trunk-model-filename {OUTPUT_TRUNK_MODEL_FILENAME}"
 
@@ -865,6 +871,8 @@ def generate_command(tuple_type, subtuple, rank):
         if subtuple['inModels'] is not None:
             in_aggregatetuple_keys = [subtuple_model["traintupleKey"] for subtuple_model in subtuple['inModels']]
             command = f"{command} {' '.join(in_aggregatetuple_keys)}"
+
+        command = f"{command} --output-model-path {OUTPUT_MODEL_FOLDER}/model"
 
         if rank is not None:
             command = f"{command} --rank {rank}"
@@ -943,7 +951,7 @@ def extract_result_from_models(tuple_type, models):
 def save_model(subtuple_directory, subtuple_key, filename='model'):
     from substrapp.models import Model
 
-    end_model_path = path.join(subtuple_directory, f'model/{filename}')
+    end_model_path = path.join(subtuple_directory, f'output_model/{filename}')
     end_model_file_hash = get_hash(end_model_path, subtuple_key)
     instance = Model.objects.create(pkhash=end_model_file_hash, validated=True)
 

--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -760,11 +760,6 @@ def prepare_volumes(subtuple_directory, tuple_type, compute_plan_id, compute_pla
 
 
 # SHOULD BE MOVED IN K8S BACKEND
-def get_k8s_client():
-    kubernetes.config.load_incluster_config()
-    return kubernetes.client.CoreV1Api()
-
-
 def prepare_chainkeys(compute_plan_id, compute_plan_tag):
     chainkeys_directory = get_chainkeys_directory(compute_plan_id)
 
@@ -775,7 +770,9 @@ def prepare_chainkeys(compute_plan_id, compute_plan_tag):
     if not os.path.exists(chainkeys_directory):
         os.makedirs(chainkeys_directory)
 
-        k8s_client = get_k8s_client()
+        kubernetes.config.load_incluster_config()
+        k8s_client = kubernetes.client.CoreV1Api()
+
         secret_namespace = os.getenv('K8S_SECRET_NAMESPACE', 'default')
         label_selector = f'compute_plan={compute_plan_tag}'
 

--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -831,7 +831,7 @@ def prepare_chainkeys(compute_plan_id, compute_plan_tag, subtuple_directory):
 
     if settings.TASK['COMPUTE_BACKEND'] == 'k8s':
         copy_chainkeys_to_output_pvc(chainkeys_directory, subtuple_directory)
-        list_files(subtuple_directory.replace('subtuple', 'outputs'))
+        list_files(os.path.join(subtuple_directory.replace('subtuple', 'outputs'), 'chainkeys'))
 
     return chainkeys_volume
 

--- a/backend/substrapp/tasks/utils.py
+++ b/backend/substrapp/tasks/utils.py
@@ -325,7 +325,7 @@ def compute_job(dockerfile_path, image_name, job_name, volumes, command,
     try:
         ts = time.time()
         BACKEND[COMPUTE_BACKEND]['get_image'](image_name)
-    except docker.errors.ImageNotFound, ImageNotFound:
+    except (docker.errors.ImageNotFound, ImageNotFound):
         logger.info(f'ImageNotFound: {image_name}. Building it')
     else:
         logger.info(f'ImageFound: {image_name}. Use it')
@@ -341,7 +341,7 @@ def compute_job(dockerfile_path, image_name, job_name, volumes, command,
                 path=dockerfile_path,
                 tag=image_name,
                 rm=remove_image)
-        except docker.errors.BuildError, BuildError as e:
+        except (docker.errors.BuildError, BuildError) as e:
             if isinstance(e, docker.errors.BuildError):
                 # catch build errors and print them for easier debugging of failed build
                 lines = [line['stream'].strip() for line in e.build_log if 'stream' in line]

--- a/backend/substrapp/tasks/utils.py
+++ b/backend/substrapp/tasks/utils.py
@@ -319,6 +319,9 @@ def compute_job(dockerfile_path, image_name, job_name, volumes, command,
 
     raise_if_no_dockerfile(dockerfile_path)
 
+    # improve that to pass real tuple key instead of retrieving it
+    subtuple_key = dockerfile_path.split('/subtuple/')[-1]
+
     build_image = True
 
     # Check if image already exist
@@ -373,7 +376,8 @@ def compute_job(dockerfile_path, image_name, job_name, volumes, command,
         capture_logs,
         environment,
         gpu_set,
-        remove_image
+        remove_image,
+        subtuple_key
     )
 
 

--- a/backend/substrapp/tasks/utils.py
+++ b/backend/substrapp/tasks/utils.py
@@ -343,7 +343,7 @@ def compute_job(subtuple_key, dockerfile_path, image_name, job_name, volumes, co
             logger.error(f'BuildError: {error}')
             raise
         else:
-            logger.info(f'BuildSuccess - {image_name} - keep cache : {remove_image}')
+            logger.info(f'BuildSuccess - {image_name} - keep cache : {not remove_image}')
             elaps = (time.time() - ts) * 1000
             logger.info(f'{COMPUTE_BACKEND} build image - elaps={elaps:.2f}ms')
 

--- a/backend/substrapp/tasks/utils.py
+++ b/backend/substrapp/tasks/utils.py
@@ -374,7 +374,7 @@ def compute_job(dockerfile_path, image_name, job_name, volumes, command,
         environment,
         gpu_set,
         remove_image,
-        subtuple_directory=dockerfile_path
+        subtuple_directory=dockerfile_path.replace('/metrics', '')  # in case of testtuple eval // DIRTY
     )
 
 

--- a/backend/substrapp/tasks/utils.py
+++ b/backend/substrapp/tasks/utils.py
@@ -40,7 +40,7 @@ BACKEND = {
         'build_image': docker_build_image,
         'local_volume': docker_get_or_create_local_volume,
         'rm_local_volume': docker_remove_local_volume,
-        'rm_image': docker_remove_image,
+        'remove_image': docker_remove_image,
         'compute': docker_compute,
     },
 
@@ -54,7 +54,7 @@ BACKEND = {
         'build_image': k8s_build_image,
         'local_volume': k8s_get_or_create_local_volume,
         'rm_local_volume': k8s_remove_local_volume,
-        'rm_image': k8s_remove_image,
+        'remove_image': k8s_remove_image,
         'compute': k8s_compute,
     },
 

--- a/backend/substrapp/tasks/utils.py
+++ b/backend/substrapp/tasks/utils.py
@@ -10,15 +10,53 @@ from django.conf import settings
 from requests.auth import HTTPBasicAuth
 from substrapp.utils import get_owner, get_remote_file_content, get_and_put_remote_file_content, NodeError
 
-from kubernetes import client, config
+from substrapp.tasks.docker_backend import (
+    docker_memory_limit, docker_cpu_count, docker_cpu_used, docker_gpu_list, docker_gpu_used, docker_get_image,
+    docker_build_image, docker_remove_local_volume, docker_get_or_create_local_volume, docker_remove_image,
+    docker_compute)
+from substrapp.tasks.k8s_backend import (
+    k8s_memory_limit, k8s_cpu_count, k8s_cpu_used, k8s_gpu_list, k8s_gpu_used, k8s_get_image, k8s_build_image,
+    k8s_remove_local_volume, k8s_get_or_create_local_volume, k8s_remove_image, k8s_compute)
 
 CELERYWORKER_IMAGE = os.environ.get('CELERYWORKER_IMAGE', 'substrafoundation/celeryworker:latest')
 CELERY_WORKER_CONCURRENCY = int(getattr(settings, 'CELERY_WORKER_CONCURRENCY'))
-DOCKER_LABEL = 'substra_task'
+TASK_LABEL = 'substra_task'
+COMPUTE_BACKEND = settings.TASK['COMPUTE_BACKEND']
 
 logger = logging.getLogger(__name__)
 
 import time
+
+BACKEND = {
+    'docker': {
+        'get_memory': docker_memory_limit,
+        'get_cpu': docker_cpu_count,
+        'get_cpu_used': docker_cpu_used,
+        'get_gpu': docker_gpu_list,
+        'get_gpu_used': docker_gpu_used,
+        'get_image': docker_get_image,
+        'build_image': docker_build_image,
+        'local_volume': docker_get_or_create_local_volume,
+        'rm_local_volume': docker_remove_local_volume,
+        'rm_image': docker_remove_image,
+        'compute': docker_compute,
+    },
+
+    'k8s': {
+        'get_memory': k8s_memory_limit,
+        'get_cpu': k8s_cpu_count,
+        'get_cpu_used': k8s_cpu_used,
+        'get_gpu': k8s_gpu_list,
+        'get_gpu_used': k8s_gpu_used,
+        'get_image': k8s_get_image,
+        'build_image': k8s_build_image,
+        'local_volume': k8s_get_or_create_local_volume,
+        'rm_local_volume': k8s_remove_local_volume,
+        'rm_image': k8s_remove_image,
+        'compute': k8s_compute,
+    },
+
+}
 
 
 def timeit(function):
@@ -64,38 +102,14 @@ def local_memory_limit():
         return int(check_output(['sysctl', '-n', 'hw.memsize']).strip()) // CELERY_WORKER_CONCURRENCY
 
 
-def docker_memory_limit():
-    docker_client = docker.from_env()
-    # Get memory limit from docker container through the API
-    # Because the docker execution may be remote
-
-    cmd = f'python3 -u -c "import os; print(int(os.sysconf("SC_PAGE_SIZE") '\
-          f'* os.sysconf("SC_PHYS_PAGES") / (1024. ** 2)) // {CELERY_WORKER_CONCURRENCY}), flush=True, end=\'\')"'
-
-    task_args = {
-        'image': CELERYWORKER_IMAGE,
-        'command': cmd,
-        'detach': False,
-        'stdout': True,
-        'stderr': True,
-        'auto_remove': False,
-        'remove': True,
-        'network_disabled': True,
-        'network_mode': 'none',
-        'privileged': False,
-        'cap_drop': ['ALL'],
-    }
-
-    memory_limit_bytes = docker_client.containers.run(**task_args)
-
-    return int(memory_limit_bytes)
-
-
 @timeit
-def get_memory_limit():
+def get_memory_limit(concurrency=None):
+
+    if concurrency is None:
+        concurrency = CELERY_WORKER_CONCURRENCY
 
     try:
-        memory_limit = docker_memory_limit()
+        memory_limit = BACKEND[COMPUTE_BACKEND]['get_memory'](concurrency, CELERYWORKER_IMAGE)
     except (docker.errors.ContainerError, docker.errors.ImageNotFound,
             docker.errors.APIError, ValueError):
         logger.info('[Warning] Cannot get memory limit from remote, get it from local.')
@@ -105,28 +119,12 @@ def get_memory_limit():
 
 
 @timeit
-def get_cpu_count(client):
-    # Get CPU count from docker container through the API
-    # Because the docker execution may be remote
-
-    task_args = {
-        'image': CELERYWORKER_IMAGE,
-        'command': 'python3 -u -c "import os; print(os.cpu_count(), flush=True)"',
-        'detach': False,
-        'stdout': True,
-        'stderr': True,
-        'auto_remove': False,
-        'remove': True,
-        'network_disabled': True,
-        'network_mode': 'none',
-        'privileged': False,
-        'cap_drop': ['ALL'],
-    }
+def get_cpu_count():
 
     cpu_count = os.cpu_count()
 
     try:
-        cpu_count_bytes = client.containers.run(**task_args).strip()
+        cpu_count_bytes = BACKEND[COMPUTE_BACKEND]['get_cpu'](CELERYWORKER_IMAGE)
     except (docker.errors.ContainerError, docker.errors.ImageNotFound, docker.errors.APIError):
         logger.info('[Warning] Cannot get cpu count from remote')
     else:
@@ -137,8 +135,12 @@ def get_cpu_count(client):
 
 
 @timeit
-def get_cpu_sets(client, concurrency):
-    cpu_count = get_cpu_count(client)
+def get_cpu_sets(concurrency=None):
+
+    if concurrency is None:
+        concurrency = CELERY_WORKER_CONCURRENCY
+
+    cpu_count = get_cpu_count()
     cpu_step = max(1, cpu_count // concurrency)
     cpu_sets = []
 
@@ -151,33 +153,12 @@ def get_cpu_sets(client, concurrency):
     return cpu_sets
 
 
-def get_gpu_list(client):
-    # Get GPU list from docker container through the API
-    # Because the docker execution may be remote
-    cmd = 'python3 -u -c "import GPUtil as gputil;import json;'\
-          'print(json.dumps([str(gpu.id) for gpu in gputil.getGPUs()]), flush=True, end=\'\')"'
-
-    task_args = {
-        'image': CELERYWORKER_IMAGE,
-        'command': cmd,
-        'detach': False,
-        'stdout': True,
-        'stderr': True,
-        'auto_remove': False,
-        'remove': True,
-        'network_disabled': True,
-        'network_mode': 'none',
-        'privileged': False,
-        'cap_drop': ['ALL'],
-        'environment': {'CUDA_DEVICE_ORDER': 'PCI_BUS_ID',
-                        'NVIDIA_VISIBLE_DEVICES': 'all'},
-        'runtime': 'nvidia'
-    }
+def get_gpu_list():
 
     gpu_list = []
 
     try:
-        gpu_list_bytes = client.containers.run(**task_args)
+        gpu_list_bytes = BACKEND[COMPUTE_BACKEND]['get_gpu'](CELERYWORKER_IMAGE)
     except (docker.errors.ContainerError, docker.errors.ImageNotFound, docker.errors.APIError):
         logger.info('[Warning] Cannot get nvidia gpu list from remote')
     else:
@@ -190,9 +171,12 @@ def get_gpu_list(client):
     return gpu_list
 
 
-def get_gpu_sets(client, concurrency):
+def get_gpu_sets(concurrency=None):
 
-    gpu_list = get_gpu_list(client)
+    if concurrency is None:
+        concurrency = CELERY_WORKER_CONCURRENCY
+
+    gpu_list = get_gpu_list()
 
     if gpu_list:
         gpu_count = len(gpu_list)
@@ -252,10 +236,8 @@ def filter_gpu_sets(used_gpu_sets, gpu_sets):
 
 def get_cpu_gpu_sets():
 
-    docker_client = docker.from_env()
-
-    cpu_sets = get_cpu_sets(docker_client, CELERY_WORKER_CONCURRENCY)
-    gpu_sets = get_gpu_sets(docker_client, CELERY_WORKER_CONCURRENCY)  # Can be None if no gpu
+    cpu_sets = get_cpu_sets()
+    gpu_sets = get_gpu_sets()  # Can be None if no gpu
 
     cpu_set = None
     gpu_set = None
@@ -263,20 +245,11 @@ def get_cpu_gpu_sets():
     while cpu_set is None:
 
         # Get ressources used
-        filters = {'status': 'running',
-                   'label': [DOCKER_LABEL]}
-
         try:
-            containers = [container.attrs
-                          for container in docker_client.containers.list(filters=filters)]
+            used_cpu_sets = BACKEND[COMPUTE_BACKEND]['get_cpu_used'](TASK_LABEL)
         except docker.errors.APIError as e:
             logger.error(e, exc_info=True)
             continue
-
-        # CPU
-        used_cpu_sets = [container['HostConfig']['CpusetCpus']
-                         for container in containers
-                         if container['HostConfig']['CpusetCpus']]
 
         cpu_sets_available = filter_cpu_sets(used_cpu_sets, cpu_sets)
 
@@ -285,29 +258,16 @@ def get_cpu_gpu_sets():
 
         # GPU
         if gpu_sets is not None:
-            env_containers = [container['Config']['Env']
-                              for container in containers]
-
-            used_gpu_sets = []
-
-            for env_list in env_containers:
-                nvidia_env_var = [s.split('=')[1]
-                                  for s in env_list if "NVIDIA_VISIBLE_DEVICES" in s]
-
-                used_gpu_sets.extend(nvidia_env_var)
-
-            gpu_sets_available = filter_gpu_sets(used_gpu_sets, gpu_sets)
-
-            if gpu_sets_available:
-                gpu_set = gpu_sets_available.pop()
+            try:
+                used_gpu_sets = BACKEND[COMPUTE_BACKEND]['get_gpu_used'](TASK_LABEL)
+            except docker.errors.APIError as e:
+                logger.error(e, exc_info=True)
+            else:
+                gpu_sets_available = filter_gpu_sets(used_gpu_sets, gpu_sets)
+                if gpu_sets_available:
+                    gpu_set = gpu_sets_available.pop()
 
     return cpu_set, gpu_set
-
-
-def container_format_log(container_name, container_logs):
-    logs = [f'[{container_name}] {log}' for log in container_logs.decode().split('\n')]
-    for log in logs:
-        logger.info(log)
 
 
 def list_files(startpath):
@@ -328,19 +288,43 @@ def list_files(startpath):
         logger.info(f'{startpath} does not exist.')
 
 
-def compute_docker(client, dockerfile_path, image_name, container_name, volumes, command,
-                   environment, remove_image=True, remove_container=True, capture_logs=True):
+def get_or_create_local_volume(volume_id):
+    return BACKEND[COMPUTE_BACKEND]['local_volume'](volume_id)
 
+
+def remove_local_volume(volume_id):
+    return BACKEND[COMPUTE_BACKEND]['rm_local_volume'](volume_id)
+
+
+def remove_image(image_name):
+    return BACKEND[COMPUTE_BACKEND]['remove_image'](image_name)
+
+
+def raise_if_no_dockerfile(dockerfile_path):
     dockerfile_fullpath = os.path.join(dockerfile_path, 'Dockerfile')
     if not os.path.exists(dockerfile_fullpath):
         raise Exception(f'Dockerfile does not exist : {dockerfile_fullpath}')
+
+
+def container_format_log(container_name, container_logs):
+    logs = [f'[{container_name}] {log}' for log in container_logs.decode().split('\n')]
+    for log in logs:
+        logger.info(log)
+
+
+def compute_job(dockerfile_path, image_name, job_name, volumes, command,
+                environment, remove_image=True, remove_container=True, capture_logs=True):
+
+    client = docker.from_env()
+
+    raise_if_no_dockerfile(dockerfile_path)
 
     build_image = True
 
     # Check if image already exist
     try:
         ts = time.time()
-        client.images.get(image_name)
+        BACKEND[COMPUTE_BACKEND]['get_image'](image_name)
     except docker.errors.ImageNotFound:
         logger.info(f'ImageNotFound: {image_name}. Building it')
     else:
@@ -353,9 +337,10 @@ def compute_docker(client, dockerfile_path, image_name, container_name, volumes,
     if build_image:
         try:
             ts = time.time()
-            client.images.build(path=dockerfile_path,
-                                tag=image_name,
-                                rm=remove_image)
+            BACKEND[COMPUTE_BACKEND]['build_image'](
+                path=dockerfile_path,
+                tag=image_name,
+                rm=remove_image)
         except docker.errors.BuildError as e:
             # catch build errors and print them for easier debugging of failed build
             lines = [line['stream'].strip() for line in e.build_log if 'stream' in line]
@@ -372,58 +357,21 @@ def compute_docker(client, dockerfile_path, image_name, container_name, volumes,
     memory_limit_mb = f'{get_memory_limit()}M'
     cpu_set, gpu_set = get_cpu_gpu_sets()    # blocking call
 
-    logger.info(f'Launch container {container_name} with {cpu_set} CPU - {gpu_set} GPU - {memory_limit_mb}.')
+    logger.info(f'Launch container {job_name} with {cpu_set} CPU - {gpu_set} GPU - {memory_limit_mb}.')
 
-    task_args = {
-        'image': image_name,
-        'name': container_name,
-        'cpuset_cpus': cpu_set,
-        'mem_limit': memory_limit_mb,
-        'command': command,
-        'volumes': volumes,
-        'shm_size': '8G',
-        'labels': [DOCKER_LABEL],
-        'detach': False,
-        'stdout': capture_logs,
-        'stderr': capture_logs,
-        'auto_remove': False,
-        'remove': False,
-        'network_disabled': True,
-        'network_mode': 'none',
-        'privileged': False,
-        'cap_drop': ['ALL'],
-        'environment': environment
-    }
-
-    if gpu_set is not None:
-        task_args['environment'].update({'NVIDIA_VISIBLE_DEVICES': gpu_set})
-        task_args['runtime'] = 'nvidia'
-
-    try:
-        ts = time.time()
-        client.containers.run(**task_args)
-    finally:
-        # we need to remove the containers to be able to remove the local
-        # volume in case of compute plan
-        container = client.containers.get(container_name)
-        if capture_logs:
-            container_format_log(
-                container_name,
-                container.logs()
-            )
-        container.remove()
-
-        # Remove images
-        if remove_image:
-            client.images.remove(image_name, force=True)
-
-        elaps = (time.time() - ts) * 1000
-        logger.info(f'client.images.run - elaps={elaps:.2f}ms')
-
-
-def get_k8s_client():
-    config.load_incluster_config()
-    return client.CoreV1Api()
+    BACKEND[COMPUTE_BACKEND]['compute'](
+        image_name,
+        job_name,
+        cpu_set,
+        memory_limit_mb,
+        command,
+        volumes,
+        TASK_LABEL,
+        capture_logs,
+        environment,
+        gpu_set,
+        remove_image
+    )
 
 
 def do_not_raise(fn):

--- a/backend/substrapp/tasks/utils.py
+++ b/backend/substrapp/tasks/utils.py
@@ -319,9 +319,6 @@ def compute_job(dockerfile_path, image_name, job_name, volumes, command,
 
     raise_if_no_dockerfile(dockerfile_path)
 
-    # improve that to pass real tuple key instead of retrieving it
-    subtuple_key = dockerfile_path.split('/subtuple/')[-1]
-
     build_image = True
 
     # Check if image already exist
@@ -377,7 +374,7 @@ def compute_job(dockerfile_path, image_name, job_name, volumes, command,
         environment,
         gpu_set,
         remove_image,
-        subtuple_key
+        subtuple_directory=dockerfile_path
     )
 
 

--- a/backend/substrapp/tasks/utils.py
+++ b/backend/substrapp/tasks/utils.py
@@ -8,7 +8,7 @@ import threading
 from subprocess import check_output
 from django.conf import settings
 from requests.auth import HTTPBasicAuth
-from substrapp.utils import get_owner, get_remote_file_content, get_and_put_remote_file_content, NodeError
+from substrapp.utils import get_owner, get_remote_file_content, get_and_put_remote_file_content, NodeError, timeit
 
 from substrapp.tasks.docker_backend import (
     docker_memory_limit, docker_cpu_count, docker_cpu_used, docker_gpu_list, docker_gpu_used, docker_get_image,
@@ -59,16 +59,6 @@ BACKEND = {
     },
 
 }
-
-
-def timeit(function):
-    def timed(*args, **kw):
-        ts = time.time()
-        result = function(*args, **kw)
-        elaps = (time.time() - ts) * 1000
-        logger.info(f'{function.__name__} - elaps={elaps:.2f}ms')
-        return result
-    return timed
 
 
 def authenticate_worker(node_id):
@@ -314,7 +304,8 @@ def container_format_log(container_name, container_logs):
         logger.info(log)
 
 
-def compute_job(dockerfile_path, image_name, job_name, volumes, command,
+@timeit
+def compute_job(subtuple_key, dockerfile_path, image_name, job_name, volumes, command,
                 environment, remove_image=True, remove_container=True, capture_logs=True):
 
     raise_if_no_dockerfile(dockerfile_path)
@@ -354,7 +345,7 @@ def compute_job(dockerfile_path, image_name, job_name, volumes, command,
         else:
             logger.info(f'BuildSuccess - {image_name} - keep cache : {remove_image}')
             elaps = (time.time() - ts) * 1000
-            logger.info(f'client.images.build - elaps={elaps:.2f}ms')
+            logger.info(f'{COMPUTE_BACKEND} build image - elaps={elaps:.2f}ms')
 
     # Limit ressources
     memory_limit_mb = f'{get_memory_limit()}M'
@@ -374,7 +365,7 @@ def compute_job(dockerfile_path, image_name, job_name, volumes, command,
         environment,
         gpu_set,
         remove_image,
-        subtuple_directory=dockerfile_path.replace('/metrics', '')  # in case of testtuple eval // DIRTY
+        subtuple_key=subtuple_key
     )
 
 

--- a/backend/substrapp/tests/tests_misc.py
+++ b/backend/substrapp/tests/tests_misc.py
@@ -10,7 +10,6 @@ from substrapp.ledger_utils import LedgerNotFound, LedgerInvalidResponse
 from substrapp.ledger_utils import get_object_from_ledger, log_fail_tuple, log_start_tuple, \
     log_success_tuple, query_tuples
 
-import docker
 import os
 
 
@@ -58,7 +57,7 @@ class MiscTests(TestCase):
             mget_cpu_count.return_value = cpu_count
             for concurrency in range(1, cpu_count + 1, 1):
                 self.assertEqual(concurrency,
-                                 len(get_cpu_sets(docker.from_env(), concurrency)))
+                                 len(get_cpu_sets(concurrency)))
 
     def test_gpu_sets(self):
         gpu_list = ['0', '1']
@@ -66,9 +65,9 @@ class MiscTests(TestCase):
             mget_gpu_list.return_value = gpu_list
             for concurrency in range(1, len(gpu_list) + 1, 1):
                 self.assertEqual(concurrency,
-                                 len(get_gpu_sets(docker.from_env(), concurrency)))
+                                 len(get_gpu_sets(concurrency)))
 
-        self.assertFalse(get_gpu_sets(docker.from_env(), concurrency))
+        self.assertFalse(get_gpu_sets(concurrency))
 
     def test_get_object_from_ledger(self):
         with patch('substrapp.ledger_utils.query_ledger') as mquery_ledger:

--- a/backend/substrapp/tests/tests_tasks.py
+++ b/backend/substrapp/tests/tests_tasks.py
@@ -35,6 +35,7 @@ from django.conf import settings
 settings_task = copy.deepcopy(settings.TASK)
 settings_task['COMPUTE_BACKEND'] = 'docker'
 
+
 # APITestCase
 @override_settings(MEDIA_ROOT=MEDIA_ROOT)
 @override_settings(CELERY_WORKER_CONCURRENCY=1)

--- a/backend/substrapp/tests/tests_tasks.py
+++ b/backend/substrapp/tests/tests_tasks.py
@@ -329,7 +329,7 @@ class TasksTests(APITestCase):
         hash_docker = uuid.uuid4().hex
         with self.mock_compute_backend:
             compute_job(
-                self.subtuple_path, 'test_compute_job_' + hash_docker,
+                'subtuple_key', self.subtuple_path, 'test_compute_job_' + hash_docker,
                 'test_compute_job_name_' + hash_docker, None, None, environment={}
             )
 

--- a/backend/substrapp/tests/tests_tasks.py
+++ b/backend/substrapp/tests/tests_tasks.py
@@ -172,7 +172,7 @@ class TasksTests(APITestCase):
             # test work
             prepare_opener(self.subtuple_path, {'dataset': {'openerHash': opener_hash}})
 
-            opener_path = os.path.join(opener_directory, 'opener.py')
+            opener_path = os.path.join(opener_directory, '__init__.py')
             self.assertTrue(os.path.exists(opener_path))
 
             # test corrupted
@@ -440,7 +440,7 @@ class TasksTests(APITestCase):
             with open(os.path.join(subtuple_directory, 'pred/perf.json'), 'w') as f:
                 f.write(f'{{"all": {perf}}}')
 
-            with open(os.path.join(subtuple_directory, 'model/model'), 'w') as f:
+            with open(os.path.join(subtuple_directory, 'output_model/model'), 'w') as f:
                 f.write("MODEL")
 
             with mock.patch('substrapp.tasks.tasks.compute_job') as mcompute_job:

--- a/backend/substrapp/tests/tests_tasks.py
+++ b/backend/substrapp/tests/tests_tasks.py
@@ -102,16 +102,16 @@ class TasksTests(APITestCase):
                 get_remote_file_content(remote_file, 'external_node_id', 'fake_pkhash')
 
     def test_resources(self):
+        with self.mock_compute_backend:
+            self.assertTrue(isinstance(get_memory_limit(), int))
 
-        self.assertTrue(isinstance(get_memory_limit(), int))
+            cpu_set, gpu_set = get_cpu_gpu_sets()
+            cpu_sets = get_cpu_sets()
+            self.assertIn(cpu_set, cpu_sets)
 
-        cpu_set, gpu_set = get_cpu_gpu_sets()
-        cpu_sets = get_cpu_sets()
-        self.assertIn(cpu_set, cpu_sets)
-
-        if gpu_set is not None:
-            gpu_sets = get_gpu_sets()
-            self.assertIn(gpu_set, gpu_sets)
+            if gpu_set is not None:
+                gpu_sets = get_gpu_sets()
+                self.assertIn(gpu_set, gpu_sets)
 
     def test_uncompress_content_tar(self):
         algo_content = self.algo.read()

--- a/backend/substrapp/utils.py
+++ b/backend/substrapp/utils.py
@@ -11,6 +11,7 @@ import requests
 import tarfile
 import zipfile
 import uuid
+import time
 
 from checksumdir import dirhash
 
@@ -264,3 +265,17 @@ def get_and_put_remote_file_content(url, auth, content_hash, content_dst_path, s
     computed_hash = get_hash(content_dst_path, key=salt)
     if computed_hash != content_hash:
         raise NodeError(f"url {url}: hash doesn't match {content_hash} vs {computed_hash}")
+
+
+def get_subtuple_directory(subtuple_key):
+    return path.join(getattr(settings, 'MEDIA_ROOT'), 'subtuple', subtuple_key)
+
+
+def timeit(function):
+    def timed(*args, **kw):
+        ts = time.time()
+        result = function(*args, **kw)
+        elaps = (time.time() - ts) * 1000
+        logger.info(f'{function.__name__} - elaps={elaps:.2f}ms')
+        return result
+    return timed

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-backend
 home: https://substra.org/
-version: 1.0.0-alpha.31
+version: 1.0.0-alpha.32
 description: Main package for Substra
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/substra-backend/requirements.lock
+++ b/charts/substra-backend/requirements.lock
@@ -5,5 +5,8 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 8.10.5
-digest: sha256:a32edfcb2781ef841a28fa1725562e2a180e9bb96225c908c1e68a5404748b12
-generated: "2020-06-05T17:46:30.053799+02:00"
+- name: docker-registry
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 1.9.2
+digest: sha256:64aac206900eb10b6099efc2fb5d6f0a41975fb211c778f5c61108d5675eaa47
+generated: "2020-06-09T15:23:33.702043+02:00"

--- a/charts/substra-backend/requirements.yaml
+++ b/charts/substra-backend/requirements.yaml
@@ -7,3 +7,7 @@ dependencies:
     repository:  https://charts.bitnami.com/bitnami
     version: 8.10.5
     condition: postgresql.enabled
+  - name: docker-registry
+    repository: https://kubernetes-charts.storage.googleapis.com/
+    version: 1.9.2
+    condition: docker-registry.enabled

--- a/charts/substra-backend/templates/deployment-server.yaml
+++ b/charts/substra-backend/templates/deployment-server.yaml
@@ -62,7 +62,7 @@ spec:
           - name: LEDGER_CONFIG_FILE
             value: /conf/{{ .Values.organization.name }}/substra-backend/conf.json
           - name: MEDIA_ROOT
-            value: {{ .Values.persistence.hostPath }}/medias/
+            value: /var/substra/medias/
           - name: PYTHONUNBUFFERED
             value: "1"
           - name: GZIP_MODELS
@@ -81,11 +81,11 @@ spec:
         volumeMounts:
           {{- range .Values.persistence.volumes }}
           - name: data-{{ .name }}
-            mountPath: {{ $.Values.persistence.hostPath }}/medias/{{ .name }}
+            mountPath: /var/substra/medias/{{ .name }}
             readOnly: {{ .readOnly.server }}
           {{- end }}
           - name: data-servermedias
-            mountPath: {{ $.Values.persistence.hostPath }}/servermedias
+            mountPath: /var/substra/servermedias
             readOnly: true
           - name: statics
             mountPath: /usr/src/app/backend/statics

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -82,8 +82,12 @@ spec:
             - name: REQUESTS_CA_BUNDLE
               value: /etc/ssl/certs/ca-certificates.crt
             {{- end }}
-            - name: SUBTUPLE_PVC
-              value: {{ include "substra.fullname" $ }}-subtuple
+            {{- range .Values.persistence.volumes }}
+            - name: {{ .name | upper }}_PVC
+              value: {{ include "substra.fullname" $ }}-{{ .name }}
+            {{- end }}
+            - name: SERVERMEDIAS_PVC
+              value: {{ template "substra.fullname" $ }}-servermedias
             - name: REGISTRY
               value: {{ .Release.Name }}-docker-registry
             - name: NAMESPACE

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -74,7 +74,7 @@ spec:
             - name: LEDGER_CONFIG_FILE
               value: /conf/{{ .Values.organization.name }}/substra-backend/conf.json
             - name: MEDIA_ROOT
-              value: {{ .Values.persistence.hostPath }}/medias/
+              value: /var/substra/medias/
             - name: PYTHONUNBUFFERED
               value: "1"
             - name: "CELERYWORKER_IMAGE"
@@ -118,11 +118,11 @@ spec:
             {{- end }}
             {{- range .Values.persistence.volumes }}
             - name: data-{{ .name }}
-              mountPath: {{ $.Values.persistence.hostPath }}/medias/{{ .name }}
+              mountPath: /var/substra/medias/{{ .name }}
               readOnly: {{ .readOnly.worker }}
             {{- end }}
             - name: data-servermedias
-              mountPath: {{ $.Values.persistence.hostPath }}/servermedias
+              mountPath: /var/substra/servermedias
               readOnly: true
             - name: config
               mountPath: /conf/{{ .Values.organization.name }}/substra-backend

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -19,6 +19,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "substra.name" . }}-worker
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: substra-worker
     spec:
       # Run the worker on the same pod as the server.
       # That's necessary because the worker and the server use the same PV.

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -89,8 +89,17 @@ spec:
             {{- end }}
             - name: SERVERMEDIAS_PVC
               value: {{ template "substra.fullname" $ }}-servermedias
+            {{- if .Values.registry.local }}
             - name: REGISTRY
-              value: {{ .Release.Name }}-docker-registry
+              value: {{ .Release.Name }}-docker-registry:5000
+            {{ else }}
+            - name: REGISTRY
+              value: {{ .Values.registry.host}}:{{ .Values.registry.port}}
+            {{ end }}
+            - name: REGISTRY_SCHEME
+              value: {{ .Values.registry.scheme}}
+            - name: REGISTRY_PULL_DOMAIN
+              value: {{ .Values.registry.pullDomain}}
             - name: NAMESPACE
               value: {{ .Release.Namespace }}
             - name: DOCKER_CACHE_PVC

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -82,7 +82,7 @@ spec:
             - name: REQUESTS_CA_BUNDLE
               value: /etc/ssl/certs/ca-certificates.crt
             {{- end }}
-            - name: DOCKERFILES_PVC
+            - name: SUBTUPLE_PVC
               value: {{ include "substra.fullname" $ }}-subtuple
             - name: REGISTRY
               value: {{ .Release.Name }}-docker-registry

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -112,8 +112,10 @@ spec:
 {{ toYaml . | indent 12 }}
           {{- end }}
           volumeMounts:
+            {{- if .Values.backend.dockerSocket.enabled }}
             - name: dockersocket
               mountPath: /var/run/docker.sock
+            {{- end }}
             {{- range .Values.persistence.volumes }}
             - name: data-{{ .name }}
               mountPath: {{ $.Values.persistence.hostPath }}/medias/{{ .name }}
@@ -143,9 +145,11 @@ spec:
           resources:
             {{- toYaml .Values.celeryworker.resources | nindent 12 }}
       volumes:
+      {{- if .Values.backend.dockerSocket.enabled }}
       - name: dockersocket
         hostPath:
-          path: /var/run/docker.sock
+          path: {{ .Values.backend.dockerSocket.hostPath }}
+      {{ end }}
       {{- range .Values.persistence.volumes }}
       - name: data-{{ .name }}
         persistentVolumeClaim:

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -82,6 +82,14 @@ spec:
             - name: REQUESTS_CA_BUNDLE
               value: /etc/ssl/certs/ca-certificates.crt
             {{- end }}
+            - name: DOCKERFILES_PVC
+              value: {{ include "substra.fullname" $ }}-subtuple
+            - name: REGISTRY
+              value: {{ .Release.Name }}-docker-registry
+            - name: NAMESPACE
+              value: {{ .Release.Namespace }}
+            - name: DOCKER_CACHE_PVC
+              value: {{ include "substra.fullname" $ }}-docker-cache
           {{- with .Values.extraEnv }}
 {{ toYaml . | indent 12 }}
           {{- end }}

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -104,6 +104,10 @@ spec:
               value: {{ .Release.Namespace }}
             - name: DOCKER_CACHE_PVC
               value: {{ include "substra.fullname" $ }}-docker-cache
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           {{- with .Values.extraEnv }}
 {{ toYaml . | indent 12 }}
           {{- end }}

--- a/charts/substra-backend/templates/job-kaniko-warmer.yaml
+++ b/charts/substra-backend/templates/job-kaniko-warmer.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "substra.fullname" . }}-kaniko-cache-warmer
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ template "substra.name" . }}-kaniko-cache-warmer
+    app.kubernetes.io/part-of: {{ template "substra.name" . }}
+spec:
+  template:
+    spec:
+      containers:
+      - name: kaniko-cache-warmer
+        image: gcr.io/kaniko-project/warmer:latest
+        args:
+        - "--cache-dir=/cache"
+        {{- range .Values.prePulledImages }}
+        - "--image={{ . }}"
+        {{- end }}
+        volumeMounts:
+        - name: kaniko-cache
+          mountPath: /cache
+          readOnly: False
+      restartPolicy: Never
+      volumes:
+      - name: kaniko-cache
+        persistentVolumeClaim:
+          claimName: {{ include "substra.fullname" $ }}-docker-cache
+  backoffLimit: 4

--- a/charts/substra-backend/templates/network-task-deny-all.yaml
+++ b/charts/substra-backend/templates/network-task-deny-all.yaml
@@ -1,0 +1,13 @@
+# Deny ALL networking in launched substra ml task
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "substra.fullname". }}-deny-ingress
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      task: substra_task  # TASK_LABEL
+  policyTypes:
+  - Ingress
+  - Egress

--- a/charts/substra-backend/templates/rbac.yaml
+++ b/charts/substra-backend/templates/rbac.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "substra.fullname" . }}-worker
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -11,10 +12,11 @@ metadata:
     app.kubernetes.io/name: {{ template "substra.name" . }}
     app.kubernetes.io/part-of: {{ template "substra.name" . }}
 ---
-kind: Role
+kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "substra.fullname" . }}-worker
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -31,11 +33,15 @@ rules:
   - apiGroups: ["batch", "extensions"]
     resources: ["jobs"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  ---
-kind: RoleBinding
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "substra.fullname" . }}-worker
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -45,8 +51,10 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "substra.fullname" . }}-worker
+    namespace: {{ .Release.Namespace }}
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: {{ template "substra.fullname" . }}-worker
+  namespace: {{ .Release.Namespace }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/substra-backend/templates/rbac.yaml
+++ b/charts/substra-backend/templates/rbac.yaml
@@ -25,7 +25,13 @@ rules:
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "watch", "list", "create", "update", "patch"]
----
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["batch", "extensions"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/charts/substra-backend/templates/rbac.yaml
+++ b/charts/substra-backend/templates/rbac.yaml
@@ -28,7 +28,7 @@ rules:
     resources: ["secrets"]
     verbs: ["get", "watch", "list", "create", "update", "patch"]
   - apiGroups: [""]
-    resources: ["pods"]
+    resources: ["pods", "pods/log"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["batch", "extensions"]
     resources: ["jobs"]

--- a/charts/substra-backend/templates/rbac.yaml
+++ b/charts/substra-backend/templates/rbac.yaml
@@ -28,7 +28,7 @@ rules:
     resources: ["secrets"]
     verbs: ["get", "watch", "list", "create", "update", "patch"]
   - apiGroups: [""]
-    resources: ["pods", "pods/log"]
+    resources: ["pods", "pods/log", "pods/status"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["batch", "extensions"]
     resources: ["jobs"]

--- a/charts/substra-backend/templates/storage.yaml
+++ b/charts/substra-backend/templates/storage.yaml
@@ -5,12 +5,12 @@ apiVersion: v1
 metadata:
   name: {{ template "substra.fullname" $ }}-{{ .name }}
 spec:
-  storageClassName: ""
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
       storage: {{ .size | quote }}
+  {{- if $.Values.persistence.hostPath }}
   selector:
     matchLabels:
       app.kubernetes.io/managed-by: {{ $.Release.Service }}
@@ -18,7 +18,11 @@ spec:
       helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
       app.kubernetes.io/name: {{ template "substra.name" $ }}-{{ .name }}
       app.kubernetes.io/part-of: {{ template "substra.name" $ }}-{{ .name }}
+  {{- else if $.Values.persistence.storageClassName }}
+  storageClassName: {{ $.Values.persistence.storageClassName }}
+  {{- end }}
 ---
+{{- if $.Values.persistence.hostPath }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -43,18 +47,19 @@ spec:
     path: {{ $.Values.persistence.hostPath }}/medias/{{ .name }}
     type: DirectoryOrCreate
 {{- end }}
+{{- end }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "substra.fullname" $ }}-servermedias
 spec:
-  storageClassName: ""
   accessModes:
     - ReadOnlyMany
   resources:
     requests:
       storage: {{ $.Values.persistence.size | quote }}
+  {{- if $.Values.persistence.hostPath }}
   selector:
     matchLabels:
       app.kubernetes.io/managed-by: {{ $.Release.Service }}
@@ -62,7 +67,11 @@ spec:
       helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
       app.kubernetes.io/name: {{ template "substra.name" $ }}-servermedias
       app.kubernetes.io/part-of: {{ template "substra.name" $ }}-servermedias
+  {{- else if $.Values.persistence.storageClassName }}
+  storageClassName: {{ $.Values.persistence.storageClassName }}
+  {{- end }}
 ---
+{{- if $.Values.persistence.hostPath }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -86,6 +95,7 @@ spec:
   hostPath:
     path: {{ $.Values.persistence.hostPath }}/servermedias
     type: DirectoryOrCreate
+{{- end }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -103,6 +113,7 @@ spec:
   resources:
     requests:
       storage: 10Gi
+  {{- if $.Values.persistence.hostPath }}
   selector:
     matchLabels:
       app.kubernetes.io/managed-by: {{ $.Release.Service }}
@@ -110,7 +121,11 @@ spec:
       helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
       app.kubernetes.io/name: {{ template "substra.name" $ }}-docker-cache
       app.kubernetes.io/part-of: {{ template "substra.name" $ }}-docker-cache
+  {{- else if $.Values.persistence.storageClassName }}
+  storageClassName: {{ $.Values.persistence.storageClassName }}
+  {{- end }}
 ---
+{{- if $.Values.persistence.hostPath }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -134,3 +149,4 @@ spec:
   hostPath:
     path: {{ .Values.persistence.hostPath }}/cache
     type: DirectoryOrCreate
+{{- end }}

--- a/charts/substra-backend/templates/storage.yaml
+++ b/charts/substra-backend/templates/storage.yaml
@@ -86,3 +86,51 @@ spec:
   hostPath:
     path: {{ $.Values.persistence.hostPath }}/servermedias
     type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "substra.fullname" $ }}-docker-cache
+  labels:
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/name: {{ template "substra.name" $ }}-docker-cache
+    app.kubernetes.io/part-of: {{ template "substra.name" $ }}-docker-cache
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: {{ $.Release.Service }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+      helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+      app.kubernetes.io/name: {{ template "substra.name" $ }}-docker-cache
+      app.kubernetes.io/part-of: {{ template "substra.name" $ }}-docker-cache
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ template "substra.fullname" $ }}-docker-cache
+  labels:
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/name: {{ template "substra.name" $ }}-docker-cache
+    app.kubernetes.io/part-of: {{ template "substra.name" $ }}-docker-cache
+spec:
+  storageClassName: ""
+  persistentVolumeReclaimPolicy: Recycle
+  claimRef:
+    name: {{ template "substra.fullname" $ }}-docker-cache
+    namespace: {{ .Release.Namespace }}
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: {{ .Values.persistence.hostPath }}/cache
+    type: DirectoryOrCreate

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -287,3 +287,11 @@ privateCa:
     name: substra-private-ca
 #    data: nil
     fileName: private-ca.crt
+
+
+registry:
+  local: true    # false if you use external docker-registry (host and port will be taken into account)
+  host: 127.0.0.1
+  port: 32000
+  scheme: http
+  pullDomain: 127.0.0.1:32000

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -177,6 +177,7 @@ docker-registry:
   storage: filesystem
   persistence:
     enabled: false
+    deleteEnabled: true
 
 prePulledImages:
 - substrafoundation/substra-tools:0.5.0

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -118,6 +118,12 @@ persistence:
       readOnly:
         server: true
         worker: false
+    # Writable by jobs only
+    - name: outputs
+      size: "10Gi"
+      readOnly:
+        server: true
+        worker: true
     - name: computeplan
       size: "10Gi"
       readOnly:

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -172,6 +172,15 @@ rabbitmq:
   persistence:
     enabled: false
 
+docker-registry:
+  enabled: true
+  storage: filesystem
+  persistence:
+    enabled: false
+
+prePulledImages:
+- substrafoundation/substra-tools:0.5.0
+
 flower:
   enabled: true
   host: flower

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -20,6 +20,10 @@ backend:
   uwsgiThreads: 2
   gzipModels: false
 
+  dockerSocket:
+    enabled: false
+    hostPath: /var/run/docker.sock
+
   image:
     repository: substrafoundation/substra-backend
     tag: latest

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -118,17 +118,23 @@ persistence:
       readOnly:
         server: true
         worker: false
+    - name: computeplan
+      size: "10Gi"
+      readOnly:
+        server: true
+        worker: false
     # Writable by jobs only
     - name: outputs
       size: "10Gi"
       readOnly:
         server: true
         worker: true
-    - name: computeplan
+    # Writable by jobs only
+    - name: local
       size: "10Gi"
       readOnly:
         server: true
-        worker: false
+        worker: true
 
 # Secrets names
 secrets:

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -79,7 +79,8 @@ users: []
   #   secret: password
 
 persistence:
-  hostPath: "/substra"
+  # storageClassName: ""
+  # hostPath: "/substra"
   size: "10Gi"
   volumes:
     - name: algos

--- a/docker/start.py
+++ b/docker/start.py
@@ -144,6 +144,7 @@ def generate_docker_compose_file(conf, launch_settings):
             f"TASK_CLEAN_EXECUTION_ENVIRONMENT=True",
             f"TASK_CACHE_DOCKER_IMAGES=False",
             f"TASK_CHAINKEYS_ENABLED=False",
+            f"COMPUTE_BACKEND=docker",
 
             f'CELERY_BROKER_URL={CELERY_BROKER_URL}',
         ]

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -144,8 +144,6 @@ deploy:
             host: network-org-1-peer-1-hlf-peer.org-1
             port: 7051
             mspID: MyOrg1MSP
-          persistence:
-            hostPath: /tmp/org-1
           incomingNodes:
             - { name: MyOrg1MSP, secret: selfSecret1 }
             - { name: MyOrg2MSP, secret: nodeSecret1w2 }
@@ -211,8 +209,6 @@ deploy:
             host: network-org-2-peer-1-hlf-peer.org-2
             port: 7051
             mspID: MyOrg2MSP
-          persistence:
-            hostPath: /tmp/org-2
           incomingNodes:
             - { name: MyOrg1MSP, secret: nodeSecret2w1 }
             - { name: MyOrg2MSP, secret: selfSecret2 }

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -167,6 +167,8 @@ deploy:
               value: 'False'
             - name: COMPUTE_BACKEND
               value: 'k8s'
+            - name: BUILD_IMAGE
+              value: 'True'
 
       - name: backend-org-2
         chartPath: charts/substra-backend
@@ -232,6 +234,8 @@ deploy:
               value: 'False'
             - name: COMPUTE_BACKEND
               value: 'k8s'
+            - name: BUILD_IMAGE
+              value: 'True'
 
 profiles:
   - name: prod

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -114,6 +114,15 @@ deploy:
           celeryworker.image: substrafoundation/celeryworker
           flower.image: substrafoundation/flower
         overrides:
+          docker-registry:
+            ingress:
+              enabled: true
+              hosts:
+                - substra-registry.node-1.com
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/client-body-buffer-size: 100m
+                nginx.ingress.kubernetes.io/proxy-body-size: 100m
           secrets:
             fabricConfigmap: network-org-1-hlf-k8s-fabric
           backend:
@@ -164,6 +173,15 @@ deploy:
           celeryworker.image: substrafoundation/celeryworker
           flower.image: substrafoundation/flower
         overrides:
+          docker-registry:
+            ingress:
+              enabled: true
+              hosts:
+                - substra-registry.node-2.com
+              annotations:
+                kubernetes.io/ingress.class: nginx
+                nginx.ingress.kubernetes.io/client-body-buffer-size: 100m
+                nginx.ingress.kubernetes.io/proxy-body-size: 100m
           secrets:
             fabricConfigmap: network-org-2-hlf-k8s-fabric
           backend:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -115,14 +115,8 @@ deploy:
           flower.image: substrafoundation/flower
         overrides:
           docker-registry:
-            ingress:
-              enabled: true
-              hosts:
-                - substra-registry.node-1.com
-              annotations:
-                kubernetes.io/ingress.class: nginx
-                nginx.ingress.kubernetes.io/client-body-buffer-size: 100m
-                nginx.ingress.kubernetes.io/proxy-body-size: 100m
+            service:
+              type: NodePort
           secrets:
             fabricConfigmap: network-org-1-hlf-k8s-fabric
           backend:
@@ -176,14 +170,8 @@ deploy:
           flower.image: substrafoundation/flower
         overrides:
           docker-registry:
-            ingress:
-              enabled: true
-              hosts:
-                - substra-registry.node-2.com
-              annotations:
-                kubernetes.io/ingress.class: nginx
-                nginx.ingress.kubernetes.io/client-body-buffer-size: 100m
-                nginx.ingress.kubernetes.io/proxy-body-size: 100m
+            service:
+              type: NodePort
           secrets:
             fabricConfigmap: network-org-2-hlf-k8s-fabric
           backend:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -161,6 +161,8 @@ deploy:
               value: "true"
             - name: DEFAULT_THROTTLE_RATES
               value: '120'
+            - name: REGISTRY_HOST
+              value: 'substra-registry.node-1.com'
 
       - name: backend-org-2
         chartPath: charts/substra-backend
@@ -220,6 +222,8 @@ deploy:
               value: "true"
             - name: DEFAULT_THROTTLE_RATES
               value: '120'
+            - name: REGISTRY_HOST
+              value: 'substra-registry.node-2.com'
 
 profiles:
   - name: prod

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -117,6 +117,11 @@ deploy:
           docker-registry:
             service:
               type: NodePort
+              nodePort: 32001
+          registry:
+            local: true
+            scheme: http
+            pullDomain: 127.0.0.1:32001
           secrets:
             fabricConfigmap: network-org-1-hlf-k8s-fabric
           backend:
@@ -172,6 +177,11 @@ deploy:
           docker-registry:
             service:
               type: NodePort
+              nodePort: 32002
+          registry:
+            local: true
+            scheme: http
+            pullDomain: 127.0.0.1:32002
           secrets:
             fabricConfigmap: network-org-2-hlf-k8s-fabric
           backend:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -124,6 +124,9 @@ deploy:
             pullDomain: 127.0.0.1:32001
           secrets:
             fabricConfigmap: network-org-1-hlf-k8s-fabric
+          celeryworker:
+            rbac:
+              enable: true
           backend:
             settings: dev
             defaultDomain: http://backend-org-1-substra-backend-server.org-1:8000
@@ -184,6 +187,9 @@ deploy:
             pullDomain: 127.0.0.1:32002
           secrets:
             fabricConfigmap: network-org-2-hlf-k8s-fabric
+          celeryworker:
+            rbac:
+              enable: true
           backend:
             settings: dev
             defaultDomain: http://backend-org-2-substra-backend-server.org-2:8000

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -163,8 +163,11 @@ deploy:
               value: "true"
             - name: DEFAULT_THROTTLE_RATES
               value: '120'
-            - name: REGISTRY_HOST
-              value: 'substra-registry.node-1.com'
+              value: '30'
+            - name: TASK_CACHE_DOCKER_IMAGES
+              value: 'False'
+            - name: COMPUTE_BACKEND
+              value: 'k8s'
 
       - name: backend-org-2
         chartPath: charts/substra-backend
@@ -226,8 +229,10 @@ deploy:
               value: "true"
             - name: DEFAULT_THROTTLE_RATES
               value: '120'
-            - name: REGISTRY_HOST
-              value: 'substra-registry.node-2.com'
+            - name: TASK_CACHE_DOCKER_IMAGES
+              value: 'False'
+            - name: COMPUTE_BACKEND
+              value: 'k8s'
 
 profiles:
   - name: prod

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -163,7 +163,6 @@ deploy:
               value: "true"
             - name: DEFAULT_THROTTLE_RATES
               value: '120'
-              value: '30'
             - name: TASK_CACHE_DOCKER_IMAGES
               value: 'False'
             - name: COMPUTE_BACKEND


### PR DESCRIPTION
Inherit from https://github.com/SubstraFoundation/substra-backend/pull/233 
Companion PR : https://github.com/SubstraFoundation/substra-tests/pull/109
The goal of this PR is to enable the usage of Kubernetes to run tasks instead of using the docker host.

In order to achieve this goal we will have to go through the following steps:
- [x] Option to choose between docker host or k8s compute backend
- [x] Build images using kaniko
- [x] Add cache warmer for kaniko
- [x] Prepare k8s volume for k8s backend
- [x] Run images using kubernetes API
- [x] Fetch results from k8s pods (model, pred, perf)
- [x] Switch from nginx file exposure to RWO pods (worker - job)
- [x] Local volume for compute plan
- [x] Value for registry address (https://github.com/SubstraFoundation/substra-backend/pull/251#pullrequestreview-418896390)
- [x] Memory Limit, Cpu Limit, GPU allocation
- [x] Service Account for job/pod creation (Need @AurelienGasser validation)
- [x] Improve security of the docker registry (Need @AurelienGasser validation)
- [x] Secure ML Task job (remains : Disable Network)
- [ ] Refactoring & Optimization

The way this is expected to work is first building the archive corresponding to the tuple if it is not already present in the registry and push the task Dockerfile to the private docker registry.

Then we run the tasks pulling from the internal registry.

For NetworkPolicy you need to install calico :
```
kubectl apply -f https://docs.projectcalico.org/manifests/calico.yaml
```
~~For this I made available new endpoints in the skaffold.yaml file that needs to be added to the user /ect/hosts file.~~

~~substra-registry.node-1.com~~
~~substra-registry.node-2.com~~
~~This is necessary for the host docker being able to pull from these images registry.~~
~~It is also necessary to add these endpoints to the host docker config as trusted insecure images registry.~~
```
  "insecure-registries": [
    "substra-registry.node-1.com",
    "substra-registry.node-2.com"
  ]
```