### PR TITLE
prepopulate local registry

### DIFF
--- a/backend/backend/settings/common.py
+++ b/backend/backend/settings/common.py
@@ -200,6 +200,9 @@ TASK = {
     'LIST_WORKSPACE': to_bool(os.environ.get('TASK_LIST_WORKSPACE', True)),
     'COMPUTE_BACKEND': os.environ.get('COMPUTE_BACKEND', 'k8s'),  # 'docker' or 'k8s'
     'BUILD_IMAGE': to_bool(os.environ.get('BUILD_IMAGE', True)),
+    'KANIKO_MIRROR': to_bool(os.environ.get('KANIKO_MIRROR', False)),
+    'KANIKO_IMAGE': os.environ.get('KANIKO_IMAGE'),
+    'KANIKO_REGISTRY': os.environ.get('KANIKO_REGISTRY'),
 }
 
 CELERY_ACCEPT_CONTENT = ['application/json']

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -254,7 +254,7 @@ def k8s_build_image(path, tag, rm):
     if IMAGE_BUILDER == 'kaniko':
         # kaniko build can be launched without privilege but
         # it needs some capabilities and to be root
-        image = KANIKO_IMAGE if not KANIKO_REGISTRY else KANIKO_IMAGE.replace('gcr.io', KANIKO_REGISTRY)
+        image = KANIKO_IMAGE if not KANIKO_REGISTRY else f'{KANIKO_REGISTRY}/{KANIKO_IMAGE}'
         command = None
         mount_path_dockerfile = path
         mount_path_cache = '/cache'

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -24,7 +24,7 @@ RUN_AS_USER = os.getenv('RUN_AS_USER')
 FS_GROUP = os.getenv('FS_GROUP')
 IMAGE_BUILDER = os.getenv('IMAGE_BUILDER')
 KANIKO_IMAGE = os.getenv('KANIKO_IMAGE')
