### PR TITLE
don't use hostPath for PVC

### DIFF
--- a/charts/substra-backend/templates/deployment-server.yaml
+++ b/charts/substra-backend/templates/deployment-server.yaml
@@ -71,7 +71,7 @@ spec:
           - name: LEDGER_CONFIG_FILE
             value: /conf/{{ .Values.organization.name }}/substra-backend/conf.json
           - name: MEDIA_ROOT
-            value: {{ .Values.persistence.hostPath }}/medias/
+            value: /var/substra/medias/
           - name: PYTHONUNBUFFERED
             value: "1"
           - name: GZIP_MODELS
@@ -90,11 +90,11 @@ spec:
         volumeMounts:
           {{- range .Values.persistence.volumes }}
           - name: data-{{ .name }}
-            mountPath: {{ $.Values.persistence.hostPath }}/medias/{{ .name }}
+            mountPath: /var/substra/medias/{{ .name }}
             readOnly: {{ .readOnly.server }}
           {{- end }}
           - name: data-servermedias
-            mountPath: {{ $.Values.persistence.hostPath }}/servermedias
+            mountPath: /var/substra/servermedias
             readOnly: true
           - name: statics
             mountPath: /usr/src/app/backend/statics
@@ -154,20 +154,20 @@ spec:
           - mountPath: /tmp/certs/
             name: ssl-certs
       {{- end }}
-      {{- if .Values.securityContext.enabled }}
+      {{- if and .Values.securityContext.enabled .Values.persistence.hostPath }}
       - name: chown-pvc
         image: alpine:latest
         imagePullPolicy: IfNotPresent
         command: ["sh", "-c"]
         args:
         - |
-          for dir in `ls -d {{ $.Values.persistence.hostPath }}/medias/*`; do
+          for dir in `ls -d /var/substra/medias/*`; do
             chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }} $dir
           done
         volumeMounts:
           {{- range .Values.persistence.volumes }}
           - name: data-{{ .name }}
-            mountPath: {{ $.Values.persistence.hostPath }}/medias/{{ .name }}
+            mountPath: /var/substra/medias/{{ .name }}
           {{- end }}
       {{- end }}
       - name: wait-postgresql

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -103,7 +103,7 @@ spec:
             - name: LEDGER_CONFIG_FILE
               value: /conf/{{ .Values.organization.name }}/substra-backend/conf.json
             - name: MEDIA_ROOT
-              value: {{ .Values.persistence.hostPath }}/medias/
+              value: /var/substra/medias/
             - name: PYTHONUNBUFFERED
               value: "1"
             - name: "CELERYWORKER_IMAGE"
@@ -147,11 +147,11 @@ spec:
             {{- end }}
             {{- range .Values.persistence.volumes }}
             - name: data-{{ .name }}
-              mountPath: {{ $.Values.persistence.hostPath }}/medias/{{ .name }}
+              mountPath: /var/substra/medias/{{ .name }}
               readOnly: {{ .readOnly.worker }}
             {{- end }}
             - name: data-servermedias
-              mountPath: {{ $.Values.persistence.hostPath }}/servermedias
+              mountPath: /var/substra/servermedias
               readOnly: true
             - name: config
               mountPath: /conf/{{ .Values.organization.name }}/substra-backend

--- a/charts/substra-backend/templates/storage.yaml
+++ b/charts/substra-backend/templates/storage.yaml
@@ -5,12 +5,12 @@ apiVersion: v1
 metadata:
   name: {{ template "substra.fullname" $ }}-{{ .name }}
 spec:
-  storageClassName: ""
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
       storage: {{ .size | quote }}
+  {{- if $.Values.persistence.hostPath }}
   selector:
     matchLabels:
       app.kubernetes.io/managed-by: {{ $.Release.Service }}
@@ -18,7 +18,11 @@ spec:
       helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
       app.kubernetes.io/name: {{ template "substra.name" $ }}-{{ .name }}
       app.kubernetes.io/part-of: {{ template "substra.name" $ }}-{{ .name }}
