### PR TITLE
Melloddy docker registry pvc

### DIFF
--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-backend
 home: https://substra.org/
-version: 1.0.0-alpha.32-melloddy.17-concurrency
+version: 1.0.0-alpha.32-melloddy.19-concurrency
 description: Main package for Substra
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -191,7 +191,8 @@ docker-registry:
   enabled: true
   storage: filesystem
   persistence:
-    enabled: false
+    enabled: true
+    size: 10Gi
     deleteEnabled: true
 
 prePulledImages:


### PR DESCRIPTION
Use pvc for docker registry data storage instead of emptyDir that may create issue if storage on node is greater than 80% (pod eviction by kubernetes)