-KANIKO_MIRROR = os.getenv('KANIKO_MIRROR')
+KANIKO_MIRROR = os.getenv('KANIKO_MIRROR').lower() == 'true'
 KANIKO_REGISTRY = os.getenv('KANIKO_REGISTRY')
 
 K8S_PVC = {

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -269,7 +269,7 @@ def k8s_build_image(path, tag, rm):
             args.append('--insecure')
 
         if KANIKO_MIRROR:
-            args.append(f'--registry-mirror={KANIKO_MIRROR}')
+            args.append(f'--registry-mirror={REGISTRY}')
 
         # https://github.com/GoogleContainerTools/kaniko/issues/778
         capabilities = ['CHOWN', 'SETUID', 'SETGID', 'FOWNER', 'DAC_OVERRIDE']

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -23,6 +23,7 @@ RUN_AS_GROUP = os.getenv('RUN_AS_GROUP')
 RUN_AS_USER = os.getenv('RUN_AS_USER')
 FS_GROUP = os.getenv('FS_GROUP')
 IMAGE_BUILDER = os.getenv('IMAGE_BUILDER')
+KANIKO_IMAGE = os.getenv('KANIKO_IMAGE')
 KANIKO_MIRROR = os.getenv('KANIKO_MIRROR')
 KANIKO_REGISTRY = os.getenv('KANIKO_REGISTRY')
 
@@ -251,8 +252,7 @@ def k8s_build_image(path, tag, rm):
     if IMAGE_BUILDER == 'kaniko':
         # kaniko build can be launched without privilege but
         # it needs some capabilities and to be root
-        kaniko_image = 'kaniko-project/executor:v0.23.0'
-        image = f'gcr.io/{kaniko_image}' if not KANIKO_REGISTRY else f'{KANIKO_REGISTRY}/{kaniko_image}'
+        image = KANIKO_IMAGE if not KANIKO_REGISTRY else KANIKO_IMAGE.replace('gcr.io', KANIKO_REGISTRY)
         command = None
         mount_path_dockerfile = path
         mount_path_cache = '/cache'

--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -5,6 +5,7 @@ import requests
 import os
 import logging
 
+from django.conf import settings
 from substrapp.utils import timeit
 
 import time
@@ -23,9 +24,10 @@ RUN_AS_GROUP = os.getenv('RUN_AS_GROUP')
 RUN_AS_USER = os.getenv('RUN_AS_USER')
 FS_GROUP = os.getenv('FS_GROUP')
 IMAGE_BUILDER = os.getenv('IMAGE_BUILDER')
-KANIKO_IMAGE = os.getenv('KANIKO_IMAGE')
-KANIKO_MIRROR = os.getenv('KANIKO_MIRROR').lower() == 'true'
-KANIKO_REGISTRY = os.getenv('KANIKO_REGISTRY')
+KANIKO_MIRROR = settings.TASK['KANIKO_MIRROR']
+KANIKO_IMAGE = settings.TASK['KANIKO_IMAGE']
+KANIKO_REGISTRY = settings.TASK['KANIKO_REGISTRY']
+
 
 K8S_PVC = {
     env_key: env_value for env_key, env_value in os.environ.items() if '_PVC' in env_key

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-backend
 home: https://substra.org/
-version: 1.0.0-alpha.32-melloddy.10
+version: 1.0.0-alpha.32-melloddy.11
 description: Main package for Substra
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-backend
 home: https://substra.org/
-version: 1.0.0-alpha.32-melloddy.9
+version: 1.0.0-alpha.32-melloddy.10
 description: Main package for Substra
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-backend
 home: https://substra.org/
-version: 1.0.0-alpha.32-melloddy.12
+version: 1.0.0-alpha.32-melloddy.13
 description: Main package for Substra
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-backend
 home: https://substra.org/
-version: 1.0.0-alpha.32-melloddy.11
+version: 1.0.0-alpha.32-melloddy.12
 description: Main package for Substra
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -143,6 +143,8 @@ spec:
               value: {{ .Values.securityContext.fsGroup | quote }}
             - name: IMAGE_BUILDER
               value: {{ .Values.backend.imageBuilder.type}}
+            - name: KANIKO_IMAGE
+              value: {{ .Values.backend.imageBuilder.kaniko.image}}
             - name: KANIKO_MIRROR
               value: {{ .Values.backend.imageBuilder.kaniko.mirror}}
             - name: KANIKO_REGISTRY

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -142,13 +142,13 @@ spec:
             - name: FS_GROUP
               value: {{ .Values.securityContext.fsGroup | quote }}
             - name: IMAGE_BUILDER
-              value: {{ .Values.backend.imageBuilder.type}}
+              value: {{ .Values.backend.imageBuilder.type | quote }}
             - name: KANIKO_IMAGE
-              value: {{ .Values.backend.imageBuilder.kaniko.image}}
+              value: {{ .Values.backend.imageBuilder.kaniko.image | quote }}
             - name: KANIKO_MIRROR
-              value: {{ .Values.backend.imageBuilder.kaniko.mirror}}
+              value: {{ .Values.backend.imageBuilder.kaniko.mirror | quote }}
             - name: KANIKO_REGISTRY
-              value: {{ .Values.backend.imageBuilder.kaniko.registry}}
+              value: {{ .Values.backend.imageBuilder.kaniko.registry | quote }}
           {{- with .Values.extraEnv }}
 {{ toYaml . | indent 12 }}
           {{- end }}

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -143,6 +143,10 @@ spec:
               value: {{ .Values.securityContext.fsGroup | quote }}
             - name: IMAGE_BUILDER
               value: {{ .Values.backend.imageBuilder.type}}
+            - name: KANIKO_MIRROR
+              value: {{ .Values.backend.imageBuilder.kaniko.mirror}}
+            - name: KANIKO_REGISTRY
+              value: {{ .Values.backend.imageBuilder.kaniko.registry}}
           {{- with .Values.extraEnv }}
 {{ toYaml . | indent 12 }}
           {{- end }}

--- a/charts/substra-backend/templates/job-image-builder-warmer.yaml
+++ b/charts/substra-backend/templates/job-image-builder-warmer.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.prePulledImages }}
 {{- if eq .Values.backend.imageBuilder.type "kaniko" }}
 apiVersion: batch/v1
 kind: Job
@@ -167,5 +168,6 @@ data:
   Dockerfile: |
     FROM {{ $img }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/substra-backend/templates/job-registry-prepopulate.yaml
+++ b/charts/substra-backend/templates/job-registry-prepopulate.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.registry.local }}
 {{ range $index, $item :=  .Values.registry.prepopulate }}
 ---
 apiVersion: apps/v1
@@ -58,4 +59,5 @@ metadata:
 data:
     Dockerfile: |
       FROM {{ .sourceRegistry }}/{{ .image }}
