### PR TITLE
Reuse metrics image in compute plans

### DIFF
--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -704,11 +704,11 @@ def _do_task(subtuple_directory, tuple_type, subtuple, compute_plan_id, rank, or
             subtuple_key=subtuple["key"],
             compute_plan_id=compute_plan_id,
             dockerfile_path=f'{subtuple_directory}/metrics',
-            image_name=f'substra/metrics_{subtuple["key"][0:8]}'.lower(),
+            image_name=f'substra/metrics_{subtuple["objective"]["hash"][0:8]}'.lower(),
             job_name=f'{tuple_type}-{subtuple["key"][0:8]}-eval'.lower(),
             volumes=common_volumes,
             command=f'--output-perf-path {OUTPUT_PERF_PATH}',
-            remove_image=not(settings.TASK['CACHE_DOCKER_IMAGES']),
+            remove_image=not(compute_plan_id is not None or settings.TASK['CACHE_DOCKER_IMAGES']),
             remove_container=settings.TASK['CLEAN_EXECUTION_ENVIRONMENT'],
             capture_logs=settings.TASK['CAPTURE_LOGS'],
             environment=environment

--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -682,7 +682,7 @@ def _do_task(subtuple_directory, tuple_type, subtuple, compute_plan_id, rank, or
         job_name=job_name,
         volumes={**common_volumes, **compute_volumes},
         command=command,
-        remove_image=not(compute_plan_id is not None or settings.TASK['CACHE_DOCKER_IMAGES']),
+        remove_image=compute_plan_id is None and not settings.TASK['CACHE_DOCKER_IMAGES'],
         remove_container=settings.TASK['CLEAN_EXECUTION_ENVIRONMENT'],
         capture_logs=settings.TASK['CAPTURE_LOGS'],
         environment=environment
@@ -708,7 +708,7 @@ def _do_task(subtuple_directory, tuple_type, subtuple, compute_plan_id, rank, or
             job_name=f'{tuple_type}-{subtuple["key"][0:8]}-eval'.lower(),
             volumes=common_volumes,
             command=f'--output-perf-path {OUTPUT_PERF_PATH}',
-            remove_image=not(compute_plan_id is not None or settings.TASK['CACHE_DOCKER_IMAGES']),
+            remove_image=compute_plan_id is None and not settings.TASK['CACHE_DOCKER_IMAGES'],
             remove_container=settings.TASK['CLEAN_EXECUTION_ENVIRONMENT'],
             capture_logs=settings.TASK['CAPTURE_LOGS'],
             environment=environment


### PR DESCRIPTION
In compute plans, the metrics image is typically the same for multiple ranks.

This PR makes it so:
- the metrics image name is built from the objective hash and not the tuple hash.
- the metrics image is not deleted after use (compute plans only)

As a result, if a compute plan uses the same objective for multiple iterations, the same metrics image will be reused without the need to rebuild it for every testtuple.

-- 

Note that this code is already merged in melloddy https://github.com/SubstraFoundation/substra-backend/pull/267. The goal of this PR is to reflect the changes in master.