### PR TITLE
Add metadata to compute plan

### DIFF
--- a/backend/substrapp/serializers/ledger/computeplan/serializer.py
+++ b/backend/substrapp/serializers/ledger/computeplan/serializer.py
@@ -78,11 +78,10 @@ class LedgerComputePlanSerializer(serializers.Serializer):
                 'dataSampleKeys': data_traintuple['train_data_sample_keys'],
                 'algoKey': data_traintuple['algo_key'],
                 'id': data_traintuple['traintuple_id'],
+                'metadata': data_traintuple.get('metadata'),
             }
             if 'in_models_ids' in data_traintuple:
                 traintuple['inModelsIDs'] = data_traintuple['in_models_ids']
-            if 'metadata' in data_traintuple:
-                traintuple['metadata'] = data_traintuple['metadata']
             if 'tag' in data_traintuple:
                 traintuple['tag'] = data_traintuple['tag']
 
@@ -93,9 +92,8 @@ class LedgerComputePlanSerializer(serializers.Serializer):
             testtuple = {
                 'traintupleID': data_testtuple['traintuple_id'],
                 'objectiveKey': data_testtuple['objective_key'],
+                'metadata': data_testtuple.get('metadata'),
             }
-            if 'metadata' in data_testtuple:
-                testtuple['metadata'] = data_testtuple['metadata']
             if 'tag' in data_testtuple:
                 testtuple['tag'] = data_testtuple['tag']
             if 'data_manager_key' in data_testtuple:
@@ -112,10 +110,9 @@ class LedgerComputePlanSerializer(serializers.Serializer):
                 'dataManagerKey': data_composite_traintuple['data_manager_key'],
                 'dataSampleKeys': data_composite_traintuple['train_data_sample_keys'],
                 'id': data_composite_traintuple['composite_traintuple_id'],
+                'metadata': data_composite_traintuple.get('metadata'),
             }
 
-            if 'metadata' in data_composite_traintuple:
-                composite_traintuple['metadata'] = data_composite_traintuple['metadata']
             if 'tag' in data_composite_traintuple:
                 composite_traintuple['tag'] = data_composite_traintuple['tag']
             if 'in_head_model_id' in data_composite_traintuple:
@@ -135,12 +132,11 @@ class LedgerComputePlanSerializer(serializers.Serializer):
                 'algoKey': data_aggregatetuple['algo_key'],
                 'worker': data_aggregatetuple['worker'],
                 'id': data_aggregatetuple['aggregatetuple_id'],
+                'metadata': data_aggregatetuple.get('metadata'),
             }
 
             if 'in_models_ids' in data_aggregatetuple:
                 aggregatetuple['inModelsIDs'] = data_aggregatetuple['in_models_ids']
-            if 'metadata' in data_aggregatetuple:
-                aggregatetuple['metadata'] = data_aggregatetuple['metadata']
             if 'tag' in data_aggregatetuple:
                 aggregatetuple['tag'] = data_aggregatetuple['tag']
 

--- a/backend/substrapp/serializers/ledger/computeplan/serializer.py
+++ b/backend/substrapp/serializers/ledger/computeplan/serializer.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from rest_framework.fields import DictField, CharField
 
 from substrapp import ledger
 from substrapp.serializers.ledger.utils import PermissionsSerializer
@@ -16,6 +17,7 @@ class ComputePlanTraintupleSerializer(serializers.Serializer):
         min_length=0,
         required=False)
     tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False, allow_null=True)
+    metadata = DictField(child=CharField(), required=False, allow_null=True)
 
 
 class ComputePlanTesttupleSerializer(serializers.Serializer):
@@ -27,6 +29,7 @@ class ComputePlanTesttupleSerializer(serializers.Serializer):
         min_length=0,
         required=False)
     tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False, allow_null=True)
+    metadata = DictField(child=CharField(), required=False, allow_null=True)
 
 
 class ComputePlanCompositeTrainTupleSerializer(serializers.Serializer):
