### PR TITLE
Fix crash when trying to save identical trunk/head models

### DIFF
--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -925,6 +925,7 @@ def save_models(subtuple_directory, tuple_type, subtuple_key):
                 subtuple_directory,
                 subtuple_key,
                 filename=filename,
+                extraKey=type_model
             )
 
             models[type_model] = {
@@ -954,11 +955,11 @@ def extract_result_from_models(tuple_type, models):
 
 
 @timeit
-def save_model(subtuple_directory, subtuple_key, filename='model'):
+def save_model(subtuple_directory, subtuple_key, filename='model', extraKey=''):
     from substrapp.models import Model
 
     end_model_path = path.join(subtuple_directory, f'model/{filename}')
-    end_model_file_hash = get_hash(end_model_path, subtuple_key)
+    end_model_file_hash = get_hash(end_model_path, subtuple_key + extraKey)
     instance = Model.objects.create(pkhash=end_model_file_hash, validated=True)
 
     with open(end_model_path, 'rb') as f:

--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -925,7 +925,7 @@ def save_models(subtuple_directory, tuple_type, subtuple_key):
                 subtuple_directory,
                 subtuple_key,
                 filename=filename,
-                extraKey=type_model
+                extra_key=type_model
             )
 
             models[type_model] = {
@@ -955,11 +955,11 @@ def extract_result_from_models(tuple_type, models):
 
 
 @timeit
-def save_model(subtuple_directory, subtuple_key, filename='model', extraKey=''):
+def save_model(subtuple_directory, subtuple_key, filename='model', extra_key=''):
     from substrapp.models import Model
 
     end_model_path = path.join(subtuple_directory, f'model/{filename}')
-    end_model_file_hash = get_hash(end_model_path, subtuple_key + extraKey)
+    end_model_file_hash = get_hash(end_model_path, subtuple_key + extra_key)
     instance = Model.objects.create(pkhash=end_model_file_hash, validated=True)
 
     with open(end_model_path, 'rb') as f:


### PR DESCRIPTION
For a composite traintuple, if the head and the trunk out models are identical, the saving fails.
﻿
That's because not only do the two models have the same composite traintuple key (expected), they ALSO have the same value.

This PR adds a salt to avoid pkhash conflicts in that case.