### PR TITLE
Disable CORS_ALLOW_CREDENTIALS by default

### DIFF
--- a/backend/backend/settings/deps/cors.py
+++ b/backend/backend/settings/deps/cors.py
@@ -13,7 +13,7 @@ common.MIDDLEWARE.insert(0, 'corsheaders.middleware.CorsMiddleware')
 
 CORS_ORIGIN_WHITELIST = json.loads(os.environ.get('CORS_ORIGIN_WHITELIST', "[]"))
 CORS_ORIGIN_ALLOW_ALL = False if CORS_ORIGIN_WHITELIST else True
-CORS_ALLOW_CREDENTIALS = True
+CORS_ALLOW_CREDENTIALS = common.to_bool(os.environ.get('CORS_ALLOW_CREDENTIALS', False))
 CORS_ALLOW_HEADERS = (
     'accept',
     'accept-encoding',

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -148,6 +148,8 @@ deploy:
             # Should be a json list
             - name: CORS_ORIGIN_WHITELIST
               value: '["http://substra-frontend.node-1.com/"]'
+            - name: CORS_ALLOW_CREDENTIALS
+              value: "false"
             - name: DEFAULT_THROTTLE_RATES
               value: '120'
 
@@ -196,6 +198,8 @@ deploy:
             # Should be a json list
             - name: CORS_ORIGIN_WHITELIST
               value: '["http://substra-frontend.node-2.com/"]'
+            - name: CORS_ALLOW_CREDENTIALS
+              value: "false"
             - name: DEFAULT_THROTTLE_RATES
               value: '120'
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -149,7 +149,7 @@ deploy:
             - name: CORS_ORIGIN_WHITELIST
               value: '["http://substra-frontend.node-1.com/"]'
             - name: CORS_ALLOW_CREDENTIALS
-              value: "false"
+              value: "true"
             - name: DEFAULT_THROTTLE_RATES
               value: '120'
 
@@ -199,7 +199,7 @@ deploy:
             - name: CORS_ORIGIN_WHITELIST
               value: '["http://substra-frontend.node-2.com/"]'
             - name: CORS_ALLOW_CREDENTIALS
-              value: "false"
+              value: "true"
             - name: DEFAULT_THROTTLE_RATES
               value: '120'
 


### PR DESCRIPTION
Disable CORS_ALLOW_CREDENTIALS
But for front-end you need to set it to true to allow it to login in the backend !