+{{- end }}
 {{- end }}

--- a/charts/substra-backend/templates/job-registry-prepopulate.yaml
+++ b/charts/substra-backend/templates/job-registry-prepopulate.yaml
@@ -1,0 +1,61 @@
+{{ range $index, $item :=  .Values.registry.prepopulate }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "substra.fullname" $ }}-registry-prepopulate-{{ $index }}
+  labels:
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    app.kubernetes.io/name: {{ template "substra.name" $ }}-registry-prepopulate-{{ $index }}
+    app.kubernetes.io/part-of: {{ template "substra.name" $ }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+        app.kubernetes.io/name: {{ template "substra.name" $ }}-registry-prepopulate-{{ $index }}
+        app.kubernetes.io/instance: {{ $.Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ template "substra.name" $ }}-registry-prepopulate-{{ $index }}
+        app.kubernetes.io/instance: {{ $.Release.Name }}
+    spec:
+      initContainers:
+      - name: kaniko
+        image: gcr.io/kaniko-project/executor:latest
+        args: ["--context=/docker-context",
+                "--destination={{ $.Release.Name }}-docker-registry:5000/{{ .image }}",
+                "--insecure"]
+        volumeMounts:
+          - name: dockerfile
+            mountPath: /docker-context
+          {{- if .dockerConfigSecretName }}
+          - name: docker-config
+            mountPath: /kaniko/.docker
+          {{- end }}
+      containers:
+      - image: gcr.io/google-containers/pause:2.0
+        name: pause
+      volumes:
+      - name: dockerfile
+        configMap:
+          name: {{ template "substra.fullname" $ }}-registry-prepopulate-dockerfile-{{ $index }}
+      {{- if .dockerConfigSecretName }}
+      - name: docker-config
+        secret:
+          secretName: {{ .dockerConfigSecretName }}
+          items:
+          - key: .dockerconfigjson
+            path: config.json
+      {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: {{ template "substra.fullname" $ }}-registry-prepopulate-dockerfile-{{ $index }}
+data:
+    Dockerfile: |
+      FROM {{ .sourceRegistry }}/{{ .image }}
+{{- end }}

--- a/charts/substra-backend/templates/job-registry-prepopulate.yaml
+++ b/charts/substra-backend/templates/job-registry-prepopulate.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       initContainers:
       - name: kaniko
-        image: gcr.io/kaniko-project/executor:latest
+        image: {{ $.Values.backend.imageBuilder.kaniko.image }}
         args: ["--context=/docker-context",
                 "--destination={{ $.Release.Name }}-docker-registry:5000/{{ .image }}",
                 "--insecure"]

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -20,6 +20,10 @@ backend:
     # type: dind
     type: kaniko
 
+    kaniko:
+      mirror: false  # If true, kaniko will pull base images from the local registry
+      registry: null  # Pull the kaniko image from a custom registry instead of GCR
+
   image:
     repository: substrafoundation/substra-backend
     tag: latest

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -291,6 +291,8 @@ registry:
   port: 32000
   scheme: http
   pullDomain: 127.0.0.1:32000
+
+  ## Local registry pre-populate
   prepopulate: []
     # - image: substrafoundation/substra-tools:0.5.0
     #   sourceRegistry: xxx.dkr.ecr.eu-west-1.amazonaws.com

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -291,6 +291,11 @@ registry:
   port: 32000
   scheme: http
   pullDomain: 127.0.0.1:32000
+  prepopulate: []
+    # - image: substrafoundation/substra-tools:0.5.0
+    #   sourceRegistry: xxx.dkr.ecr.eu-west-1.amazonaws.com
+    #   dockerConfigSecretName: docker-config
+
 ## Pod Security Policy
 ## ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
 psp:

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -21,6 +21,7 @@ backend:
     type: kaniko
 
     kaniko:
+      image: gcr.io/kaniko-project/executor:v0.23.0
       mirror: false  # If true, kaniko will pull base images from the local registry
       registry: null  # Pull the kaniko image from a custom registry instead of GCR
 


### PR DESCRIPTION
Pre-populate the local registry from an arbitrary source registry (with auth)

---

I intentionally separated it from the existing cache warmer, because it serves a different purpose : 

- the cache warmer **populates the cache volume** (builder-dependent)
- the registry prepopulate **populates the docker registry** (builder-independent)
