### PR TITLE
Add pod affinity to the worker task

### DIFF
--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -603,6 +603,25 @@ def _k8s_compute(name, task_args, subtuple_key):
         security_context=security_context
     )
 
+    pod_affinity = kubernetes.client.V1Affinity(
+        pod_affinity=kubernetes.client.V1PodAffinity(
+            required_during_scheduling_ignored_during_execution=[
+                kubernetes.client.V1PodAffinityTerm(
+                    label_selector=kubernetes.client.V1LabelSelector(
+                        match_expressions=[
+                            kubernetes.client.V1LabelSelectorRequirement(
+                                key="app.kubernetes.io/component",
+                                operator="In",
+                                values=["substra-worker"]
+                            )
+                        ]
+                    ),
+                    topology_key="kubernetes.io/hostname"
+                )
+            ]
+        )
+    )
+
     template = kubernetes.client.V1PodTemplateSpec(
         metadata=kubernetes.client.V1ObjectMeta(name=name,
                                                 labels={'app': name,
@@ -610,6 +629,7 @@ def _k8s_compute(name, task_args, subtuple_key):
                                                 ),
         spec=kubernetes.client.V1PodSpec(
             restart_policy='Never',
+            affinity=pod_affinity,
             containers=[container_compute],
             volumes=volumes
         )

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -19,6 +19,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "substra.name" . }}-worker
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: substra-worker
     spec:
       # Run the worker on the same pod as the server.
       # That's necessary because the worker and the server use the same PV.


### PR DESCRIPTION
Adding this the compute pod should always get scheduled on the same node as the substra worker pod.