### PR TITLE
Add prefix functionality for S3 bucket upload

### DIFF
--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -887,7 +887,7 @@ def transfer_to_bucket(tuple_key, paths):
             's3',
             aws_access_key_id=ACCESS_KEY,
             aws_secret_access_key=SECRET_KEY)
-        s3.upload_file(tar_path, BUCKET_NAME, f'{S3_PREFIX}{tar_name}' if S3_PREFIX else tar_name)
+        s3.upload_file(tar_path, BUCKET_NAME, f'{S3_PREFIX}/{tar_name}' if S3_PREFIX else tar_name)
 
 
 @timeit

--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -52,6 +52,7 @@ TAG_VALUE_FOR_TRANSFER_BUCKET = "transferBucket"
 ACCESS_KEY = os.getenv('BUCKET_TRANSFER_ID')
 SECRET_KEY = os.getenv('BUCKET_TRANSFER_SECRET')
 BUCKET_NAME = os.getenv('BUCKET_TRANSFER_NAME')
+S3_PREFIX = os.getenv('BUCKET_TRANSFER_PREFIX')
 
 
 class TasksError(Exception):
@@ -886,7 +887,7 @@ def transfer_to_bucket(tuple_key, paths):
             's3',
             aws_access_key_id=ACCESS_KEY,
             aws_secret_access_key=SECRET_KEY)
-        s3.upload_file(tar_path, BUCKET_NAME, tar_name)
+        s3.upload_file(tar_path, BUCKET_NAME, f'{S3_PREFIX}{tar_name}' if S3_PREFIX else tar_name)
 
 
 @timeit


### PR DESCRIPTION
Currently, generated tar.gz files can only be uploaded at the root of an s3 bucket.

This PR adds support for `.tar.gz` upload into s3 prefixes, which are the s3 equivalent of subfolders.