+  {{- else if $.Values.persistence.storageClassName }}
+  storageClassName: {{ $.Values.persistence.storageClassName }}
+  {{- end }}
 ---
+{{- if $.Values.persistence.hostPath }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -43,18 +47,19 @@ spec:
     path: {{ $.Values.persistence.hostPath }}/medias/{{ .name }}
     type: DirectoryOrCreate
 {{- end }}
+{{- end }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "substra.fullname" $ }}-servermedias
 spec:
-  storageClassName: ""
   accessModes:
     - ReadOnlyMany
   resources:
     requests:
       storage: {{ $.Values.persistence.size | quote }}
+  {{- if $.Values.persistence.hostPath }}
   selector:
     matchLabels:
       app.kubernetes.io/managed-by: {{ $.Release.Service }}
@@ -62,7 +67,11 @@ spec:
       helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
       app.kubernetes.io/name: {{ template "substra.name" $ }}-servermedias
       app.kubernetes.io/part-of: {{ template "substra.name" $ }}-servermedias
+  {{- else if $.Values.persistence.storageClassName }}
+  storageClassName: {{ $.Values.persistence.storageClassName }}
+  {{- end }}
 ---
+{{- if $.Values.persistence.hostPath }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -86,6 +95,7 @@ spec:
   hostPath:
     path: {{ $.Values.persistence.hostPath }}/servermedias
     type: DirectoryOrCreate
+{{- end }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -103,6 +113,7 @@ spec:
   resources:
     requests:
       storage: 10Gi
+  {{- if $.Values.persistence.hostPath }}
   selector:
     matchLabels:
       app.kubernetes.io/managed-by: {{ $.Release.Service }}
@@ -110,7 +121,11 @@ spec:
       helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
       app.kubernetes.io/name: {{ template "substra.name" $ }}-docker-cache
       app.kubernetes.io/part-of: {{ template "substra.name" $ }}-docker-cache
+  {{- else if $.Values.persistence.storageClassName }}
+  storageClassName: {{ $.Values.persistence.storageClassName }}
+  {{- end }}
 ---
+{{- if $.Values.persistence.hostPath }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -134,3 +149,4 @@ spec:
   hostPath:
     path: {{ .Values.persistence.hostPath }}/cache
     type: DirectoryOrCreate
+{{- end }}

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -70,7 +70,8 @@ users: []
   #   secret: password
 
 persistence:
-  hostPath: "/substra"
+  # storageClassName: ""
+  # hostPath: "/substra"
   size: "10Gi"
   volumes:
     - name: algos

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -144,8 +144,6 @@ deploy:
             host: network-org-1-peer-1-hlf-peer.org-1
             port: 7051
             mspID: MyOrg1MSP
-          persistence:
-            hostPath: /tmp/org-1
           incomingNodes:
             - { name: MyOrg1MSP, secret: selfSecret1 }
             - { name: MyOrg2MSP, secret: nodeSecret1w2 }
@@ -211,8 +209,6 @@ deploy:
             host: network-org-2-peer-1-hlf-peer.org-2
             port: 7051
             mspID: MyOrg2MSP
-          persistence:
-            hostPath: /tmp/org-2
           incomingNodes:
             - { name: MyOrg1MSP, secret: nodeSecret2w1 }
             - { name: MyOrg2MSP, secret: selfSecret2 }


### PR DESCRIPTION
Changes:

- Make `hostPath` value optional + introduce `storageClassName` value
- Only `chown` data folders when hostPath is used. I can't see a benefit to chown in non-hostPath scenarios
- Use `/var/substra` instead of `/substra` for the mount path (see note below)

--- 

Note: I chose `/var/substra` because  1. /var is a more standard place to store data, and 2.  there are 100+ occurrences of the string /substra in the project, which makes future refactors painful. 

:warning:  If we merge this we'll need to update `/substra` to `/var/substra` in `script-cleanup.sh` (melloddy-deploy)
