### PR TITLE
Add worker update strategy as a value

### DIFF
--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-backend
 home: https://substra.org/
-version: 1.0.0-alpha.31
+version: 1.0.0-alpha.32
 description: Main package for Substra
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/part-of: {{ template "substra.name" . }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.celeryworker.updateStrategy }}
   selector:
     matchLabels:
         app.kubernetes.io/name: {{ template "substra.name" . }}-worker

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -227,6 +227,7 @@ celeryscheduler:
 
 celeryworker:
   replicaCount: 1
+  updateStrategy: RollingUpdate
   image:
     repository: substrafoundation/celeryworker
     tag: latest


### PR DESCRIPTION
Sometimes when running high memory workers it is not possible to perform a rolling update as there is not enough memory in the cluster to satisfy the requests of two worker.

Making this a value we can set gives us the possibility to choose a deployment strategy `Recreate` which will first delete the old worker and then recreate a new worker.

Documentation: [k8s-deployment-strategy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#deploymentstrategy-v1-apps)