@@ -42,6 +45,7 @@ class ComputePlanCompositeTrainTupleSerializer(serializers.Serializer):
                                               allow_null=True)
     out_trunk_model_permissions = PermissionsSerializer()
     tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False, allow_null=True)
+    metadata = DictField(child=CharField(), required=False, allow_null=True)
 
 
 class ComputePlanAggregatetupleSerializer(serializers.Serializer):
@@ -53,6 +57,7 @@ class ComputePlanAggregatetupleSerializer(serializers.Serializer):
         min_length=0,
         required=False)
     tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False, allow_null=True)
+    metadata = DictField(child=CharField(), required=False, allow_null=True)
 
 
 class LedgerComputePlanSerializer(serializers.Serializer):
@@ -61,6 +66,7 @@ class LedgerComputePlanSerializer(serializers.Serializer):
     composite_traintuples = ComputePlanCompositeTrainTupleSerializer(many=True, required=False)
     aggregatetuples = ComputePlanAggregatetupleSerializer(many=True, required=False)
     tag = serializers.CharField(min_length=0, max_length=64, allow_blank=True, required=False, allow_null=True)
+    metadata = DictField(child=CharField(), required=False, allow_null=True)
     clean_models = serializers.BooleanField(required=False)
 
     def get_args(self, data):
@@ -75,6 +81,8 @@ class LedgerComputePlanSerializer(serializers.Serializer):
             }
             if 'in_models_ids' in data_traintuple:
                 traintuple['inModelsIDs'] = data_traintuple['in_models_ids']
+            if 'metadata' in data_traintuple:
+                traintuple['metadata'] = data_traintuple['metadata']
             if 'tag' in data_traintuple:
                 traintuple['tag'] = data_traintuple['tag']
 
@@ -86,6 +94,8 @@ class LedgerComputePlanSerializer(serializers.Serializer):
                 'traintupleID': data_testtuple['traintuple_id'],
                 'objectiveKey': data_testtuple['objective_key'],
             }
+            if 'metadata' in data_testtuple:
+                testtuple['metadata'] = data_testtuple['metadata']
             if 'tag' in data_testtuple:
                 testtuple['tag'] = data_testtuple['tag']
             if 'data_manager_key' in data_testtuple:
@@ -104,6 +114,8 @@ class LedgerComputePlanSerializer(serializers.Serializer):
                 'id': data_composite_traintuple['composite_traintuple_id'],
             }
 
+            if 'metadata' in data_composite_traintuple:
+                composite_traintuple['metadata'] = data_composite_traintuple['metadata']
             if 'tag' in data_composite_traintuple:
                 composite_traintuple['tag'] = data_composite_traintuple['tag']
             if 'in_head_model_id' in data_composite_traintuple:
@@ -127,6 +139,8 @@ class LedgerComputePlanSerializer(serializers.Serializer):
 
             if 'in_models_ids' in data_aggregatetuple:
                 aggregatetuple['inModelsIDs'] = data_aggregatetuple['in_models_ids']
+            if 'metadata' in data_aggregatetuple:
+                aggregatetuple['metadata'] = data_aggregatetuple['metadata']
             if 'tag' in data_aggregatetuple:
                 aggregatetuple['tag'] = data_aggregatetuple['tag']
 
@@ -137,6 +151,7 @@ class LedgerComputePlanSerializer(serializers.Serializer):
             'testtuples': testtuples,
             'compositeTraintuples': composite_traintuples,
             'aggregatetuples': aggregatetuples,
+            'metadata': data.get('metadata'),
             'tag': data.get('tag'),
             'cleanModels': data.get('clean_models', False),
         }


### PR DESCRIPTION
:link: **Related Pull Requests :**
• [substra](https://github.com/SubstraFoundation/substra/pull/189)
• [substra-tests](https://github.com/SubstraFoundation/substra-tests/pull/112)
• [substra-chaincode](https://github.com/SubstraFoundation/substra-chaincode/pull/121)

This PR aims to add a metadata field to the compute plan asset.