### PR TITLE
Add validation schema for helm values

### DIFF
--- a/charts/substra-backend/values.schema.json
+++ b/charts/substra-backend/values.schema.json
@@ -1,0 +1,89 @@
+{
+    "$schema": "substra-backend validation schema",
+    "$id": "values.yaml",
+    "type": "object",
+    "title": "substra-backend values schema",
+    "description": "This schema contain the whole document",
+    "default": {},
+    "examples": [
+        {
+            "users": [
+                {
+                    "name": "node-1",
+                    "secret": "str0ngp@$swr0d44forbackend"
+                }
+            ]
+        }
+    ],
+    "required": [
+        "users"
+    ],
+    "additionalProperties": true,
+    "properties": {
+        "users": {
+            "$id": "#/properties/users",
+            "type": "array",
+            "title": "The backend users validation schema",
+            "description": "Verification that the users created within the chart match the backend users requirements",
+            "default": [],
+            "examples": [
+                [
+                    {
+                        "name": "node-1",
+                        "secret": "str0ngp@$swr0d44forbackend"
+                    }
+                ]
+            ],
+            "additionalItems": true,
+            "items": {
+                "anyOf": [
+                    {
+                        "$id": "#/properties/users/items/anyOf/0",
+                        "type": "object",
+                        "title": "The first anyOf schema",
+                        "description": "User items",
+                        "default": {},
+                        "examples": [
+                            {
+                                "name": "node-1",
+                                "secret": "str0ngp@$swr0d44forbackend"
+                            }
+                        ],
+                        "required": [
+                            "name",
+                            "secret"
+                        ],
+                        "additionalProperties": true,
+                        "properties": {
+                            "name": {
+                                "$id": "#/properties/users/items/anyOf/0/properties/name",
+                                "type": "string",
+                                "title": "Username schema",
+                                "description": "Backend user names",
+                                "default": "",
+                                "examples": [
+                                    "node-1"
+                                ]
+                            },
+                            "secret": {
+                                "$id": "#/properties/users/items/anyOf/0/properties/secret",
+                                "type": "string",
+                                "title": "Password schema",
+                                "description": "Backend user password",
+                                "default": "",
+                                "examples": [
+                                    "str0ngp@$swr0d44forbackend"
+                                ],
+                                "maxLength": 64,
+                                "minLength": 20,
+                                "pattern": "(.*[A-z].*)"
+                            }
+                        }
+                    }
+                ],
+                "$id": "#/properties/users/items"
+            },
+            "uniqueItems": true
+        }
+    }
+}


### PR DESCRIPTION
Add a simple validation schema for the Helm values, this validation schema enforce prod settings constraints on the user values.
You can check your value.yaml file is valid running `helm lint --values <values_file>`.

resolve #262 

## Sample values for testing
```yaml
users:
    - name: user-1
      secret: "111111111111s111111111111111111111111111111ze"
    - name: user-2
      secret: 456846881654841dsfsdf8sdf4sdf6
```
> Valid ✅ 
```yaml
users:
    - name: user-1
      secret: "111111111111111111111111111111111111111111"
```
> Error ❌  => password should contain atleast one letter
```yaml
users:
    - name: user-1
      secret: "111111111111s111111111111111111111111111111ze"
    - name: user-2
      secret: "456846881654841dsfsdf8sdf4sdf6"
    - name: user-2
      secret: "456846881654841dsfsdf8sdf4sdf6"
```
> Error ❌ => Items must be unique

There is currently no way to check for sub-items uniqueness so we can't check the same username is not used twice with a different password.
```yaml
users:
    - name: user-1
      secret: "111111111111s111111111111111111111111111111ze"
    - name: user-2
      secret: "45684688"
```
> Error ❌  => secret should be atleast 20 char

## Suggestions 

I am open for suggestions if you think we should also validate some other fields.