### PR TITLE
Return key instead of pkhash

### DIFF
--- a/backend/substrapp/tests/assets.py
+++ b/backend/substrapp/tests/assets.py
@@ -14,45 +14,24 @@ In order to update this file:
 
 objective = [
     {
-        "key": "1cdafbb018dd195690111d74916b76c96892d897ec3587c814f287946db446c3",
-        "name": "Skin Lesion Classification Objective",
+        "key": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
+        "name": "9224cad96c964b7b8ed2f7eb5872c27a_global - Objective 0",
         "description": {
-            "hash": "1cdafbb018dd195690111d74916b76c96892d897ec3587c814f287946db446c3",
-            "storageAddress": "http://testserver/objective/1cdafbb018dd195690111d74916b76c96892d897ec3587c814f287946db446c3/description/"
+            "hash": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
+            "storageAddress": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/description/"
         },
         "metrics": {
-            "name": "macro-average recall",
-            "hash": "e5762042461c355761dd8986b510ea23494d5638a671370dabbf0ac73f8a3208",
-            "storageAddress": "http://testserver/objective/1cdafbb018dd195690111d74916b76c96892d897ec3587c814f287946db446c3/metrics/"
-        },
-        "owner": "MyOrg1MSP",
-        "testDataset": None,
-        "permissions": {
-            "process": {
-                "public": True,
-                "authorizedIDs": []
-            }
-        }
-    },
-    {
-        "key": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
-        "name": "Skin Lesion Classification Objective",
-        "description": {
-            "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
-            "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/description/"
-        },
-        "metrics": {
-            "name": "macro-average recall",
-            "hash": "e5762042461c355761dd8986b510ea23494d5638a671370dabbf0ac73f8a3208",
-            "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
+            "name": "test metrics",
+            "hash": "0d64f855e07524da60203067713ab08fd6e479a02ebcb70364b2c6a2a29367e1",
+            "storageAddress": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
         },
         "owner": "MyOrg1MSP",
         "testDataset": {
-            "dataManagerKey": "ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932",
+            "dataManagerKey": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
             "dataSampleKeys": [
-                "8bf3bf4f753a32f27d18c86405e7a406a83a55610d91abcca9acc525061b8ecf",
-                "17d58b67ae2028018108c9bf555fa58b2ddcfe560e0117294196e79d26140b2a"
+                "ffed4147fffff2f18130b7332c1460ecccd8e1378765c415b82b948c19e98a68"
             ],
+            "metadata": {},
             "worker": ""
         },
         "permissions": {
@@ -60,22 +39,53 @@ objective = [
                 "public": True,
                 "authorizedIDs": []
             }
-        }
+        },
+        "metadata": {}
+    },
+    {
+        "key": "b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3",
+        "name": "9224cad96c964b7b8ed2f7eb5872c27a_global - Objective 1",
+        "description": {
+            "hash": "b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3",
+            "storageAddress": "http://testserver/objective/b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3/description/"
+        },
+        "metrics": {
+            "name": "test metrics",
+            "hash": "1a61bea02e3e75f8197d682cbaa6110c9709fbfbd4f16964acc390c70e7a22fe",
+            "storageAddress": "http://testserver/objective/b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3/metrics/"
+        },
+        "owner": "MyOrg2MSP",
+        "testDataset": {
+            "dataManagerKey": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+            "dataSampleKeys": [
+                "edaa4ccdfc9bcadda859498fbb550a6e1fc6baf176389c3eb18afc8a382b4145"
+            ],
+            "metadata": {},
+            "worker": ""
+        },
+        "permissions": {
+            "process": {
+                "public": True,
+                "authorizedIDs": []
+            }
+        },
+        "metadata": {}
     }
 ]
 
 datamanager = [
     {
-        "objectiveKey": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
+        "objectiveKey": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
         "description": {
-            "hash": "258bef187a166b3fef5cb86e68c8f7e154c283a148cd5bc344fec7e698821ad3",
-            "storageAddress": "http://testserver/data_manager/ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932/description/"
+            "hash": "8acac2e3b700de1e27ee00b8cc0b49a883476d4234015658cbff7a701332a498",
+            "storageAddress": "http://testserver/data_manager/e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204/description/"
         },
-        "key": "ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932",
-        "name": "Simplified ISIC 2018",
+        "key": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+        "metadata": {},
+        "name": "9224cad96c964b7b8ed2f7eb5872c27a_global - Dataset 0",
         "opener": {
-            "hash": "ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932",
-            "storageAddress": "http://testserver/data_manager/ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932/opener/"
+            "hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "storageAddress": "http://testserver/data_manager/e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204/opener/"
         },
         "owner": "MyOrg1MSP",
         "permissions": {
@@ -84,19 +94,20 @@ datamanager = [
                 "authorizedIDs": []
             }
         },
-        "type": "Images"
+        "type": "Test"
     },
     {
-        "objectiveKey": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
+        "objectiveKey": "b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3",
         "description": {
-            "hash": "15863c2af1fcfee9ca6f61f04be8a0eaaf6a45e4d50c421788d450d198e580f1",
-            "storageAddress": "http://testserver/data_manager/8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca/description/"
+            "hash": "0b32ac306997ff74a6b24e79264133de33d841e546f3f88b26a18d46e18223d9",
+            "storageAddress": "http://testserver/data_manager/aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02/description/"
         },
-        "key": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
-        "name": "ISIC 2018",
+        "key": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+        "metadata": {},
+        "name": "9224cad96c964b7b8ed2f7eb5872c27a_global - Dataset 1",
         "opener": {
-            "hash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca",
-            "storageAddress": "http://testserver/data_manager/8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca/opener/"
+            "hash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+            "storageAddress": "http://testserver/data_manager/aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02/opener/"
         },
         "owner": "MyOrg2MSP",
         "permissions": {
@@ -105,21 +116,21 @@ datamanager = [
                 "authorizedIDs": []
             }
         },
-        "type": "Images"
+        "type": "Test"
     }
 ]
 
 algo = [
     {
-        "key": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
-        "name": "Logistic regression",
+        "key": "4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be",
+        "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple - Algo 0",
         "content": {
-            "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
-            "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/"
+            "hash": "4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be",
+            "storageAddress": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
         },
         "description": {
-            "hash": "124a0425b746d7072282d167b53cb6aab3a31bf1946dae89135c15b0126ebec3",
-            "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/description/"
+            "hash": "22b9af671a660afd001b15c5a85edaa81dc42fbda7aef03f2fd76aa10d2e5151",
+            "storageAddress": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/description/"
         },
         "owner": "MyOrg1MSP",
         "permissions": {
@@ -127,18 +138,79 @@ algo = [
                 "public": True,
                 "authorizedIDs": []
             }
-        }
+        },
+        "metadata": {}
     },
     {
-        "key": "0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f",
-        "name": "Neural Network",
+        "key": "59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30",
+        "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_federated_learning_workflow - Algo 0",
         "content": {
-            "hash": "0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f",
-            "storageAddress": "http://testserver/algo/0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f/file/"
+            "hash": "59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30",
+            "storageAddress": "http://testserver/algo/59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30/file/"
         },
         "description": {
-            "hash": "b9463411a01ea00869bdffce6e59a5c100a4e635c0a9386266cad3c77eb28e9e",
-            "storageAddress": "http://testserver/algo/0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f/description/"
+            "hash": "df548aab4b1a66e08021774e0b70e6f59b858ba41afa550396d213357326f891",
+            "storageAddress": "http://testserver/algo/59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30/description/"
+        },
+        "owner": "MyOrg1MSP",
+        "permissions": {
+            "process": {
+                "public": True,
+                "authorizedIDs": []
+            }
+        },
+        "metadata": {}
+    },
+    {
+        "key": "e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8",
+        "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_same_node - Algo 0",
+        "content": {
+            "hash": "e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8",
+            "storageAddress": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
+        },
+        "description": {
+            "hash": "851fc503e6136c86f4a0f4035aa6d59c44f017694757769b9b2d7d39a7f5dc3c",
+            "storageAddress": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/description/"
+        },
+        "owner": "MyOrg1MSP",
+        "permissions": {
+            "process": {
+                "public": True,
+                "authorizedIDs": []
+            }
+        },
+        "metadata": {}
+    },
+    {
+        "key": "ebbd8c65dfe07d826d692f806deceffd296e715fa4db9e652304180dd7ee293d",
+        "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_traintuple_execution_failure - Algo 0",
+        "content": {
+            "hash": "ebbd8c65dfe07d826d692f806deceffd296e715fa4db9e652304180dd7ee293d",
+            "storageAddress": "http://testserver/algo/ebbd8c65dfe07d826d692f806deceffd296e715fa4db9e652304180dd7ee293d/file/"
+        },
+        "description": {
+            "hash": "d0289ce5f4ec35ea5eff7dc76b36cdc93c90bc3d76f55a8707a701f699742292",
+            "storageAddress": "http://testserver/algo/ebbd8c65dfe07d826d692f806deceffd296e715fa4db9e652304180dd7ee293d/description/"
+        },
+        "owner": "MyOrg1MSP",
+        "permissions": {
+            "process": {
+                "public": True,
+                "authorizedIDs": []
+            }
+        },
+        "metadata": {}
+    },
+    {
+        "key": "c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593",
+        "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_different_nodes - Algo 0",
+        "content": {
+            "hash": "c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593",
+            "storageAddress": "http://testserver/algo/c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593/file/"
+        },
+        "description": {
+            "hash": "9a56aa11bdb75a1b5c2641493d546d4a28ec4d9d60aa0df18f5c2a019f8518b7",
+            "storageAddress": "http://testserver/algo/c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593/description/"
         },
         "owner": "MyOrg2MSP",
         "permissions": {
@@ -146,112 +218,35 @@ algo = [
                 "public": True,
                 "authorizedIDs": []
             }
-        }
-    },
-    {
-        "key": "9c3d8777e11fd72cbc0fd672bec3a0848f8518b4d56706008cc05f8a1cee44f9",
-        "name": "Random Forest",
-        "content": {
-            "hash": "9c3d8777e11fd72cbc0fd672bec3a0848f8518b4d56706008cc05f8a1cee44f9",
-            "storageAddress": "http://testserver/algo/9c3d8777e11fd72cbc0fd672bec3a0848f8518b4d56706008cc05f8a1cee44f9/file/"
         },
-        "description": {
-            "hash": "4acea40c4b51996c88ef279c5c9aa41ab77b97d38c5ca167e978a98b2e402675",
-            "storageAddress": "http://testserver/algo/9c3d8777e11fd72cbc0fd672bec3a0848f8518b4d56706008cc05f8a1cee44f9/description/"
-        },
-        "owner": "MyOrg2MSP",
-        "permissions": {
-            "process": {
-                "public": True,
-                "authorizedIDs": []
-            }
-        }
+        "metadata": {}
     }
 ]
 
 traintuple = [
     {
-        "key": "c1d77d8e53f048b60863a1c453c60392e3f2b7b38dd0853f9b9664a5cef1c7cc",
+        "key": "3169bb172502f67556a6f12b856a5d653441227842aded24ade6b7866d3b624d",
         "algo": {
-            "name": "Neural Network",
-            "hash": "0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f",
-            "storageAddress": "http://testserver/algo/0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f/file/"
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple - Algo 0",
+            "hash": "4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be",
+            "storageAddress": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
         },
-        "creator": "MyOrg2MSP",
+        "creator": "MyOrg1MSP",
         "dataset": {
-            "worker": "MyOrg2MSP",
+            "worker": "MyOrg1MSP",
             "keys": [
-                "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
-                "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
+                "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f"
             ],
-            "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca"
+            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "metadata": {}
         },
         "computePlanID": "",
-        "inModels": None,
-        "log": "[00-01-0032-d50bc08]",
-        "outModel": None,
-        "permissions": {
-            "process": {
-                "public": True,
-                "authorizedIDs": []
-            }
-        },
-        "rank": 0,
-        "status": "failed",
-        "tag": "(should fail) My super tag"
-    },
-    {
-        "key": "a55fb929e12bca0be8e7d6db58bc7f5b6d2134c7c36d29961729da54d383dc01",
-        "algo": {
-            "name": "Random Forest",
-            "hash": "9c3d8777e11fd72cbc0fd672bec3a0848f8518b4d56706008cc05f8a1cee44f9",
-            "storageAddress": "http://testserver/algo/9c3d8777e11fd72cbc0fd672bec3a0848f8518b4d56706008cc05f8a1cee44f9/file/"
-        },
-        "creator": "MyOrg2MSP",
-        "dataset": {
-            "worker": "MyOrg2MSP",
-            "keys": [
-                "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
-                "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
-            ],
-            "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca"
-        },
-        "computePlanID": "",
-        "inModels": None,
-        "log": "[00-01-0032-5bd86f9]",
-        "outModel": None,
-        "permissions": {
-            "process": {
-                "public": True,
-                "authorizedIDs": []
-            }
-        },
-        "rank": 0,
-        "status": "failed",
-        "tag": "(should fail) My other tag"
-    },
-    {
-        "key": "d376a672c7231fba31e23c868202e088a06783da48577654360025050eaf88cc",
-        "algo": {
-            "name": "Logistic regression",
-            "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
-            "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/"
-        },
-        "creator": "MyOrg2MSP",
-        "dataset": {
-            "worker": "MyOrg2MSP",
-            "keys": [
-                "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
-                "e3644123451975be20909fcfd9c664a0573d9bfe04c5021625412d78c3536f1c"
-            ],
-            "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca"
-        },
-        "computePlanID": "2341f3e69a54010176575567aa7c2e728405c89969a6354dbf21cf477e986c42",
         "inModels": None,
         "log": "",
+        "metadata": {},
         "outModel": {
-            "hash": "14ea126a4c0cef4378aabce7157794c5d2d7f9dcf7057826805b2a12f90fd0f0",
-            "storageAddress": "http://testserver/model/14ea126a4c0cef4378aabce7157794c5d2d7f9dcf7057826805b2a12f90fd0f0/file/"
+            "hash": "940262c35a6b33c2b7c8811fa785899b00e287ffa05e3cb5a23c857e9c89c760",
+            "storageAddress": "http://testserver/model/940262c35a6b33c2b7c8811fa785899b00e287ffa05e3cb5a23c857e9c89c760/file/"
         },
         "permissions": {
             "process": {
@@ -264,27 +259,28 @@ traintuple = [
         "tag": ""
     },
     {
-        "key": "d7e429016148abfac682ec6a183b7883ccb96cd375bb3c7f5d3c35816c04f7d6",
+        "key": "a9c586b72c9c11412b0c9f81d599651a964d04934bca9f1886dd2d084f438a70",
         "algo": {
-            "name": "Logistic regression",
-            "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
-            "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/"
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple - Algo 0",
+            "hash": "4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be",
+            "storageAddress": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
         },
-        "creator": "MyOrg2MSP",
+        "creator": "MyOrg1MSP",
         "dataset": {
-            "worker": "MyOrg2MSP",
+            "worker": "MyOrg1MSP",
             "keys": [
-                "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
-                "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
+                "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3"
             ],
-            "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca"
+            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "metadata": {}
         },
         "computePlanID": "",
         "inModels": None,
         "log": "",
+        "metadata": {},
         "outModel": {
-            "hash": "149f94d883cff77f5770b10f9ca54b817a9362d8f36f370d7138939679a0f78e",
-            "storageAddress": "http://testserver/model/149f94d883cff77f5770b10f9ca54b817a9362d8f36f370d7138939679a0f78e/file/"
+            "hash": "f33d3c7a21e97f5f0edd636f3b313c6a7757cc458614e49da74d58af7fc0c4c2",
+            "storageAddress": "http://testserver/model/f33d3c7a21e97f5f0edd636f3b313c6a7757cc458614e49da74d58af7fc0c4c2/file/"
         },
         "permissions": {
             "process": {
@@ -294,6 +290,273 @@ traintuple = [
         },
         "rank": 0,
         "status": "done",
+        "tag": ""
+    },
+    {
+        "key": "ea7180ccc125dcceff10400fd2943f1e02fc915262c67f19986b3a9edbd765fb",
+        "algo": {
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple - Algo 0",
+            "hash": "4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be",
+            "storageAddress": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
+        },
+        "creator": "MyOrg1MSP",
+        "dataset": {
+            "worker": "MyOrg1MSP",
+            "keys": [
+                "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135"
+            ],
+            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "metadata": {}
+        },
+        "computePlanID": "",
+        "inModels": None,
+        "log": "",
+        "metadata": {},
+        "outModel": {
+            "hash": "02ccc4eeb426f7bbfe746a06a4c63a2023a8f2ea2c72f92242cc5f7f1164383c",
+            "storageAddress": "http://testserver/model/02ccc4eeb426f7bbfe746a06a4c63a2023a8f2ea2c72f92242cc5f7f1164383c/file/"
+        },
+        "permissions": {
+            "process": {
+                "public": True,
+                "authorizedIDs": []
+            }
+        },
+        "rank": 0,
+        "status": "done",
+        "tag": ""
+    },
+    {
+        "key": "137804ca8660878062e419e340efd2826ce0d528c47a40879e30cdc1e77da1b0",
+        "algo": {
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_federated_learning_workflow - Algo 0",
+            "hash": "59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30",
+            "storageAddress": "http://testserver/algo/59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30/file/"
+        },
+        "creator": "MyOrg1MSP",
+        "dataset": {
+            "worker": "MyOrg2MSP",
+            "keys": [
+                "26e52856b27261fc12e9615d5914027dc5986cd8bb37ccf1da4c7aa47b74a8ea",
+                "704740917e35b36648b80d9826e1f24d2082bf113f1693ba08975c7c405cb01f",
+                "88608067e903a7b5cbfed480e7c4ee9eaf7eb37994cb2fec045497f324508a33",
+                "e453da42246d9be33204fa30fb91755b989bbdeee2559dd93e14f57b57d1847f"
+            ],
+            "openerHash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+            "metadata": {}
+        },
+        "computePlanID": "4a7f743fd9a5ccaa6f8366a10f92955486ab15116a1e43f6c1ba1b9504f6b157",
+        "inModels": [
+            {
+                "traintupleKey": "49dedc3b4e763a2d09e39f4e5eee3d4910beee8b4e3ba666f9c6ef00f1632ec3",
+                "hash": "714ee81465576b09f1e4c6e0f28e82189501c46ed36569c9867eff851a285888",
+                "storageAddress": "http://testserver/model/714ee81465576b09f1e4c6e0f28e82189501c46ed36569c9867eff851a285888/file/"
+            }
+        ],
+        "log": "",
+        "metadata": {},
+        "outModel": {
+            "hash": "4672cd5a9e134a6f6c54144c3a8e8330b2147fa10264ca8e9fbac9b9075cacd0",
+            "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/model/4672cd5a9e134a6f6c54144c3a8e8330b2147fa10264ca8e9fbac9b9075cacd0/file/"
+        },
+        "permissions": {
+            "process": {
+                "public": True,
+                "authorizedIDs": []
+            }
+        },
+        "rank": 1,
+        "status": "done",
+        "tag": "foo"
+    },
+    {
+        "key": "49dedc3b4e763a2d09e39f4e5eee3d4910beee8b4e3ba666f9c6ef00f1632ec3",
+        "algo": {
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_federated_learning_workflow - Algo 0",
+            "hash": "59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30",
+            "storageAddress": "http://testserver/algo/59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30/file/"
+        },
+        "creator": "MyOrg1MSP",
+        "dataset": {
+            "worker": "MyOrg1MSP",
+            "keys": [
+                "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f",
+                "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135",
+                "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
+                "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
+            ],
+            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "metadata": {}
+        },
+        "computePlanID": "4a7f743fd9a5ccaa6f8366a10f92955486ab15116a1e43f6c1ba1b9504f6b157",
+        "inModels": None,
+        "log": "",
+        "metadata": {},
+        "outModel": {
+            "hash": "714ee81465576b09f1e4c6e0f28e82189501c46ed36569c9867eff851a285888",
+            "storageAddress": "http://testserver/model/714ee81465576b09f1e4c6e0f28e82189501c46ed36569c9867eff851a285888/file/"
+        },
+        "permissions": {
+            "process": {
+                "public": True,
+                "authorizedIDs": []
+            }
+        },
+        "rank": 0,
+        "status": "done",
+        "tag": "foo"
+    },
+    {
+        "key": "e623fe67c0dc4ed78d4e34f9f0fad0ac3a5fa7aafb819a3e1961f978d7540b2a",
+        "algo": {
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_different_nodes - Algo 0",
+            "hash": "c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593",
+            "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/algo/c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593/file/"
+        },
+        "creator": "MyOrg1MSP",
+        "dataset": {
+            "worker": "MyOrg2MSP",
+            "keys": [
+                "26e52856b27261fc12e9615d5914027dc5986cd8bb37ccf1da4c7aa47b74a8ea",
+                "704740917e35b36648b80d9826e1f24d2082bf113f1693ba08975c7c405cb01f",
+                "88608067e903a7b5cbfed480e7c4ee9eaf7eb37994cb2fec045497f324508a33",
+                "e453da42246d9be33204fa30fb91755b989bbdeee2559dd93e14f57b57d1847f"
+            ],
+            "openerHash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+            "metadata": {}
+        },
+        "computePlanID": "",
+        "inModels": None,
+        "log": "",
+        "metadata": {},
+        "outModel": {
+            "hash": "d771446f0be15ebaa66db902f5a98a5005611de4ea44d3a5fe77c50ee34ff114",
+            "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/model/d771446f0be15ebaa66db902f5a98a5005611de4ea44d3a5fe77c50ee34ff114/file/"
+        },
+        "permissions": {
+            "process": {
+                "public": True,
+                "authorizedIDs": []
+            }
+        },
+        "rank": 0,
+        "status": "done",
+        "tag": ""
+    },
+    {
+        "key": "e3aab7fe0c51e970edecdfa1f780fd529e437d92603e66e57f230d926c7808b6",
+        "algo": {
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_same_node - Algo 0",
+            "hash": "e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8",
+            "storageAddress": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
+        },
+        "creator": "MyOrg1MSP",
+        "dataset": {
+            "worker": "MyOrg1MSP",
+            "keys": [
+                "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f",
+                "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135",
+                "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
+                "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
+            ],
+            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "metadata": {}
+        },
+        "computePlanID": "",
+        "inModels": None,
+        "log": "",
+        "metadata": {
+            "foo": "bar"
+        },
+        "outModel": {
+            "hash": "420ce592a42e0c78e644447173b54046163a2afeadd37227cef6866fc7d4c4f7",
+            "storageAddress": "http://testserver/model/420ce592a42e0c78e644447173b54046163a2afeadd37227cef6866fc7d4c4f7/file/"
+        },
+        "permissions": {
+            "process": {
+                "public": True,
+                "authorizedIDs": []
+            }
+        },
+        "rank": 0,
+        "status": "done",
+        "tag": ""
+    },
+    {
+        "key": "fcdbcf06d54b634edfe2dd2d46cfe8d63076570394b7335fab6e6aac99b51909",
+        "algo": {
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_same_node - Algo 0",
+            "hash": "e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8",
+            "storageAddress": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
+        },
+        "creator": "MyOrg1MSP",
+        "dataset": {
+            "worker": "MyOrg1MSP",
+            "keys": [
+                "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f",
+                "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135",
+                "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
+                "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
+            ],
+            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "metadata": {}
+        },
+        "computePlanID": "",
+        "inModels": [
+            {
+                "traintupleKey": "e3aab7fe0c51e970edecdfa1f780fd529e437d92603e66e57f230d926c7808b6",
+                "hash": "420ce592a42e0c78e644447173b54046163a2afeadd37227cef6866fc7d4c4f7",
+                "storageAddress": "http://testserver/model/420ce592a42e0c78e644447173b54046163a2afeadd37227cef6866fc7d4c4f7/file/"
+            }
+        ],
+        "log": "",
+        "metadata": {},
+        "outModel": {
+            "hash": "7b3183a99222df2b18de11c8f767fdca2c7ebb0d4fa8bfe03c4f169cfea2aba2",
+            "storageAddress": "http://testserver/model/7b3183a99222df2b18de11c8f767fdca2c7ebb0d4fa8bfe03c4f169cfea2aba2/file/"
+        },
+        "permissions": {
+            "process": {
+                "public": True,
+                "authorizedIDs": []
+            }
+        },
+        "rank": 0,
+        "status": "done",
+        "tag": ""
+    },
+    {
+        "key": "5e18aef8a6748b220c82532c39b297159704f0b2b602ab8e5c4e6e59f2ec6cba",
+        "algo": {
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_traintuple_execution_failure - Algo 0",
+            "hash": "ebbd8c65dfe07d826d692f806deceffd296e715fa4db9e652304180dd7ee293d",
+            "storageAddress": "http://testserver/algo/ebbd8c65dfe07d826d692f806deceffd296e715fa4db9e652304180dd7ee293d/file/"
+        },
+        "creator": "MyOrg1MSP",
+        "dataset": {
+            "worker": "MyOrg1MSP",
+            "keys": [
+                "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f",
+                "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135",
+                "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
+                "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
+            ],
+            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "metadata": {}
+        },
+        "computePlanID": "",
+        "inModels": None,
+        "log": "[00-01-0117-d64af6f]",
+        "metadata": {},
+        "outModel": None,
+        "permissions": {
+            "process": {
+                "public": True,
+                "authorizedIDs": []
+            }
+        },
+        "rank": 0,
+        "status": "failed",
         "tag": ""
     }
 ]
@@ -301,80 +564,227 @@ traintuple = [
 testtuple = [
     {
         "algo": {
-            "name": "Logistic regression",
-            "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
-            "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/"
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_composite_traintuples_execution - Algo 0",
+            "hash": "09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf",
+            "storageAddress": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
         },
         "certified": True,
         "computePlanID": "",
-        "creator": "MyOrg2MSP",
+        "creator": "MyOrg1MSP",
         "dataset": {
             "worker": "MyOrg1MSP",
             "keys": [
-                "17d58b67ae2028018108c9bf555fa58b2ddcfe560e0117294196e79d26140b2a",
-                "8bf3bf4f753a32f27d18c86405e7a406a83a55610d91abcca9acc525061b8ecf"
+                "ffed4147fffff2f18130b7332c1460ecccd8e1378765c415b82b948c19e98a68"
             ],
-            "openerHash": "ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932",
-            "perf": 0
+            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "perf": 32
         },
-        "key": "b835634d3ffb38fa98101619717aa07b62051ab2caa7be784dd1cfaef374d99a",
+        "key": "8cd0eb9ae2349fc33b36ebb689963840bdfd3ffe4f24392d77dba85c4c087d02",
         "log": "",
+        "metadata": {},
         "objective": {
-            "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
+            "hash": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
             "metrics": {
-                "hash": "e5762042461c355761dd8986b510ea23494d5638a671370dabbf0ac73f8a3208",
-                "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
+                "hash": "0d64f855e07524da60203067713ab08fd6e479a02ebcb70364b2c6a2a29367e1",
+                "storageAddress": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
             }
         },
         "rank": 0,
         "status": "done",
-        "tag": "substra",
-        "traintupleKey": "d7e429016148abfac682ec6a183b7883ccb96cd375bb3c7f5d3c35816c04f7d6",
+        "tag": "bar",
+        "traintupleKey": "2978ca1f7d5520ef42a82c86a2e24d5b00f04c73013febdb5ed35d32dc606e92",
+        "traintupleType": "compositeTraintuple"
+    },
+    {
+        "algo": {
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
+            "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
+            "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+        },
+        "certified": True,
+        "computePlanID": "",
+        "creator": "MyOrg1MSP",
+        "dataset": {
+            "worker": "MyOrg2MSP",
+            "keys": [
+                "edaa4ccdfc9bcadda859498fbb550a6e1fc6baf176389c3eb18afc8a382b4145"
+            ],
+            "openerHash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+            "perf": 32
+        },
+        "key": "87e835650d84ca0cf26ac332bad4f4d732a30606505f57f1817fb6580f16adc5",
+        "log": "",
+        "metadata": {},
+        "objective": {
+            "hash": "b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3",
+            "metrics": {
+                "hash": "1a61bea02e3e75f8197d682cbaa6110c9709fbfbd4f16964acc390c70e7a22fe",
+                "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/objective/b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3/metrics/"
+            }
+        },
+        "rank": 0,
+        "status": "done",
+        "tag": "",
+        "traintupleKey": "3be92d96d1abdabfbe6a4ff612d70f7f867f450c38ea344bd98d0775bec826fd",
+        "traintupleType": "compositeTraintuple"
+    },
+    {
+        "algo": {
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
+            "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
+            "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+        },
+        "certified": True,
+        "computePlanID": "",
+        "creator": "MyOrg1MSP",
+        "dataset": {
+            "worker": "MyOrg1MSP",
+            "keys": [
+                "ffed4147fffff2f18130b7332c1460ecccd8e1378765c415b82b948c19e98a68"
+            ],
+            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "perf": 32
+        },
+        "key": "6075c796cc470f1e1de7b98d8a4d28b19e48c1d662ee9bdb982c0354088d2f2a",
+        "log": "",
+        "metadata": {},
+        "objective": {
+            "hash": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
+            "metrics": {
+                "hash": "0d64f855e07524da60203067713ab08fd6e479a02ebcb70364b2c6a2a29367e1",
+                "storageAddress": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
+            }
+        },
+        "rank": 0,
+        "status": "done",
+        "tag": "",
+        "traintupleKey": "5adbd24ea21cb23b1ffc65151038a62c97f2d745d7df0928e683707f15a09556",
+        "traintupleType": "compositeTraintuple"
+    },
+    {
+        "algo": {
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_same_node - Algo 0",
+            "hash": "e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8",
+            "storageAddress": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
+        },
+        "certified": True,
+        "computePlanID": "",
+        "creator": "MyOrg1MSP",
+        "dataset": {
+            "worker": "MyOrg1MSP",
+            "keys": [
+                "ffed4147fffff2f18130b7332c1460ecccd8e1378765c415b82b948c19e98a68"
+            ],
+            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "perf": 2
+        },
+        "key": "e2f386a88a1702cecf0270742a31cdf0be4a9d9b083467679058d00aaff55ac4",
+        "log": "",
+        "metadata": {},
+        "objective": {
+            "hash": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
+            "metrics": {
+                "hash": "0d64f855e07524da60203067713ab08fd6e479a02ebcb70364b2c6a2a29367e1",
+                "storageAddress": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
+            }
+        },
+        "rank": 0,
+        "status": "done",
+        "tag": "",
+        "traintupleKey": "e3aab7fe0c51e970edecdfa1f780fd529e437d92603e66e57f230d926c7808b6",
+        "traintupleType": "traintuple"
+    },
+    {
+        "algo": {
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_different_nodes - Algo 0",
+            "hash": "c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593",
+            "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/algo/c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593/file/"
+        },
+        "certified": True,
+        "computePlanID": "",
+        "creator": "MyOrg1MSP",
+        "dataset": {
+            "worker": "MyOrg1MSP",
+            "keys": [
+                "ffed4147fffff2f18130b7332c1460ecccd8e1378765c415b82b948c19e98a68"
+            ],
+            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "perf": 2
+        },
+        "key": "0599697085f343a8298ee3a87bd0000285e944fa4a05f541aa985d3eab50c04d",
+        "log": "",
+        "metadata": {},
+        "objective": {
+            "hash": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
+            "metrics": {
+                "hash": "0d64f855e07524da60203067713ab08fd6e479a02ebcb70364b2c6a2a29367e1",
+                "storageAddress": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
+            }
+        },
+        "rank": 0,
+        "status": "done",
+        "tag": "",
+        "traintupleKey": "e623fe67c0dc4ed78d4e34f9f0fad0ac3a5fa7aafb819a3e1961f978d7540b2a",
         "traintupleType": "traintuple"
     }
 ]
 
 computeplan = [
     {
-        "computePlanID": "2341f3e69a54010176575567aa7c2e728405c89969a6354dbf21cf477e986c42",
+        "computePlanID": "4a7f743fd9a5ccaa6f8366a10f92955486ab15116a1e43f6c1ba1b9504f6b157",
         "traintupleKeys": [
-            "d376a672c7231fba31e23c868202e088a06783da48577654360025050eaf88cc"
+            "49dedc3b4e763a2d09e39f4e5eee3d4910beee8b4e3ba666f9c6ef00f1632ec3",
+            "137804ca8660878062e419e340efd2826ce0d528c47a40879e30cdc1e77da1b0"
         ],
         "aggregatetupleKeys": None,
         "compositeTraintupleKeys": None,
         "testtupleKeys": None,
+        "cleanModels": False,
         "tag": "",
+        "metadata": {},
         "status": "done",
-        "tupleCount": 1,
-        "doneCount": 1
+        "tupleCount": 2,
+        "doneCount": 2,
+        "IDToKey": {}
     }
 ]
 
 compositetraintuple = [
     {
-        "key": "e83d39acb3870a06f46d92bcc251cc54e6f96d5be756a08fcba321819b86333f",
+        "key": "2978ca1f7d5520ef42a82c86a2e24d5b00f04c73013febdb5ed35d32dc606e92",
         "algo": {
-            "name": "Logistic regression (composite)",
-            "hash": "468a18f9c9dedefa32d266c8263f117cd0e859ffecf531d2b90a220559acd96f",
-            "storageAddress": "http://testserver/composite_algo/468a18f9c9dedefa32d266c8263f117cd0e859ffecf531d2b90a220559acd96f/file/"
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_composite_traintuples_execution - Algo 0",
+            "hash": "09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf",
+            "storageAddress": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
         },
         "creator": "MyOrg1MSP",
         "dataset": {
-            "worker": "MyOrg2MSP",
+            "worker": "MyOrg1MSP",
             "keys": [
-                "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
-                "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
+                "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f",
+                "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135",
+                "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
+                "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
             ],
-            "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca"
+            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "metadata": {}
         },
         "computePlanID": "",
-        "inHeadModel": None,
-        "inTrunkModel": None,
+        "inHeadModel": {
+            "traintupleKey": "aa9be143edc6ef051ea255fd77bb54ba40c71bb39afa3ece502dd36782d02a71",
+            "hash": "64c72dc39772e122ef552d10ff101ef6cee94935a84678a0125f7c3fd044dff8",
+            "storageAddress": ""
+        },
+        "inTrunkModel": {
+            "traintupleKey": "aa9be143edc6ef051ea255fd77bb54ba40c71bb39afa3ece502dd36782d02a71",
+            "hash": "00009a1256f8ce55ed907221000035daf1ac28111b5a3a03289da2f0601edf8f",
+            "storageAddress": "http://testserver/model/00009a1256f8ce55ed907221000035daf1ac28111b5a3a03289da2f0601edf8f/file/"
+        },
         "log": "",
+        "metadata": {},
         "outHeadModel": {
             "outModel": {
-                "hash": "df3f74523a807d0c2b06abffb0a1ca4d44c6a121dc61280608caab5fba450ee9",
-                "storageAddress": "http://testserver/model/df3f74523a807d0c2b06abffb0a1ca4d44c6a121dc61280608caab5fba450ee9/file/"
+                "hash": "349b475ebd9458739af8685b8b75d7aeb1290209eabadad1b9b8afaa2b05c8d5"
             },
             "permissions": {
                 "process": {
@@ -387,8 +797,8 @@ compositetraintuple = [
         },
         "outTrunkModel": {
             "outModel": {
-                "hash": "2485b8f0bed25260684d8052ab6f77e0817e821eaea8acd763ed8e64701d9b47",
-                "storageAddress": "http://testserver/model/2485b8f0bed25260684d8052ab6f77e0817e821eaea8acd763ed8e64701d9b47/file/"
+                "hash": "692e3f70b9ebfca3c2e51e2a92c18092cc24dda547debefd6eb4bdd38ca6d803",
+                "storageAddress": "http://testserver/model/692e3f70b9ebfca3c2e51e2a92c18092cc24dda547debefd6eb4bdd38ca6d803/file/"
             },
             "permissions": {
                 "process": {
@@ -401,21 +811,458 @@ compositetraintuple = [
         },
         "rank": 0,
         "status": "done",
+        "tag": ""
+    },
+    {
+        "key": "aa9be143edc6ef051ea255fd77bb54ba40c71bb39afa3ece502dd36782d02a71",
+        "algo": {
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_composite_traintuples_execution - Algo 0",
+            "hash": "09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf",
+            "storageAddress": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
+        },
+        "creator": "MyOrg1MSP",
+        "dataset": {
+            "worker": "MyOrg1MSP",
+            "keys": [
+                "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f",
+                "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135",
+                "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
+                "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
+            ],
+            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "metadata": {}
+        },
+        "computePlanID": "",
+        "inHeadModel": None,
+        "inTrunkModel": None,
+        "log": "",
+        "metadata": {},
+        "outHeadModel": {
+            "outModel": {
+                "hash": "64c72dc39772e122ef552d10ff101ef6cee94935a84678a0125f7c3fd044dff8"
+            },
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorizedIDs": [
+                        "MyOrg1MSP"
+                    ]
+                }
+            }
+        },
+        "outTrunkModel": {
+            "outModel": {
+                "hash": "00009a1256f8ce55ed907221000035daf1ac28111b5a3a03289da2f0601edf8f",
+                "storageAddress": "http://testserver/model/00009a1256f8ce55ed907221000035daf1ac28111b5a3a03289da2f0601edf8f/file/"
+            },
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorizedIDs": [
+                        "MyOrg1MSP"
+                    ]
+                }
+            }
+        },
+        "rank": 0,
+        "status": "done",
+        "tag": ""
+    },
+    {
+        "key": "2d3e98fbeafebf1995db3ab205b9f803b18a1be8b4af72e242faceee3dd7d224",
+        "algo": {
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_composite_traintuple_execution_failure - Algo 0",
+            "hash": "0fbb505a32ae8785c08d37fe7bf7476d7365c3a0cef7c6e05c61c06db3267593",
+            "storageAddress": "http://testserver/composite_algo/0fbb505a32ae8785c08d37fe7bf7476d7365c3a0cef7c6e05c61c06db3267593/file/"
+        },
+        "creator": "MyOrg1MSP",
+        "dataset": {
+            "worker": "MyOrg1MSP",
+            "keys": [
+                "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f",
+                "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135",
+                "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
+                "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
+            ],
+            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "metadata": {}
+        },
+        "computePlanID": "",
+        "inHeadModel": None,
+        "inTrunkModel": None,
+        "log": "[00-01-0117-d390d32]",
+        "metadata": {},
+        "outHeadModel": {
+            "outModel": None,
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorizedIDs": [
+                        "MyOrg1MSP"
+                    ]
+                }
+            }
+        },
+        "outTrunkModel": {
+            "outModel": None,
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorizedIDs": [
+                        "MyOrg1MSP"
+                    ]
+                }
+            }
+        },
+        "rank": 0,
+        "status": "failed",
+        "tag": ""
+    },
+    {
+        "key": "7dbd4b2ac9e81b6dedd775809e0903d8fa55ce2cb8094bd6c4c20c2b0448b716",
+        "algo": {
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple_execution_failure - Algo 0",
+            "hash": "5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c",
+            "storageAddress": "http://testserver/composite_algo/5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c/file/"
+        },
+        "creator": "MyOrg1MSP",
+        "dataset": {
+            "worker": "MyOrg1MSP",
+            "keys": [
+                "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f"
+            ],
+            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "metadata": {}
+        },
+        "computePlanID": "",
+        "inHeadModel": None,
+        "inTrunkModel": None,
+        "log": "",
+        "metadata": {},
+        "outHeadModel": {
+            "outModel": {
+                "hash": "8b87222907027a470d6d99409b0de9a9ced07142d026ab875d6ddfdecf9db96d"
+            },
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorizedIDs": [
+                        "MyOrg1MSP"
+                    ]
+                }
+            }
+        },
+        "outTrunkModel": {
+            "outModel": {
+                "hash": "fcfcaa4f3be73940006fc54566b2946fabd5ee677496a5dd43e4b8c0c3c3d54d",
+                "storageAddress": "http://testserver/model/fcfcaa4f3be73940006fc54566b2946fabd5ee677496a5dd43e4b8c0c3c3d54d/file/"
+            },
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorizedIDs": [
+                        "MyOrg1MSP"
+                    ]
+                }
+            }
+        },
+        "rank": 0,
+        "status": "done",
+        "tag": ""
+    },
+    {
+        "key": "df3e19426496a5b8a79d8f1b96e52de9fe3a07b6a81a9b5d9a34a824d52c1841",
+        "algo": {
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple_execution_failure - Algo 0",
+            "hash": "5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c",
+            "storageAddress": "http://testserver/composite_algo/5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c/file/"
+        },
+        "creator": "MyOrg1MSP",
+        "dataset": {
+            "worker": "MyOrg1MSP",
+            "keys": [
+                "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135"
+            ],
+            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "metadata": {}
+        },
+        "computePlanID": "",
+        "inHeadModel": None,
+        "inTrunkModel": None,
+        "log": "",
+        "metadata": {},
+        "outHeadModel": {
+            "outModel": {
+                "hash": "bffb89749a253de1d451a836748dc813035dbcacb01fb85911b97c577c10ea6d"
+            },
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorizedIDs": [
+                        "MyOrg1MSP"
+                    ]
+                }
+            }
+        },
+        "outTrunkModel": {
+            "outModel": {
+                "hash": "682d31d9e95654ed0aaf81184136d87c7ff2a0046c3d24181508f112d58b330d",
+                "storageAddress": "http://testserver/model/682d31d9e95654ed0aaf81184136d87c7ff2a0046c3d24181508f112d58b330d/file/"
+            },
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorizedIDs": [
+                        "MyOrg1MSP"
+                    ]
+                }
+            }
+        },
+        "rank": 0,
+        "status": "done",
+        "tag": ""
+    },
+    {
+        "key": "3197bd6c56bc47089864c76b47b6115eb3551901ba304722ce581561c37b0c7b",
+        "algo": {
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
+            "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
+            "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+        },
+        "creator": "MyOrg1MSP",
+        "dataset": {
+            "worker": "MyOrg1MSP",
+            "keys": [
+                "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f"
+            ],
+            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "metadata": {}
+        },
+        "computePlanID": "",
+        "inHeadModel": None,
+        "inTrunkModel": None,
+        "log": "",
+        "metadata": {},
+        "outHeadModel": {
+            "outModel": {
+                "hash": "7d7ed2eac5e822ea90058387dd35d1270639ecc4982a6d72b619b8659813163a"
+            },
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorizedIDs": [
+                        "MyOrg1MSP"
+                    ]
+                }
+            }
+        },
+        "outTrunkModel": {
+            "outModel": {
+                "hash": "b312a262592aa7ed56a07d0eb02bec0548745eb7316d4ea86b3719b2497d8cb2",
+                "storageAddress": "http://testserver/model/b312a262592aa7ed56a07d0eb02bec0548745eb7316d4ea86b3719b2497d8cb2/file/"
+            },
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorizedIDs": [
+                        "MyOrg1MSP",
+                        "MyOrg2MSP"
+                    ]
+                }
+            }
+        },
+        "rank": 0,
+        "status": "done",
+        "tag": ""
+    },
+    {
+        "key": "3be92d96d1abdabfbe6a4ff612d70f7f867f450c38ea344bd98d0775bec826fd",
+        "algo": {
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
+            "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
+            "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+        },
+        "creator": "MyOrg1MSP",
+        "dataset": {
+            "worker": "MyOrg2MSP",
+            "keys": [
+                "704740917e35b36648b80d9826e1f24d2082bf113f1693ba08975c7c405cb01f"
+            ],
+            "openerHash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+            "metadata": {}
+        },
+        "computePlanID": "",
+        "inHeadModel": {
+            "traintupleKey": "e7b96818eadcdce6940c16b388bbd264549646a45bb8ea75e8f218d224c18162",
+            "hash": "3af8f86ed9fe07237497e52d1ced195d7e4752f7d130327929f96ea688d60a41",
+            "storageAddress": ""
+        },
+        "inTrunkModel": {
+            "traintupleKey": "9cb5582fc3e822b9ddabbf7479097df05381294e3559f31a35c20f2e46e4885c",
+            "hash": "4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688",
+            "storageAddress": "http://testserver/model/4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688/file/"
+        },
+        "log": "",
+        "metadata": {},
+        "outHeadModel": {
+            "outModel": {
+                "hash": "8b6a7f3b7feef0a2c157bf2acfd2596fd7815a0a69b0a41b7451bab47d022eaa"
+            },
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorizedIDs": [
+                        "MyOrg2MSP"
+                    ]
+                }
+            }
+        },
+        "outTrunkModel": {
+            "outModel": {
+                "hash": "66392ca3e6a5935fb8e22a5ee5b8af31dbec5655ff087b98f071abf7e4f3ce74",
+                "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/model/66392ca3e6a5935fb8e22a5ee5b8af31dbec5655ff087b98f071abf7e4f3ce74/file/"
+            },
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorizedIDs": [
+                        "MyOrg1MSP",
+                        "MyOrg2MSP"
+                    ]
+                }
+            }
+        },
+        "rank": 0,
+        "status": "done",
+        "tag": ""
+    },
+    {
+        "key": "5adbd24ea21cb23b1ffc65151038a62c97f2d745d7df0928e683707f15a09556",
+        "algo": {
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
+            "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
+            "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+        },
+        "creator": "MyOrg1MSP",
+        "dataset": {
+            "worker": "MyOrg1MSP",
+            "keys": [
+                "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135"
+            ],
+            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "metadata": {}
+        },
+        "computePlanID": "",
+        "inHeadModel": {
+            "traintupleKey": "3197bd6c56bc47089864c76b47b6115eb3551901ba304722ce581561c37b0c7b",
+            "hash": "7d7ed2eac5e822ea90058387dd35d1270639ecc4982a6d72b619b8659813163a",
+            "storageAddress": ""
+        },
+        "inTrunkModel": {
+            "traintupleKey": "9cb5582fc3e822b9ddabbf7479097df05381294e3559f31a35c20f2e46e4885c",
+            "hash": "4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688",
+            "storageAddress": "http://testserver/model/4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688/file/"
+        },
+        "log": "",
+        "metadata": {},
+        "outHeadModel": {
+            "outModel": {
+                "hash": "28a705e08e765569bd89262f821e1c7285e43fa1e82df2f833464b8ff890c7bd"
+            },
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorizedIDs": [
+                        "MyOrg1MSP"
+                    ]
+                }
+            }
+        },
+        "outTrunkModel": {
+            "outModel": {
+                "hash": "14b7e3254896db4f43c582695c39d096f33e1390e3ecaa8b0e6e7619bf827044",
+                "storageAddress": "http://testserver/model/14b7e3254896db4f43c582695c39d096f33e1390e3ecaa8b0e6e7619bf827044/file/"
+            },
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorizedIDs": [
+                        "MyOrg1MSP",
+                        "MyOrg2MSP"
+                    ]
+                }
+            }
+        },
+        "rank": 0,
+        "status": "done",
+        "tag": ""
+    },
+    {
+        "key": "e7b96818eadcdce6940c16b388bbd264549646a45bb8ea75e8f218d224c18162",
+        "algo": {
+            "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
+            "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
+            "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+        },
+        "creator": "MyOrg1MSP",
+        "dataset": {
+            "worker": "MyOrg2MSP",
+            "keys": [
+                "26e52856b27261fc12e9615d5914027dc5986cd8bb37ccf1da4c7aa47b74a8ea"
+            ],
+            "openerHash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+            "metadata": {}
+        },
+        "computePlanID": "",
+        "inHeadModel": None,
+        "inTrunkModel": None,
+        "log": "",
+        "metadata": {},
+        "outHeadModel": {
+            "outModel": {
+                "hash": "3af8f86ed9fe07237497e52d1ced195d7e4752f7d130327929f96ea688d60a41"
+            },
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorizedIDs": [
+                        "MyOrg2MSP"
+                    ]
+                }
+            }
+        },
+        "outTrunkModel": {
+            "outModel": {
+                "hash": "cd8a895a9b604ccbb2e2bf9f081d0560bfd86f4a98beabd833d4c7c36f35cd9d",
+                "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/model/cd8a895a9b604ccbb2e2bf9f081d0560bfd86f4a98beabd833d4c7c36f35cd9d/file/"
+            },
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorizedIDs": [
+                        "MyOrg1MSP",
+                        "MyOrg2MSP"
+                    ]
+                }
+            }
+        },
+        "rank": 0,
+        "status": "done",
         "tag": "substra"
     }
 ]
 
 compositealgo = [
     {
-        "key": "468a18f9c9dedefa32d266c8263f117cd0e859ffecf531d2b90a220559acd96f",
-        "name": "Logistic regression (composite)",
+        "key": "09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf",
+        "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_composite_traintuples_execution - Algo 0",
         "content": {
-            "hash": "468a18f9c9dedefa32d266c8263f117cd0e859ffecf531d2b90a220559acd96f",
-            "storageAddress": "http://testserver/composite_algo/468a18f9c9dedefa32d266c8263f117cd0e859ffecf531d2b90a220559acd96f/file/"
+            "hash": "09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf",
+            "storageAddress": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
         },
         "description": {
-            "hash": "a5108cfd377dce09c5c2e439fc1527e4b50128099b1e8ec525b6e4dc85f7300f",
-            "storageAddress": "http://testserver/composite_algo/468a18f9c9dedefa32d266c8263f117cd0e859ffecf531d2b90a220559acd96f/description/"
+            "hash": "aa444b9dc8cac0c80263b3970ddc403757abc6bcb546eb322a1711f1b8ec294d",
+            "storageAddress": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/description/"
         },
         "owner": "MyOrg1MSP",
         "permissions": {
@@ -423,248 +1270,648 @@ compositealgo = [
                 "public": True,
                 "authorizedIDs": []
             }
-        }
+        },
+        "metadata": {}
+    },
+    {
+        "key": "0fbb505a32ae8785c08d37fe7bf7476d7365c3a0cef7c6e05c61c06db3267593",
+        "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_composite_traintuple_execution_failure - Algo 0",
+        "content": {
+            "hash": "0fbb505a32ae8785c08d37fe7bf7476d7365c3a0cef7c6e05c61c06db3267593",
+            "storageAddress": "http://testserver/composite_algo/0fbb505a32ae8785c08d37fe7bf7476d7365c3a0cef7c6e05c61c06db3267593/file/"
+        },
+        "description": {
+            "hash": "6d184a2e6d8097cc55e4b435bbd5b9c6d7211274472585448411cd435149e941",
+            "storageAddress": "http://testserver/composite_algo/0fbb505a32ae8785c08d37fe7bf7476d7365c3a0cef7c6e05c61c06db3267593/description/"
+        },
+        "owner": "MyOrg1MSP",
+        "permissions": {
+            "process": {
+                "public": True,
+                "authorizedIDs": []
+            }
+        },
+        "metadata": {}
+    },
+    {
+        "key": "5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c",
+        "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple_execution_failure - Algo 0",
+        "content": {
+            "hash": "5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c",
+            "storageAddress": "http://testserver/composite_algo/5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c/file/"
+        },
+        "description": {
+            "hash": "61cc1c0f3962bc4d60151041e02b55ca9788ea7a8a848dfc67f3fc3194b5a202",
+            "storageAddress": "http://testserver/composite_algo/5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c/description/"
+        },
+        "owner": "MyOrg1MSP",
+        "permissions": {
+            "process": {
+                "public": True,
+                "authorizedIDs": []
+            }
+        },
+        "metadata": {}
+    },
+    {
+        "key": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
+        "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
+        "content": {
+            "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
+            "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+        },
+        "description": {
+            "hash": "066d354d20dfa689cd5ca22f99445dc47589971c6d958bd6841beeae585f1054",
+            "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/description/"
+        },
+        "owner": "MyOrg1MSP",
+        "permissions": {
+            "process": {
+                "public": True,
+                "authorizedIDs": []
+            }
+        },
+        "metadata": {}
     }
 ]
 
 model = [
     {
         "traintuple": {
-            "key": "c1d77d8e53f048b60863a1c453c60392e3f2b7b38dd0853f9b9664a5cef1c7cc",
+            "key": "3169bb172502f67556a6f12b856a5d653441227842aded24ade6b7866d3b624d",
             "algo": {
-                "name": "Neural Network",
-                "hash": "0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f",
-                "storageAddress": "http://testserver/algo/0acc5180e09b6a6ac250f4e3c172e2893f617aa1c22ef1f379019d20fe44142f/file/"
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple - Algo 0",
+                "hash": "4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be",
+                "storageAddress": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
             },
-            "creator": "MyOrg2MSP",
-            "dataset": {
-                "worker": "MyOrg2MSP",
-                "keys": [
-                    "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
-                    "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
-                ],
-                "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca"
-            },
-            "computePlanID": "",
-            "inModels": None,
-            "log": "[00-01-0032-d50bc08]",
-            "outModel": None,
-            "permissions": {
-                "process": {
-                    "public": True,
-                    "authorizedIDs": []
-                }
-            },
-            "rank": 0,
-            "status": "failed",
-            "tag": "(should fail) My super tag"
-        },
-        "testtuple": {
-            "algo": None,
-            "certified": False,
-            "computePlanID": "",
-            "creator": "",
-            "dataset": None,
-            "key": "",
-            "log": "",
-            "objective": None,
-            "rank": 0,
-            "status": "",
-            "tag": "",
-            "traintupleKey": "",
-            "traintupleType": ""
-        }
-    },
-    {
-        "traintuple": {
-            "key": "a55fb929e12bca0be8e7d6db58bc7f5b6d2134c7c36d29961729da54d383dc01",
-            "algo": {
-                "name": "Random Forest",
-                "hash": "9c3d8777e11fd72cbc0fd672bec3a0848f8518b4d56706008cc05f8a1cee44f9",
-                "storageAddress": "http://testserver/algo/9c3d8777e11fd72cbc0fd672bec3a0848f8518b4d56706008cc05f8a1cee44f9/file/"
-            },
-            "creator": "MyOrg2MSP",
-            "dataset": {
-                "worker": "MyOrg2MSP",
-                "keys": [
-                    "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
-                    "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
-                ],
-                "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca"
-            },
-            "computePlanID": "",
-            "inModels": None,
-            "log": "[00-01-0032-5bd86f9]",
-            "outModel": None,
-            "permissions": {
-                "process": {
-                    "public": True,
-                    "authorizedIDs": []
-                }
-            },
-            "rank": 0,
-            "status": "failed",
-            "tag": "(should fail) My other tag"
-        },
-        "testtuple": {
-            "algo": None,
-            "certified": False,
-            "computePlanID": "",
-            "creator": "",
-            "dataset": None,
-            "key": "",
-            "log": "",
-            "objective": None,
-            "rank": 0,
-            "status": "",
-            "tag": "",
-            "traintupleKey": "",
-            "traintupleType": ""
-        }
-    },
-    {
-        "traintuple": {
-            "key": "d376a672c7231fba31e23c868202e088a06783da48577654360025050eaf88cc",
-            "algo": {
-                "name": "Logistic regression",
-                "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
-                "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/"
-            },
-            "creator": "MyOrg2MSP",
-            "dataset": {
-                "worker": "MyOrg2MSP",
-                "keys": [
-                    "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
-                    "e3644123451975be20909fcfd9c664a0573d9bfe04c5021625412d78c3536f1c"
-                ],
-                "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca"
-            },
-            "computePlanID": "2341f3e69a54010176575567aa7c2e728405c89969a6354dbf21cf477e986c42",
-            "inModels": None,
-            "log": "",
-            "outModel": {
-                "hash": "14ea126a4c0cef4378aabce7157794c5d2d7f9dcf7057826805b2a12f90fd0f0",
-                "storageAddress": "http://testserver/model/14ea126a4c0cef4378aabce7157794c5d2d7f9dcf7057826805b2a12f90fd0f0/file/"
-            },
-            "permissions": {
-                "process": {
-                    "public": True,
-                    "authorizedIDs": []
-                }
-            },
-            "rank": 0,
-            "status": "done",
-            "tag": ""
-        },
-        "testtuple": {
-            "algo": None,
-            "certified": False,
-            "computePlanID": "",
-            "creator": "",
-            "dataset": None,
-            "key": "",
-            "log": "",
-            "objective": None,
-            "rank": 0,
-            "status": "",
-            "tag": "",
-            "traintupleKey": "",
-            "traintupleType": ""
-        }
-    },
-    {
-        "traintuple": {
-            "key": "d7e429016148abfac682ec6a183b7883ccb96cd375bb3c7f5d3c35816c04f7d6",
-            "algo": {
-                "name": "Logistic regression",
-                "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
-                "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/"
-            },
-            "creator": "MyOrg2MSP",
-            "dataset": {
-                "worker": "MyOrg2MSP",
-                "keys": [
-                    "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
-                    "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
-                ],
-                "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca"
-            },
-            "computePlanID": "",
-            "inModels": None,
-            "log": "",
-            "outModel": {
-                "hash": "149f94d883cff77f5770b10f9ca54b817a9362d8f36f370d7138939679a0f78e",
-                "storageAddress": "http://testserver/model/149f94d883cff77f5770b10f9ca54b817a9362d8f36f370d7138939679a0f78e/file/"
-            },
-            "permissions": {
-                "process": {
-                    "public": True,
-                    "authorizedIDs": []
-                }
-            },
-            "rank": 0,
-            "status": "done",
-            "tag": ""
-        },
-        "testtuple": {
-            "algo": {
-                "name": "Logistic regression",
-                "hash": "9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d",
-                "storageAddress": "http://testserver/algo/9fe61782e7b4d445dff6bc0baae01eb3fa6e926ad0f6870365d605eee5bd169d/file/"
-            },
-            "certified": True,
-            "computePlanID": "",
-            "creator": "MyOrg2MSP",
+            "creator": "MyOrg1MSP",
             "dataset": {
                 "worker": "MyOrg1MSP",
                 "keys": [
-                    "17d58b67ae2028018108c9bf555fa58b2ddcfe560e0117294196e79d26140b2a",
-                    "8bf3bf4f753a32f27d18c86405e7a406a83a55610d91abcca9acc525061b8ecf"
+                    "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f"
                 ],
-                "openerHash": "ce9f292c72e9b82697445117f9c2d1d18ce0f8ed07ff91dadb17d668bddf8932",
-                "perf": 0
+                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "metadata": {}
             },
-            "key": "b835634d3ffb38fa98101619717aa07b62051ab2caa7be784dd1cfaef374d99a",
+            "computePlanID": "",
+            "inModels": None,
             "log": "",
-            "objective": {
-                "hash": "3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71",
-                "metrics": {
-                    "hash": "e5762042461c355761dd8986b510ea23494d5638a671370dabbf0ac73f8a3208",
-                    "storageAddress": "http://testserver/objective/3d70ab46d710dacb0f48cb42db4874fac14e048a0d415e266aad38c09591ee71/metrics/"
+            "metadata": {},
+            "outModel": {
+                "hash": "940262c35a6b33c2b7c8811fa785899b00e287ffa05e3cb5a23c857e9c89c760",
+                "storageAddress": "http://testserver/model/940262c35a6b33c2b7c8811fa785899b00e287ffa05e3cb5a23c857e9c89c760/file/"
+            },
+            "permissions": {
+                "process": {
+                    "public": True,
+                    "authorizedIDs": []
                 }
             },
             "rank": 0,
             "status": "done",
-            "tag": "substra",
-            "traintupleKey": "d7e429016148abfac682ec6a183b7883ccb96cd375bb3c7f5d3c35816c04f7d6",
-            "traintupleType": "traintuple"
-        }
+            "tag": ""
+        },
+        "testtuple": {
+            "algo": None,
+            "certified": False,
+            "computePlanID": "",
+            "creator": "",
+            "dataset": None,
+            "key": "",
+            "log": "",
+            "metadata": None,
+            "objective": None,
+            "rank": 0,
+            "status": "",
+            "tag": "",
+            "traintupleKey": "",
+            "traintupleType": ""
+        },
+        "nonCertifiedTesttuples": None
     },
     {
-        "compositeTraintuple": {
-            "key": "e83d39acb3870a06f46d92bcc251cc54e6f96d5be756a08fcba321819b86333f",
+        "traintuple": {
+            "key": "a9c586b72c9c11412b0c9f81d599651a964d04934bca9f1886dd2d084f438a70",
             "algo": {
-                "name": "Logistic regression (composite)",
-                "hash": "468a18f9c9dedefa32d266c8263f117cd0e859ffecf531d2b90a220559acd96f",
-                "storageAddress": "http://testserver/composite_algo/468a18f9c9dedefa32d266c8263f117cd0e859ffecf531d2b90a220559acd96f/file/"
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple - Algo 0",
+                "hash": "4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be",
+                "storageAddress": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
+            },
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg1MSP",
+                "keys": [
+                    "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3"
+                ],
+                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "metadata": {}
+            },
+            "computePlanID": "",
+            "inModels": None,
+            "log": "",
+            "metadata": {},
+            "outModel": {
+                "hash": "f33d3c7a21e97f5f0edd636f3b313c6a7757cc458614e49da74d58af7fc0c4c2",
+                "storageAddress": "http://testserver/model/f33d3c7a21e97f5f0edd636f3b313c6a7757cc458614e49da74d58af7fc0c4c2/file/"
+            },
+            "permissions": {
+                "process": {
+                    "public": True,
+                    "authorizedIDs": []
+                }
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": ""
+        },
+        "testtuple": {
+            "algo": None,
+            "certified": False,
+            "computePlanID": "",
+            "creator": "",
+            "dataset": None,
+            "key": "",
+            "log": "",
+            "metadata": None,
+            "objective": None,
+            "rank": 0,
+            "status": "",
+            "tag": "",
+            "traintupleKey": "",
+            "traintupleType": ""
+        },
+        "nonCertifiedTesttuples": None
+    },
+    {
+        "traintuple": {
+            "key": "ea7180ccc125dcceff10400fd2943f1e02fc915262c67f19986b3a9edbd765fb",
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple - Algo 0",
+                "hash": "4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be",
+                "storageAddress": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
+            },
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg1MSP",
+                "keys": [
+                    "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135"
+                ],
+                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "metadata": {}
+            },
+            "computePlanID": "",
+            "inModels": None,
+            "log": "",
+            "metadata": {},
+            "outModel": {
+                "hash": "02ccc4eeb426f7bbfe746a06a4c63a2023a8f2ea2c72f92242cc5f7f1164383c",
+                "storageAddress": "http://testserver/model/02ccc4eeb426f7bbfe746a06a4c63a2023a8f2ea2c72f92242cc5f7f1164383c/file/"
+            },
+            "permissions": {
+                "process": {
+                    "public": True,
+                    "authorizedIDs": []
+                }
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": ""
+        },
+        "testtuple": {
+            "algo": None,
+            "certified": False,
+            "computePlanID": "",
+            "creator": "",
+            "dataset": None,
+            "key": "",
+            "log": "",
+            "metadata": None,
+            "objective": None,
+            "rank": 0,
+            "status": "",
+            "tag": "",
+            "traintupleKey": "",
+            "traintupleType": ""
+        },
+        "nonCertifiedTesttuples": None
+    },
+    {
+        "traintuple": {
+            "key": "137804ca8660878062e419e340efd2826ce0d528c47a40879e30cdc1e77da1b0",
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_federated_learning_workflow - Algo 0",
+                "hash": "59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30",
+                "storageAddress": "http://testserver/algo/59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30/file/"
             },
             "creator": "MyOrg1MSP",
             "dataset": {
                 "worker": "MyOrg2MSP",
                 "keys": [
-                    "31510dc1d8be788f7c5d28d05714f7efb9edb667762966b9adc02eadeaacebe9",
-                    "03a1f878768ea8624942d46a3b438c37992e626c2cf655023bcc3bed69d485d1"
+                    "26e52856b27261fc12e9615d5914027dc5986cd8bb37ccf1da4c7aa47b74a8ea",
+                    "704740917e35b36648b80d9826e1f24d2082bf113f1693ba08975c7c405cb01f",
+                    "88608067e903a7b5cbfed480e7c4ee9eaf7eb37994cb2fec045497f324508a33",
+                    "e453da42246d9be33204fa30fb91755b989bbdeee2559dd93e14f57b57d1847f"
                 ],
-                "openerHash": "8dd01465003a9b1e01c99c904d86aa518b3a5dd9dc8d40fe7d075c726ac073ca"
+                "openerHash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+                "metadata": {}
+            },
+            "computePlanID": "4a7f743fd9a5ccaa6f8366a10f92955486ab15116a1e43f6c1ba1b9504f6b157",
+            "inModels": [
+                {
+                    "traintupleKey": "49dedc3b4e763a2d09e39f4e5eee3d4910beee8b4e3ba666f9c6ef00f1632ec3",
+                    "hash": "714ee81465576b09f1e4c6e0f28e82189501c46ed36569c9867eff851a285888",
+                    "storageAddress": "http://testserver/model/714ee81465576b09f1e4c6e0f28e82189501c46ed36569c9867eff851a285888/file/"
+                }
+            ],
+            "log": "",
+            "metadata": {},
+            "outModel": {
+                "hash": "4672cd5a9e134a6f6c54144c3a8e8330b2147fa10264ca8e9fbac9b9075cacd0",
+                "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/model/4672cd5a9e134a6f6c54144c3a8e8330b2147fa10264ca8e9fbac9b9075cacd0/file/"
+            },
+            "permissions": {
+                "process": {
+                    "public": True,
+                    "authorizedIDs": []
+                }
+            },
+            "rank": 1,
+            "status": "done",
+            "tag": "foo"
+        },
+        "testtuple": {
+            "algo": None,
+            "certified": False,
+            "computePlanID": "",
+            "creator": "",
+            "dataset": None,
+            "key": "",
+            "log": "",
+            "metadata": None,
+            "objective": None,
+            "rank": 0,
+            "status": "",
+            "tag": "",
+            "traintupleKey": "",
+            "traintupleType": ""
+        },
+        "nonCertifiedTesttuples": None
+    },
+    {
+        "traintuple": {
+            "key": "49dedc3b4e763a2d09e39f4e5eee3d4910beee8b4e3ba666f9c6ef00f1632ec3",
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_federated_learning_workflow - Algo 0",
+                "hash": "59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30",
+                "storageAddress": "http://testserver/algo/59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30/file/"
+            },
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg1MSP",
+                "keys": [
+                    "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f",
+                    "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135",
+                    "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
+                    "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
+                ],
+                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "metadata": {}
+            },
+            "computePlanID": "4a7f743fd9a5ccaa6f8366a10f92955486ab15116a1e43f6c1ba1b9504f6b157",
+            "inModels": None,
+            "log": "",
+            "metadata": {},
+            "outModel": {
+                "hash": "714ee81465576b09f1e4c6e0f28e82189501c46ed36569c9867eff851a285888",
+                "storageAddress": "http://testserver/model/714ee81465576b09f1e4c6e0f28e82189501c46ed36569c9867eff851a285888/file/"
+            },
+            "permissions": {
+                "process": {
+                    "public": True,
+                    "authorizedIDs": []
+                }
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": "foo"
+        },
+        "testtuple": {
+            "algo": None,
+            "certified": False,
+            "computePlanID": "",
+            "creator": "",
+            "dataset": None,
+            "key": "",
+            "log": "",
+            "metadata": None,
+            "objective": None,
+            "rank": 0,
+            "status": "",
+            "tag": "",
+            "traintupleKey": "",
+            "traintupleType": ""
+        },
+        "nonCertifiedTesttuples": None
+    },
+    {
+        "traintuple": {
+            "key": "e623fe67c0dc4ed78d4e34f9f0fad0ac3a5fa7aafb819a3e1961f978d7540b2a",
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_different_nodes - Algo 0",
+                "hash": "c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593",
+                "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/algo/c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593/file/"
+            },
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg2MSP",
+                "keys": [
+                    "26e52856b27261fc12e9615d5914027dc5986cd8bb37ccf1da4c7aa47b74a8ea",
+                    "704740917e35b36648b80d9826e1f24d2082bf113f1693ba08975c7c405cb01f",
+                    "88608067e903a7b5cbfed480e7c4ee9eaf7eb37994cb2fec045497f324508a33",
+                    "e453da42246d9be33204fa30fb91755b989bbdeee2559dd93e14f57b57d1847f"
+                ],
+                "openerHash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+                "metadata": {}
             },
             "computePlanID": "",
-            "inHeadModel": None,
-            "inTrunkModel": None,
+            "inModels": None,
             "log": "",
+            "metadata": {},
+            "outModel": {
+                "hash": "d771446f0be15ebaa66db902f5a98a5005611de4ea44d3a5fe77c50ee34ff114",
+                "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/model/d771446f0be15ebaa66db902f5a98a5005611de4ea44d3a5fe77c50ee34ff114/file/"
+            },
+            "permissions": {
+                "process": {
+                    "public": True,
+                    "authorizedIDs": []
+                }
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": ""
+        },
+        "testtuple": {
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_different_nodes - Algo 0",
+                "hash": "c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593",
+                "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/algo/c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593/file/"
+            },
+            "certified": True,
+            "computePlanID": "",
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg1MSP",
+                "keys": [
+                    "ffed4147fffff2f18130b7332c1460ecccd8e1378765c415b82b948c19e98a68"
+                ],
+                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "perf": 2
+            },
+            "key": "0599697085f343a8298ee3a87bd0000285e944fa4a05f541aa985d3eab50c04d",
+            "log": "",
+            "metadata": {},
+            "objective": {
+                "hash": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
+                "metrics": {
+                    "hash": "0d64f855e07524da60203067713ab08fd6e479a02ebcb70364b2c6a2a29367e1",
+                    "storageAddress": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
+                }
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": "",
+            "traintupleKey": "e623fe67c0dc4ed78d4e34f9f0fad0ac3a5fa7aafb819a3e1961f978d7540b2a",
+            "traintupleType": "traintuple"
+        },
+        "nonCertifiedTesttuples": None
+    },
+    {
+        "traintuple": {
+            "key": "e3aab7fe0c51e970edecdfa1f780fd529e437d92603e66e57f230d926c7808b6",
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_same_node - Algo 0",
+                "hash": "e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8",
+                "storageAddress": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
+            },
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg1MSP",
+                "keys": [
+                    "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f",
+                    "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135",
+                    "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
+                    "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
+                ],
+                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "metadata": {}
+            },
+            "computePlanID": "",
+            "inModels": None,
+            "log": "",
+            "metadata": {
+                "foo": "bar"
+            },
+            "outModel": {
+                "hash": "420ce592a42e0c78e644447173b54046163a2afeadd37227cef6866fc7d4c4f7",
+                "storageAddress": "http://testserver/model/420ce592a42e0c78e644447173b54046163a2afeadd37227cef6866fc7d4c4f7/file/"
+            },
+            "permissions": {
+                "process": {
+                    "public": True,
+                    "authorizedIDs": []
+                }
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": ""
+        },
+        "testtuple": {
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_same_node - Algo 0",
+                "hash": "e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8",
+                "storageAddress": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
+            },
+            "certified": True,
+            "computePlanID": "",
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg1MSP",
+                "keys": [
+                    "ffed4147fffff2f18130b7332c1460ecccd8e1378765c415b82b948c19e98a68"
+                ],
+                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "perf": 2
+            },
+            "key": "e2f386a88a1702cecf0270742a31cdf0be4a9d9b083467679058d00aaff55ac4",
+            "log": "",
+            "metadata": {},
+            "objective": {
+                "hash": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
+                "metrics": {
+                    "hash": "0d64f855e07524da60203067713ab08fd6e479a02ebcb70364b2c6a2a29367e1",
+                    "storageAddress": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
+                }
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": "",
+            "traintupleKey": "e3aab7fe0c51e970edecdfa1f780fd529e437d92603e66e57f230d926c7808b6",
+            "traintupleType": "traintuple"
+        },
+        "nonCertifiedTesttuples": None
+    },
+    {
+        "traintuple": {
+            "key": "fcdbcf06d54b634edfe2dd2d46cfe8d63076570394b7335fab6e6aac99b51909",
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_same_node - Algo 0",
+                "hash": "e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8",
+                "storageAddress": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
+            },
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg1MSP",
+                "keys": [
+                    "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f",
+                    "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135",
+                    "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
+                    "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
+                ],
+                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "metadata": {}
+            },
+            "computePlanID": "",
+            "inModels": [
+                {
+                    "traintupleKey": "e3aab7fe0c51e970edecdfa1f780fd529e437d92603e66e57f230d926c7808b6",
+                    "hash": "420ce592a42e0c78e644447173b54046163a2afeadd37227cef6866fc7d4c4f7",
+                    "storageAddress": "http://testserver/model/420ce592a42e0c78e644447173b54046163a2afeadd37227cef6866fc7d4c4f7/file/"
+                }
+            ],
+            "log": "",
+            "metadata": {},
+            "outModel": {
+                "hash": "7b3183a99222df2b18de11c8f767fdca2c7ebb0d4fa8bfe03c4f169cfea2aba2",
+                "storageAddress": "http://testserver/model/7b3183a99222df2b18de11c8f767fdca2c7ebb0d4fa8bfe03c4f169cfea2aba2/file/"
+            },
+            "permissions": {
+                "process": {
+                    "public": True,
+                    "authorizedIDs": []
+                }
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": ""
+        },
+        "testtuple": {
+            "algo": None,
+            "certified": False,
+            "computePlanID": "",
+            "creator": "",
+            "dataset": None,
+            "key": "",
+            "log": "",
+            "metadata": None,
+            "objective": None,
+            "rank": 0,
+            "status": "",
+            "tag": "",
+            "traintupleKey": "",
+            "traintupleType": ""
+        },
+        "nonCertifiedTesttuples": None
+    },
+    {
+        "traintuple": {
+            "key": "5e18aef8a6748b220c82532c39b297159704f0b2b602ab8e5c4e6e59f2ec6cba",
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_traintuple_execution_failure - Algo 0",
+                "hash": "ebbd8c65dfe07d826d692f806deceffd296e715fa4db9e652304180dd7ee293d",
+                "storageAddress": "http://testserver/algo/ebbd8c65dfe07d826d692f806deceffd296e715fa4db9e652304180dd7ee293d/file/"
+            },
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg1MSP",
+                "keys": [
+                    "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f",
+                    "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135",
+                    "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
+                    "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
+                ],
+                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "metadata": {}
+            },
+            "computePlanID": "",
+            "inModels": None,
+            "log": "[00-01-0117-d64af6f]",
+            "metadata": {},
+            "outModel": None,
+            "permissions": {
+                "process": {
+                    "public": True,
+                    "authorizedIDs": []
+                }
+            },
+            "rank": 0,
+            "status": "failed",
+            "tag": ""
+        },
+        "testtuple": {
+            "algo": None,
+            "certified": False,
+            "computePlanID": "",
+            "creator": "",
+            "dataset": None,
+            "key": "",
+            "log": "",
+            "metadata": None,
+            "objective": None,
+            "rank": 0,
+            "status": "",
+            "tag": "",
+            "traintupleKey": "",
+            "traintupleType": ""
+        },
+        "nonCertifiedTesttuples": None
+    },
+    {
+        "compositeTraintuple": {
+            "key": "2978ca1f7d5520ef42a82c86a2e24d5b00f04c73013febdb5ed35d32dc606e92",
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_composite_traintuples_execution - Algo 0",
+                "hash": "09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf",
+                "storageAddress": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
+            },
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg1MSP",
+                "keys": [
+                    "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f",
+                    "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135",
+                    "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
+                    "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
+                ],
+                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "metadata": {}
+            },
+            "computePlanID": "",
+            "inHeadModel": {
+                "traintupleKey": "aa9be143edc6ef051ea255fd77bb54ba40c71bb39afa3ece502dd36782d02a71",
+                "hash": "64c72dc39772e122ef552d10ff101ef6cee94935a84678a0125f7c3fd044dff8",
+                "storageAddress": ""
+            },
+            "inTrunkModel": {
+                "traintupleKey": "aa9be143edc6ef051ea255fd77bb54ba40c71bb39afa3ece502dd36782d02a71",
+                "hash": "00009a1256f8ce55ed907221000035daf1ac28111b5a3a03289da2f0601edf8f",
+                "storageAddress": "http://testserver/model/00009a1256f8ce55ed907221000035daf1ac28111b5a3a03289da2f0601edf8f/file/"
+            },
+            "log": "",
+            "metadata": {},
             "outHeadModel": {
                 "outModel": {
-                    "hash": "df3f74523a807d0c2b06abffb0a1ca4d44c6a121dc61280608caab5fba450ee9",
-                    "storageAddress": "http://testserver/model/df3f74523a807d0c2b06abffb0a1ca4d44c6a121dc61280608caab5fba450ee9/file/"
+                    "hash": "349b475ebd9458739af8685b8b75d7aeb1290209eabadad1b9b8afaa2b05c8d5"
                 },
                 "permissions": {
                     "process": {
@@ -677,8 +1924,8 @@ model = [
             },
             "outTrunkModel": {
                 "outModel": {
-                    "hash": "2485b8f0bed25260684d8052ab6f77e0817e821eaea8acd763ed8e64701d9b47",
-                    "storageAddress": "http://testserver/model/2485b8f0bed25260684d8052ab6f77e0817e821eaea8acd763ed8e64701d9b47/file/"
+                    "hash": "692e3f70b9ebfca3c2e51e2a92c18092cc24dda547debefd6eb4bdd38ca6d803",
+                    "storageAddress": "http://testserver/model/692e3f70b9ebfca3c2e51e2a92c18092cc24dda547debefd6eb4bdd38ca6d803/file/"
                 },
                 "permissions": {
                     "process": {
@@ -691,7 +1938,98 @@ model = [
             },
             "rank": 0,
             "status": "done",
-            "tag": "substra"
+            "tag": ""
+        },
+        "testtuple": {
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_composite_traintuples_execution - Algo 0",
+                "hash": "09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf",
+                "storageAddress": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
+            },
+            "certified": True,
+            "computePlanID": "",
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg1MSP",
+                "keys": [
+                    "ffed4147fffff2f18130b7332c1460ecccd8e1378765c415b82b948c19e98a68"
+                ],
+                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "perf": 32
+            },
+            "key": "8cd0eb9ae2349fc33b36ebb689963840bdfd3ffe4f24392d77dba85c4c087d02",
+            "log": "",
+            "metadata": {},
+            "objective": {
+                "hash": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
+                "metrics": {
+                    "hash": "0d64f855e07524da60203067713ab08fd6e479a02ebcb70364b2c6a2a29367e1",
+                    "storageAddress": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
+                }
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": "",
+            "traintupleKey": "2978ca1f7d5520ef42a82c86a2e24d5b00f04c73013febdb5ed35d32dc606e92",
+            "traintupleType": "compositeTraintuple"
+        },
+        "nonCertifiedTesttuples": None
+    },
+    {
+        "compositeTraintuple": {
+            "key": "aa9be143edc6ef051ea255fd77bb54ba40c71bb39afa3ece502dd36782d02a71",
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_composite_traintuples_execution - Algo 0",
+                "hash": "09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf",
+                "storageAddress": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
+            },
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg1MSP",
+                "keys": [
+                    "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f",
+                    "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135",
+                    "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
+                    "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
+                ],
+                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "metadata": {}
+            },
+            "computePlanID": "",
+            "inHeadModel": None,
+            "inTrunkModel": None,
+            "log": "",
+            "metadata": {},
+            "outHeadModel": {
+                "outModel": {
+                    "hash": "64c72dc39772e122ef552d10ff101ef6cee94935a84678a0125f7c3fd044dff8"
+                },
+                "permissions": {
+                    "process": {
+                        "public": False,
+                        "authorizedIDs": [
+                            "MyOrg1MSP"
+                        ]
+                    }
+                }
+            },
+            "outTrunkModel": {
+                "outModel": {
+                    "hash": "00009a1256f8ce55ed907221000035daf1ac28111b5a3a03289da2f0601edf8f",
+                    "storageAddress": "http://testserver/model/00009a1256f8ce55ed907221000035daf1ac28111b5a3a03289da2f0601edf8f/file/"
+                },
+                "permissions": {
+                    "process": {
+                        "public": False,
+                        "authorizedIDs": [
+                            "MyOrg1MSP"
+                        ]
+                    }
+                }
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": ""
         },
         "testtuple": {
             "algo": None,
@@ -701,13 +2039,802 @@ model = [
             "dataset": None,
             "key": "",
             "log": "",
+            "metadata": None,
             "objective": None,
             "rank": 0,
             "status": "",
             "tag": "",
             "traintupleKey": "",
             "traintupleType": ""
-        }
+        },
+        "nonCertifiedTesttuples": None
+    },
+    {
+        "compositeTraintuple": {
+            "key": "2d3e98fbeafebf1995db3ab205b9f803b18a1be8b4af72e242faceee3dd7d224",
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_composite_traintuple_execution_failure - Algo 0",
+                "hash": "0fbb505a32ae8785c08d37fe7bf7476d7365c3a0cef7c6e05c61c06db3267593",
+                "storageAddress": "http://testserver/composite_algo/0fbb505a32ae8785c08d37fe7bf7476d7365c3a0cef7c6e05c61c06db3267593/file/"
+            },
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg1MSP",
+                "keys": [
+                    "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f",
+                    "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135",
+                    "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
+                    "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
+                ],
+                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "metadata": {}
+            },
+            "computePlanID": "",
+            "inHeadModel": None,
+            "inTrunkModel": None,
+            "log": "[00-01-0117-d390d32]",
+            "metadata": {},
+            "outHeadModel": {
+                "outModel": None,
+                "permissions": {
+                    "process": {
+                        "public": False,
+                        "authorizedIDs": [
+                            "MyOrg1MSP"
+                        ]
+                    }
+                }
+            },
+            "outTrunkModel": {
+                "outModel": None,
+                "permissions": {
+                    "process": {
+                        "public": False,
+                        "authorizedIDs": [
+                            "MyOrg1MSP"
+                        ]
+                    }
+                }
+            },
+            "rank": 0,
+            "status": "failed",
+            "tag": ""
+        },
+        "testtuple": {
+            "algo": None,
+            "certified": False,
+            "computePlanID": "",
+            "creator": "",
+            "dataset": None,
+            "key": "",
+            "log": "",
+            "metadata": None,
+            "objective": None,
+            "rank": 0,
+            "status": "",
+            "tag": "",
+            "traintupleKey": "",
+            "traintupleType": ""
+        },
+        "nonCertifiedTesttuples": None
+    },
+    {
+        "compositeTraintuple": {
+            "key": "7dbd4b2ac9e81b6dedd775809e0903d8fa55ce2cb8094bd6c4c20c2b0448b716",
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple_execution_failure - Algo 0",
+                "hash": "5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c",
+                "storageAddress": "http://testserver/composite_algo/5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c/file/"
+            },
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg1MSP",
+                "keys": [
+                    "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f"
+                ],
+                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "metadata": {}
+            },
+            "computePlanID": "",
+            "inHeadModel": None,
+            "inTrunkModel": None,
+            "log": "",
+            "metadata": {},
+            "outHeadModel": {
+                "outModel": {
+                    "hash": "8b87222907027a470d6d99409b0de9a9ced07142d026ab875d6ddfdecf9db96d"
+                },
+                "permissions": {
+                    "process": {
+                        "public": False,
+                        "authorizedIDs": [
+                            "MyOrg1MSP"
+                        ]
+                    }
+                }
+            },
+            "outTrunkModel": {
+                "outModel": {
+                    "hash": "fcfcaa4f3be73940006fc54566b2946fabd5ee677496a5dd43e4b8c0c3c3d54d",
+                    "storageAddress": "http://testserver/model/fcfcaa4f3be73940006fc54566b2946fabd5ee677496a5dd43e4b8c0c3c3d54d/file/"
+                },
+                "permissions": {
+                    "process": {
+                        "public": False,
+                        "authorizedIDs": [
+                            "MyOrg1MSP"
+                        ]
+                    }
+                }
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": ""
+        },
+        "testtuple": {
+            "algo": None,
+            "certified": False,
+            "computePlanID": "",
+            "creator": "",
+            "dataset": None,
+            "key": "",
+            "log": "",
+            "metadata": None,
+            "objective": None,
+            "rank": 0,
+            "status": "",
+            "tag": "",
+            "traintupleKey": "",
+            "traintupleType": ""
+        },
+        "nonCertifiedTesttuples": None
+    },
+    {
+        "compositeTraintuple": {
+            "key": "df3e19426496a5b8a79d8f1b96e52de9fe3a07b6a81a9b5d9a34a824d52c1841",
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple_execution_failure - Algo 0",
+                "hash": "5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c",
+                "storageAddress": "http://testserver/composite_algo/5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c/file/"
+            },
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg1MSP",
+                "keys": [
+                    "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135"
+                ],
+                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "metadata": {}
+            },
+            "computePlanID": "",
+            "inHeadModel": None,
+            "inTrunkModel": None,
+            "log": "",
+            "metadata": {},
+            "outHeadModel": {
+                "outModel": {
+                    "hash": "bffb89749a253de1d451a836748dc813035dbcacb01fb85911b97c577c10ea6d"
+                },
+                "permissions": {
+                    "process": {
+                        "public": False,
+                        "authorizedIDs": [
+                            "MyOrg1MSP"
+                        ]
+                    }
+                }
+            },
+            "outTrunkModel": {
+                "outModel": {
+                    "hash": "682d31d9e95654ed0aaf81184136d87c7ff2a0046c3d24181508f112d58b330d",
+                    "storageAddress": "http://testserver/model/682d31d9e95654ed0aaf81184136d87c7ff2a0046c3d24181508f112d58b330d/file/"
+                },
+                "permissions": {
+                    "process": {
+                        "public": False,
+                        "authorizedIDs": [
+                            "MyOrg1MSP"
+                        ]
+                    }
+                }
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": ""
+        },
+        "testtuple": {
+            "algo": None,
+            "certified": False,
+            "computePlanID": "",
+            "creator": "",
+            "dataset": None,
+            "key": "",
+            "log": "",
+            "metadata": None,
+            "objective": None,
+            "rank": 0,
+            "status": "",
+            "tag": "",
+            "traintupleKey": "",
+            "traintupleType": ""
+        },
+        "nonCertifiedTesttuples": None
+    },
+    {
+        "compositeTraintuple": {
+            "key": "3197bd6c56bc47089864c76b47b6115eb3551901ba304722ce581561c37b0c7b",
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
+                "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
+                "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+            },
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg1MSP",
+                "keys": [
+                    "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f"
+                ],
+                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "metadata": {}
+            },
+            "computePlanID": "",
+            "inHeadModel": None,
+            "inTrunkModel": None,
+            "log": "",
+            "metadata": {},
+            "outHeadModel": {
+                "outModel": {
+                    "hash": "7d7ed2eac5e822ea90058387dd35d1270639ecc4982a6d72b619b8659813163a"
+                },
+                "permissions": {
+                    "process": {
+                        "public": False,
+                        "authorizedIDs": [
+                            "MyOrg1MSP"
+                        ]
+                    }
+                }
+            },
+            "outTrunkModel": {
+                "outModel": {
+                    "hash": "b312a262592aa7ed56a07d0eb02bec0548745eb7316d4ea86b3719b2497d8cb2",
+                    "storageAddress": "http://testserver/model/b312a262592aa7ed56a07d0eb02bec0548745eb7316d4ea86b3719b2497d8cb2/file/"
+                },
+                "permissions": {
+                    "process": {
+                        "public": False,
+                        "authorizedIDs": [
+                            "MyOrg1MSP",
+                            "MyOrg2MSP"
+                        ]
+                    }
+                }
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": ""
+        },
+        "testtuple": {
+            "algo": None,
+            "certified": False,
+            "computePlanID": "",
+            "creator": "",
+            "dataset": None,
+            "key": "",
+            "log": "",
+            "metadata": None,
+            "objective": None,
+            "rank": 0,
+            "status": "",
+            "tag": "",
+            "traintupleKey": "",
+            "traintupleType": ""
+        },
+        "nonCertifiedTesttuples": None
+    },
+    {
+        "compositeTraintuple": {
+            "key": "3be92d96d1abdabfbe6a4ff612d70f7f867f450c38ea344bd98d0775bec826fd",
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
+                "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
+                "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+            },
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg2MSP",
+                "keys": [
+                    "704740917e35b36648b80d9826e1f24d2082bf113f1693ba08975c7c405cb01f"
+                ],
+                "openerHash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+                "metadata": {}
+            },
+            "computePlanID": "",
+            "inHeadModel": {
+                "traintupleKey": "e7b96818eadcdce6940c16b388bbd264549646a45bb8ea75e8f218d224c18162",
+                "hash": "3af8f86ed9fe07237497e52d1ced195d7e4752f7d130327929f96ea688d60a41",
+                "storageAddress": ""
+            },
+            "inTrunkModel": {
+                "traintupleKey": "9cb5582fc3e822b9ddabbf7479097df05381294e3559f31a35c20f2e46e4885c",
+                "hash": "4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688",
+                "storageAddress": "http://testserver/model/4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688/file/"
+            },
+            "log": "",
+            "metadata": {},
+            "outHeadModel": {
+                "outModel": {
+                    "hash": "8b6a7f3b7feef0a2c157bf2acfd2596fd7815a0a69b0a41b7451bab47d022eaa"
+                },
+                "permissions": {
+                    "process": {
+                        "public": False,
+                        "authorizedIDs": [
+                            "MyOrg2MSP"
+                        ]
+                    }
+                }
+            },
+            "outTrunkModel": {
+                "outModel": {
+                    "hash": "66392ca3e6a5935fb8e22a5ee5b8af31dbec5655ff087b98f071abf7e4f3ce74",
+                    "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/model/66392ca3e6a5935fb8e22a5ee5b8af31dbec5655ff087b98f071abf7e4f3ce74/file/"
+                },
+                "permissions": {
+                    "process": {
+                        "public": False,
+                        "authorizedIDs": [
+                            "MyOrg1MSP",
+                            "MyOrg2MSP"
+                        ]
+                    }
+                }
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": ""
+        },
+        "testtuple": {
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
+                "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
+                "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+            },
+            "certified": True,
+            "computePlanID": "",
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg2MSP",
+                "keys": [
+                    "edaa4ccdfc9bcadda859498fbb550a6e1fc6baf176389c3eb18afc8a382b4145"
+                ],
+                "openerHash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+                "perf": 32
+            },
+            "key": "87e835650d84ca0cf26ac332bad4f4d732a30606505f57f1817fb6580f16adc5",
+            "log": "",
+            "metadata": {},
+            "objective": {
+                "hash": "b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3",
+                "metrics": {
+                    "hash": "1a61bea02e3e75f8197d682cbaa6110c9709fbfbd4f16964acc390c70e7a22fe",
+                    "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/objective/b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3/metrics/"
+                }
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": "",
+            "traintupleKey": "3be92d96d1abdabfbe6a4ff612d70f7f867f450c38ea344bd98d0775bec826fd",
+            "traintupleType": "compositeTraintuple"
+        },
+        "nonCertifiedTesttuples": None
+    },
+    {
+        "compositeTraintuple": {
+            "key": "5adbd24ea21cb23b1ffc65151038a62c97f2d745d7df0928e683707f15a09556",
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
+                "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
+                "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+            },
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg1MSP",
+                "keys": [
+                    "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135"
+                ],
+                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "metadata": {}
+            },
+            "computePlanID": "",
+            "inHeadModel": {
+                "traintupleKey": "3197bd6c56bc47089864c76b47b6115eb3551901ba304722ce581561c37b0c7b",
+                "hash": "7d7ed2eac5e822ea90058387dd35d1270639ecc4982a6d72b619b8659813163a",
+                "storageAddress": ""
+            },
+            "inTrunkModel": {
+                "traintupleKey": "9cb5582fc3e822b9ddabbf7479097df05381294e3559f31a35c20f2e46e4885c",
+                "hash": "4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688",
+                "storageAddress": "http://testserver/model/4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688/file/"
+            },
+            "log": "",
+            "metadata": {},
+            "outHeadModel": {
+                "outModel": {
+                    "hash": "28a705e08e765569bd89262f821e1c7285e43fa1e82df2f833464b8ff890c7bd"
+                },
+                "permissions": {
+                    "process": {
+                        "public": False,
+                        "authorizedIDs": [
+                            "MyOrg1MSP"
+                        ]
+                    }
+                }
+            },
+            "outTrunkModel": {
+                "outModel": {
+                    "hash": "14b7e3254896db4f43c582695c39d096f33e1390e3ecaa8b0e6e7619bf827044",
+                    "storageAddress": "http://testserver/model/14b7e3254896db4f43c582695c39d096f33e1390e3ecaa8b0e6e7619bf827044/file/"
+                },
+                "permissions": {
+                    "process": {
+                        "public": False,
+                        "authorizedIDs": [
+                            "MyOrg1MSP",
+                            "MyOrg2MSP"
+                        ]
+                    }
+                }
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": ""
+        },
+        "testtuple": {
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
+                "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
+                "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+            },
+            "certified": True,
+            "computePlanID": "",
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg1MSP",
+                "keys": [
+                    "ffed4147fffff2f18130b7332c1460ecccd8e1378765c415b82b948c19e98a68"
+                ],
+                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "perf": 32
+            },
+            "key": "6075c796cc470f1e1de7b98d8a4d28b19e48c1d662ee9bdb982c0354088d2f2a",
+            "log": "",
+            "metadata": {},
+            "objective": {
+                "hash": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
+                "metrics": {
+                    "hash": "0d64f855e07524da60203067713ab08fd6e479a02ebcb70364b2c6a2a29367e1",
+                    "storageAddress": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
+                }
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": "",
+            "traintupleKey": "5adbd24ea21cb23b1ffc65151038a62c97f2d745d7df0928e683707f15a09556",
+            "traintupleType": "compositeTraintuple"
+        },
+        "nonCertifiedTesttuples": None
+    },
+    {
+        "compositeTraintuple": {
+            "key": "e7b96818eadcdce6940c16b388bbd264549646a45bb8ea75e8f218d224c18162",
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
+                "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
+                "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+            },
+            "creator": "MyOrg1MSP",
+            "dataset": {
+                "worker": "MyOrg2MSP",
+                "keys": [
+                    "26e52856b27261fc12e9615d5914027dc5986cd8bb37ccf1da4c7aa47b74a8ea"
+                ],
+                "openerHash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+                "metadata": {}
+            },
+            "computePlanID": "",
+            "inHeadModel": None,
+            "inTrunkModel": None,
+            "log": "",
+            "metadata": {},
+            "outHeadModel": {
+                "outModel": {
+                    "hash": "3af8f86ed9fe07237497e52d1ced195d7e4752f7d130327929f96ea688d60a41"
+                },
+                "permissions": {
+                    "process": {
+                        "public": False,
+                        "authorizedIDs": [
+                            "MyOrg2MSP"
+                        ]
+                    }
+                }
+            },
+            "outTrunkModel": {
+                "outModel": {
+                    "hash": "cd8a895a9b604ccbb2e2bf9f081d0560bfd86f4a98beabd833d4c7c36f35cd9d",
+                    "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/model/cd8a895a9b604ccbb2e2bf9f081d0560bfd86f4a98beabd833d4c7c36f35cd9d/file/"
+                },
+                "permissions": {
+                    "process": {
+                        "public": False,
+                        "authorizedIDs": [
+                            "MyOrg1MSP",
+                            "MyOrg2MSP"
+                        ]
+                    }
+                }
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": ""
+        },
+        "testtuple": {
+            "algo": None,
+            "certified": False,
+            "computePlanID": "",
+            "creator": "",
+            "dataset": None,
+            "key": "",
+            "log": "",
+            "metadata": None,
+            "objective": None,
+            "rank": 0,
+            "status": "",
+            "tag": "",
+            "traintupleKey": "",
+            "traintupleType": ""
+        },
+        "nonCertifiedTesttuples": None
+    },
+    {
+        "aggregatetuple": {
+            "key": "9936e27a5738298e39e4308c0d4d612ada6ef1463bdbfe2b446b8e62230237a5",
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple_execution_failure - Algo 1",
+                "hash": "16acae7a5d702a97c4cce626bbe5c44d367d73617ee42e81660bce7494379986",
+                "storageAddress": "http://testserver/aggregate_algo/16acae7a5d702a97c4cce626bbe5c44d367d73617ee42e81660bce7494379986/file/"
+            },
+            "creator": "MyOrg1MSP",
+            "computePlanID": "",
+            "log": "[00-01-0117-a45d457]",
+            "metadata": {},
+            "inModels": [
+                {
+                    "traintupleKey": "7dbd4b2ac9e81b6dedd775809e0903d8fa55ce2cb8094bd6c4c20c2b0448b716",
+                    "hash": "fcfcaa4f3be73940006fc54566b2946fabd5ee677496a5dd43e4b8c0c3c3d54d",
+                    "storageAddress": "http://testserver/model/fcfcaa4f3be73940006fc54566b2946fabd5ee677496a5dd43e4b8c0c3c3d54d/file/"
+                },
+                {
+                    "traintupleKey": "df3e19426496a5b8a79d8f1b96e52de9fe3a07b6a81a9b5d9a34a824d52c1841",
+                    "hash": "682d31d9e95654ed0aaf81184136d87c7ff2a0046c3d24181508f112d58b330d",
+                    "storageAddress": "http://testserver/model/682d31d9e95654ed0aaf81184136d87c7ff2a0046c3d24181508f112d58b330d/file/"
+                }
+            ],
+            "outModel": None,
+            "rank": 0,
+            "status": "failed",
+            "tag": "",
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorizedIDs": [
+                        "MyOrg1MSP"
+                    ]
+                }
+            },
+            "worker": "MyOrg1MSP"
+        },
+        "testtuple": {
+            "algo": None,
+            "certified": False,
+            "computePlanID": "",
+            "creator": "",
+            "dataset": None,
+            "key": "",
+            "log": "",
+            "metadata": None,
+            "objective": None,
+            "rank": 0,
+            "status": "",
+            "tag": "",
+            "traintupleKey": "",
+            "traintupleType": ""
+        },
+        "nonCertifiedTesttuples": None
+    },
+    {
+        "aggregatetuple": {
+            "key": "0c6d79470e536e7390623b37622228b507620e5878fe196112e23111168dcb38",
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple - Algo 1",
+                "hash": "25081cda2aab5915fe1d732c6483e24ef8fb2484a6e856c8ed912b36577d3d9a",
+                "storageAddress": "http://testserver/aggregate_algo/25081cda2aab5915fe1d732c6483e24ef8fb2484a6e856c8ed912b36577d3d9a/file/"
+            },
+            "creator": "MyOrg1MSP",
+            "computePlanID": "",
+            "log": "",
+            "metadata": {},
+            "inModels": [
+                {
+                    "traintupleKey": "3169bb172502f67556a6f12b856a5d653441227842aded24ade6b7866d3b624d",
+                    "hash": "940262c35a6b33c2b7c8811fa785899b00e287ffa05e3cb5a23c857e9c89c760",
+                    "storageAddress": "http://testserver/model/940262c35a6b33c2b7c8811fa785899b00e287ffa05e3cb5a23c857e9c89c760/file/"
+                },
+                {
+                    "traintupleKey": "ea7180ccc125dcceff10400fd2943f1e02fc915262c67f19986b3a9edbd765fb",
+                    "hash": "02ccc4eeb426f7bbfe746a06a4c63a2023a8f2ea2c72f92242cc5f7f1164383c",
+                    "storageAddress": "http://testserver/model/02ccc4eeb426f7bbfe746a06a4c63a2023a8f2ea2c72f92242cc5f7f1164383c/file/"
+                },
+                {
+                    "traintupleKey": "a9c586b72c9c11412b0c9f81d599651a964d04934bca9f1886dd2d084f438a70",
+                    "hash": "f33d3c7a21e97f5f0edd636f3b313c6a7757cc458614e49da74d58af7fc0c4c2",
+                    "storageAddress": "http://testserver/model/f33d3c7a21e97f5f0edd636f3b313c6a7757cc458614e49da74d58af7fc0c4c2/file/"
+                }
+            ],
+            "outModel": {
+                "hash": "bd2e6a510edc11974e3d8b5459f0d4bd9b3169afe1fa47643147351f51fb18ac",
+                "storageAddress": "http://testserver/model/bd2e6a510edc11974e3d8b5459f0d4bd9b3169afe1fa47643147351f51fb18ac/file/"
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": "",
+            "permissions": {
+                "process": {
+                    "public": True,
+                    "authorizedIDs": []
+                }
+            },
+            "worker": "MyOrg1MSP"
+        },
+        "testtuple": {
+            "algo": None,
+            "certified": False,
+            "computePlanID": "",
+            "creator": "",
+            "dataset": None,
+            "key": "",
+            "log": "",
+            "metadata": None,
+            "objective": None,
+            "rank": 0,
+            "status": "",
+            "tag": "",
+            "traintupleKey": "",
+            "traintupleType": ""
+        },
+        "nonCertifiedTesttuples": None
+    },
+    {
+        "aggregatetuple": {
+            "key": "9cb5582fc3e822b9ddabbf7479097df05381294e3559f31a35c20f2e46e4885c",
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 1",
+                "hash": "576485095a2f9bc78ed6238b847c9c679fb755b822c0cc6e08e60ea227ec0648",
+                "storageAddress": "http://testserver/aggregate_algo/576485095a2f9bc78ed6238b847c9c679fb755b822c0cc6e08e60ea227ec0648/file/"
+            },
+            "creator": "MyOrg1MSP",
+            "computePlanID": "",
+            "log": "",
+            "metadata": {},
+            "inModels": [
+                {
+                    "traintupleKey": "3197bd6c56bc47089864c76b47b6115eb3551901ba304722ce581561c37b0c7b",
+                    "hash": "b312a262592aa7ed56a07d0eb02bec0548745eb7316d4ea86b3719b2497d8cb2",
+                    "storageAddress": "http://testserver/model/b312a262592aa7ed56a07d0eb02bec0548745eb7316d4ea86b3719b2497d8cb2/file/"
+                },
+                {
+                    "traintupleKey": "e7b96818eadcdce6940c16b388bbd264549646a45bb8ea75e8f218d224c18162",
+                    "hash": "cd8a895a9b604ccbb2e2bf9f081d0560bfd86f4a98beabd833d4c7c36f35cd9d",
+                    "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/model/cd8a895a9b604ccbb2e2bf9f081d0560bfd86f4a98beabd833d4c7c36f35cd9d/file/"
+                }
+            ],
+            "outModel": {
+                "hash": "4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688",
+                "storageAddress": "http://testserver/model/4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688/file/"
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": "",
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorizedIDs": [
+                        "MyOrg1MSP",
+                        "MyOrg2MSP"
+                    ]
+                }
+            },
+            "worker": "MyOrg1MSP"
+        },
+        "testtuple": {
+            "algo": None,
+            "certified": False,
+            "computePlanID": "",
+            "creator": "",
+            "dataset": None,
+            "key": "",
+            "log": "",
+            "metadata": None,
+            "objective": None,
+            "rank": 0,
+            "status": "",
+            "tag": "",
+            "traintupleKey": "",
+            "traintupleType": ""
+        },
+        "nonCertifiedTesttuples": None
+    },
+    {
+        "aggregatetuple": {
+            "key": "d57e8f3597a9c065d02c65c5a6def14b83a585a43223c227dad729b8e807e147",
+            "algo": {
+                "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 1",
+                "hash": "576485095a2f9bc78ed6238b847c9c679fb755b822c0cc6e08e60ea227ec0648",
+                "storageAddress": "http://testserver/aggregate_algo/576485095a2f9bc78ed6238b847c9c679fb755b822c0cc6e08e60ea227ec0648/file/"
+            },
+            "creator": "MyOrg1MSP",
+            "computePlanID": "",
+            "log": "",
+            "metadata": {},
+            "inModels": [
+                {
+                    "traintupleKey": "5adbd24ea21cb23b1ffc65151038a62c97f2d745d7df0928e683707f15a09556",
+                    "hash": "14b7e3254896db4f43c582695c39d096f33e1390e3ecaa8b0e6e7619bf827044",
+                    "storageAddress": "http://testserver/model/14b7e3254896db4f43c582695c39d096f33e1390e3ecaa8b0e6e7619bf827044/file/"
+                },
+                {
+                    "traintupleKey": "3be92d96d1abdabfbe6a4ff612d70f7f867f450c38ea344bd98d0775bec826fd",
+                    "hash": "66392ca3e6a5935fb8e22a5ee5b8af31dbec5655ff087b98f071abf7e4f3ce74",
+                    "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/model/66392ca3e6a5935fb8e22a5ee5b8af31dbec5655ff087b98f071abf7e4f3ce74/file/"
+                }
+            ],
+            "outModel": {
+                "hash": "d62bd637d4223726e96c46337539da3bbd94dc3a3b4f233f1c7152dd3b02364d",
+                "storageAddress": "http://testserver/model/d62bd637d4223726e96c46337539da3bbd94dc3a3b4f233f1c7152dd3b02364d/file/"
+            },
+            "rank": 0,
+            "status": "done",
+            "tag": "",
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorizedIDs": [
+                        "MyOrg1MSP",
+                        "MyOrg2MSP"
+                    ]
+                }
+            },
+            "worker": "MyOrg1MSP"
+        },
+        "testtuple": {
+            "algo": None,
+            "certified": False,
+            "computePlanID": "",
+            "creator": "",
+            "dataset": None,
+            "key": "",
+            "log": "",
+            "metadata": None,
+            "objective": None,
+            "rank": 0,
+            "status": "",
+            "tag": "",
+            "traintupleKey": "",
+            "traintupleType": ""
+        },
+        "nonCertifiedTesttuples": None
     }
 ]
 

--- a/backend/substrapp/tests/common.py
+++ b/backend/substrapp/tests/common.py
@@ -12,6 +12,8 @@ from rest_framework.test import APIClient
 # Given username and password it returns "Basic GENERATED_TOKEN"
 from users.serializers import CustomTokenObtainPairSerializer
 
+import urllib
+
 
 def generate_basic_auth_header(username, password):
     return 'Basic ' + base64.b64encode(f'{username}:{password}'.encode()).decode()
@@ -297,3 +299,9 @@ class FakeRequest(object):
 class FakeTask(object):
     def __init__(self, task_id):
         self.id = task_id
+
+
+def encode_filter(params):
+    # We need to quote the params string because the filter function
+    # in the backend use the same  ':' url separator for key:value filtering object
+    return urllib.parse.quote(params)

--- a/backend/substrapp/tests/generate_assets.py
+++ b/backend/substrapp/tests/generate_assets.py
@@ -7,12 +7,11 @@ dir_path = os.path.dirname(__file__)
 assets_path = os.path.join(dir_path, 'assets.py')
 
 
-def main(network):
+def main():
 
-    client = substra.Client()
-    client.add_profile('default', 'http://substra-backend.node-1.com', '0.0')
+    client = substra.Client(url='http://substra-backend.node-1.com',
+                            insecure=False)
     client.login('node-1', 'p@$swr0d44')
-    client.set_profile('default')
 
     assets = {}
     assets['objective'] = json.dumps(client.list_objective(), indent=4)
@@ -24,9 +23,10 @@ def main(network):
     assets['compositetraintuple'] = json.dumps(client.list_composite_traintuple(), indent=4)
     assets['compositealgo'] = json.dumps(client.list_composite_algo(), indent=4)
 
-    assets['model'] = json.dumps([res for res in client.client.list('model')
-                                  if (('traintuple' in res or 'compositeTraintuple' in res) and 'testtuple' in res)],
-                                 indent=4)
+    models = client._backend.list(substra.sdk.schemas.Type.Model)
+    models = [(model, list(model.keys()).pop()) for model in models]
+    assets['model'] = json.dumps([client._backend.get(substra.sdk.schemas.Type.Model, model[mtype]['key'])
+                                  for model, mtype in models], indent=4)
 
     with open(assets_path, 'w') as f:
         f.write('"""\nWARNING\n=======\n\nDO NOT MANUALLY EDIT THIS FILE!\n\n'

--- a/backend/substrapp/tests/query/tests_query_algo.py
+++ b/backend/substrapp/tests/query/tests_query_algo.py
@@ -89,7 +89,7 @@ class AlgoQueryTests(APITestCase):
 
     def test_add_algo_sync_ok(self):
         self.add_default_objective()
-        pkhash, data = self.get_default_algo_data_zip()
+        key, data = self.get_default_algo_data_zip()
 
         url = reverse('substrapp:algo-list')
         extra = {
@@ -98,17 +98,12 @@ class AlgoQueryTests(APITestCase):
         }
 
         with mock.patch('substrapp.ledger.invoke_ledger') as minvoke_ledger:
-            minvoke_ledger.return_value = {'pkhash': pkhash}
+            minvoke_ledger.return_value = {'pkhash': key}
 
             response = self.client.post(url, data, format='multipart', **extra)
             r = response.json()
 
-            self.assertEqual(r['pkhash'], pkhash)
-            self.assertEqual(r['validated'], True)
-            self.assertEqual(r['description'],
-                             f'http://testserver/media/algos/{r["pkhash"]}/{self.data_description_filename}')
-            self.assertEqual(r['file'],
-                             f'http://testserver/media/algos/{r["pkhash"]}/{self.algo_filename_zip}')
+            self.assertEqual(r['key'], key)
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @override_settings(LEDGER_SYNC_ENABLED=False)
@@ -120,7 +115,7 @@ class AlgoQueryTests(APITestCase):
     )
     def test_add_algo_no_sync_ok(self):
         self.add_default_objective()
-        pkhash, data = self.get_default_algo_data()
+        key, data = self.get_default_algo_data()
 
         url = reverse('substrapp:algo-list')
         extra = {
@@ -135,12 +130,7 @@ class AlgoQueryTests(APITestCase):
             response = self.client.post(url, data, format='multipart', **extra)
             r = response.json()
 
-            self.assertEqual(r['pkhash'], pkhash)
-            self.assertEqual(r['validated'], False)
-            self.assertEqual(r['description'],
-                             f'http://testserver/media/algos/{r["pkhash"]}/{self.data_description_filename}')
-            self.assertEqual(r['file'],
-                             f'http://testserver/media/algos/{r["pkhash"]}/{self.algo_filename}')
+            self.assertEqual(r['key'], key)
             self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
 
     def test_add_algo_ko(self):

--- a/backend/substrapp/tests/query/tests_query_compositetraintuple.py
+++ b/backend/substrapp/tests/query/tests_query_compositetraintuple.py
@@ -71,9 +71,9 @@ class CompositeTraintupleQueryTests(APITestCase):
         with mock.patch('substrapp.ledger.invoke_ledger') as minvoke_ledger, \
                 mock.patch('substrapp.views.compositetraintuple.query_ledger') as mquery_ledger:
 
-            raw_pkhash = 'compositetraintuple_pkhash'.encode('utf-8').hex()
-            mquery_ledger.return_value = {'key': raw_pkhash}
-            minvoke_ledger.return_value = {'pkhash': raw_pkhash}
+            raw_key = 'compositetraintuple_key'.encode('utf-8').hex()
+            mquery_ledger.return_value = {'key': raw_key}
+            minvoke_ledger.return_value = {'pkhash': raw_key}
 
             response = self.client.post(url, data, format='json', **extra)
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -116,8 +116,8 @@ class CompositeTraintupleQueryTests(APITestCase):
         with mock.patch('substrapp.ledger.invoke_ledger') as minvoke_ledger, \
                 mock.patch('substrapp.views.compositetraintuple.query_ledger') as mquery_ledger:
 
-            raw_pkhash = 'compositetraintuple_pkhash'.encode('utf-8').hex()
-            mquery_ledger.return_value = {'key': raw_pkhash}
+            raw_key = 'compositetraintuple_key'.encode('utf-8').hex()
+            mquery_ledger.return_value = {'key': raw_key}
             minvoke_ledger.return_value = None
 
             response = self.client.post(url, data, format='json', **extra)

--- a/backend/substrapp/tests/query/tests_query_datamanager.py
+++ b/backend/substrapp/tests/query/tests_query_datamanager.py
@@ -55,7 +55,7 @@ class DataManagerQueryTests(APITestCase):
 
     def test_add_datamanager_sync_ok(self):
 
-        pkhash, data = self.get_default_datamanager_data()
+        key, data = self.get_default_datamanager_data()
 
         url = reverse('substrapp:data_manager-list')
         extra = {
@@ -64,16 +64,12 @@ class DataManagerQueryTests(APITestCase):
         }
 
         with mock.patch('substrapp.ledger.invoke_ledger') as minvoke_ledger:
-            minvoke_ledger.return_value = {'pkhash': pkhash}
+            minvoke_ledger.return_value = {'pkhash': key}
 
             response = self.client.post(url, data, format='multipart', **extra)
             r = response.json()
 
-            self.assertEqual(r['pkhash'], pkhash)
-            self.assertEqual(r['validated'], True)
-            self.assertEqual(r['description'],
-                             f'http://testserver/media/datamanagers/{r["pkhash"]}/{self.data_description_filename}')
-
+            self.assertEqual(r['key'], key)
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @override_settings(LEDGER_SYNC_ENABLED=False)
@@ -85,7 +81,7 @@ class DataManagerQueryTests(APITestCase):
     )
     def test_add_datamanager_no_sync_ok(self):
 
-        pkhash, data = self.get_default_datamanager_data()
+        key, data = self.get_default_datamanager_data()
 
         url = reverse('substrapp:data_manager-list')
         extra = {
@@ -101,10 +97,7 @@ class DataManagerQueryTests(APITestCase):
             response = self.client.post(url, data, format='multipart', **extra)
             r = response.json()
 
-            self.assertEqual(r['pkhash'], pkhash)
-            self.assertEqual(r['validated'], False)
-            self.assertEqual(r['description'],
-                             f'http://testserver/media/datamanagers/{r["pkhash"]}/{self.data_description_filename}')
+            self.assertEqual(r['key'], key)
             self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
 
     def test_add_datamanager_ko(self):

--- a/backend/substrapp/tests/query/tests_query_objective.py
+++ b/backend/substrapp/tests/query/tests_query_objective.py
@@ -74,7 +74,7 @@ class ObjectiveQueryTests(APITestCase):
 
     def test_add_objective_sync_ok(self):
         self.add_default_data_manager()
-        pkhash, data = self.get_default_objective_data()
+        key, data = self.get_default_objective_data()
 
         url = reverse('substrapp:objective-list')
         extra = {
@@ -83,17 +83,12 @@ class ObjectiveQueryTests(APITestCase):
         }
 
         with mock.patch('substrapp.ledger.invoke_ledger') as minvoke_ledger:
-            minvoke_ledger.return_value = {'pkhash': pkhash}
+            minvoke_ledger.return_value = {'pkhash': key}
 
             response = self.client.post(url, data, format='multipart', **extra)
             r = response.json()
 
-            self.assertEqual(r['pkhash'], pkhash)
-            self.assertEqual(r['validated'], True)
-            self.assertEqual(r['description'],
-                             f'http://testserver/media/objectives/{r["pkhash"]}/{self.objective_description_filename}')
-            self.assertEqual(r['metrics'],
-                             f'http://testserver/media/objectives/{r["pkhash"]}/{self.objective_metrics_filename}')
+            self.assertEqual(r['key'], key)
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @override_settings(LEDGER_SYNC_ENABLED=False)
@@ -105,7 +100,7 @@ class ObjectiveQueryTests(APITestCase):
     )
     def test_add_objective_no_sync_ok(self):
         self.add_default_data_manager()
-        pkhash, data = self.get_default_objective_data()
+        key, data = self.get_default_objective_data()
 
         url = reverse('substrapp:objective-list')
         extra = {
@@ -121,18 +116,13 @@ class ObjectiveQueryTests(APITestCase):
 
             r = response.json()
 
-            self.assertEqual(r['pkhash'], pkhash)
-            self.assertEqual(r['validated'], False)
-            self.assertEqual(r['description'],
-                             f'http://testserver/media/objectives/{r["pkhash"]}/{self.objective_description_filename}')
-            self.assertEqual(r['metrics'],
-                             f'http://testserver/media/objectives/{r["pkhash"]}/{self.objective_metrics_filename}')
+            self.assertEqual(r['key'], key)
             self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
 
     def test_add_objective_conflict(self):
         self.add_default_data_manager()
 
-        pkhash, data = self.get_default_objective_data()
+        key, data = self.get_default_objective_data()
 
         url = reverse('substrapp:objective-list')
 
@@ -142,12 +132,12 @@ class ObjectiveQueryTests(APITestCase):
         }
 
         with mock.patch('substrapp.ledger.invoke_ledger') as minvoke_ledger:
-            minvoke_ledger.return_value = {'pkhash': pkhash}
+            minvoke_ledger.return_value = {'pkhash': key}
 
             response = self.client.post(url, data, format='multipart', **extra)
             r = response.json()
 
-            self.assertEqual(r['pkhash'], pkhash)
+            self.assertEqual(r['key'], key)
             self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
             # XXX reload data as the previous call to post change it
@@ -156,7 +146,7 @@ class ObjectiveQueryTests(APITestCase):
             r = response.json()
 
             self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
-            self.assertEqual(r['pkhash'], pkhash)
+            self.assertEqual(r['key'], key)
 
     def test_add_objective_ko(self):
         url = reverse('substrapp:objective-list')

--- a/backend/substrapp/tests/query/tests_query_tuples.py
+++ b/backend/substrapp/tests/query/tests_query_tuples.py
@@ -61,9 +61,9 @@ class TraintupleQueryTests(APITestCase):
         with mock.patch('substrapp.ledger.invoke_ledger') as minvoke_ledger, \
                 mock.patch('substrapp.views.traintuple.query_ledger') as mquery_ledger:
 
-            raw_pkhash = 'traintuple_pkhash'.encode('utf-8').hex()
-            mquery_ledger.return_value = {'key': raw_pkhash}
-            minvoke_ledger.return_value = {'pkhash': raw_pkhash}
+            raw_key = 'traintuple_key'.encode('utf-8').hex()
+            mquery_ledger.return_value = {'key': raw_key}
+            minvoke_ledger.return_value = {'pkhash': raw_key}
 
             response = self.client.post(url, data, format='json', **extra)
 
@@ -100,8 +100,8 @@ class TraintupleQueryTests(APITestCase):
         with mock.patch('substrapp.ledger.invoke_ledger') as minvoke_ledger, \
                 mock.patch('substrapp.views.traintuple.query_ledger') as mquery_ledger:
 
-            raw_pkhash = 'traintuple_pkhash'.encode('utf-8').hex()
-            mquery_ledger.return_value = {'key': raw_pkhash}
+            raw_key = 'traintuple_key'.encode('utf-8').hex()
+            mquery_ledger.return_value = {'key': raw_key}
             minvoke_ledger.return_value = None
 
             response = self.client.post(url, data, format='json', **extra)
@@ -172,9 +172,9 @@ class TesttupleQueryTests(APITestCase):
         with mock.patch('substrapp.ledger.invoke_ledger') as minvoke_ledger, \
                 mock.patch('substrapp.views.testtuple.query_ledger') as mquery_ledger:
 
-            raw_pkhash = 'testtuple_pkhash'.encode('utf-8').hex()
-            mquery_ledger.return_value = {'key': raw_pkhash}
-            minvoke_ledger.return_value = {'pkhash': raw_pkhash}
+            raw_key = 'testtuple_key'.encode('utf-8').hex()
+            mquery_ledger.return_value = {'key': raw_key}
+            minvoke_ledger.return_value = {'pkhash': raw_key}
 
             response = self.client.post(url, data, format='json', **extra)
 
@@ -208,8 +208,8 @@ class TesttupleQueryTests(APITestCase):
         with mock.patch('substrapp.ledger.invoke_ledger') as minvoke_ledger, \
                 mock.patch('substrapp.views.testtuple.query_ledger') as mquery_ledger:
 
-            raw_pkhash = 'testtuple_pkhash'.encode('utf-8').hex()
-            mquery_ledger.return_value = {'key': raw_pkhash}
+            raw_key = 'testtuple_key'.encode('utf-8').hex()
+            mquery_ledger.return_value = {'key': raw_key}
             minvoke_ledger.return_value = None
 
             response = self.client.post(url, data, format='json', **extra)

--- a/backend/substrapp/tests/views/tests_views_datasample.py
+++ b/backend/substrapp/tests/views/tests_views_datasample.py
@@ -62,8 +62,8 @@ class DataSampleViewTests(APITestCase):
         data_path2 = os.path.join(dir_path, '../../../../fixtures/chunantes/datasamples/datasample0/0024899.zip')
 
         # dir hash
-        pkhash1 = '24fb12ff87485f6b0bc5349e5bf7f36ccca4eb1353395417fdae7d8d787f178c'
-        pkhash2 = '30f6c797e277451b0a08da7119ed86fb2986fa7fab2258bf3edbd9f1752ed553'
+        key1 = '24fb12ff87485f6b0bc5349e5bf7f36ccca4eb1353395417fdae7d8d787f178c'
+        key2 = '30f6c797e277451b0a08da7119ed86fb2986fa7fab2258bf3edbd9f1752ed553'
 
         data_manager_keys = [
             get_hash(os.path.join(dir_path, '../../../../fixtures/chunantes/datamanagers/datamanager0/opener.py'))]
@@ -82,9 +82,9 @@ class DataSampleViewTests(APITestCase):
                 mock.patch.object(LedgerDataSampleSerializer, 'create') as mcreate:
 
             mdatamanager.return_value = FakeFilterDataManager(1)
-            mcreate.return_value = {'keys': [pkhash1, pkhash2]}
+            mcreate.return_value = {'keys': [key1, key2]}
             response = self.client.post(url, data=data, format='multipart', **self.extra)
-        self.assertEqual([r['pkhash'] for r in response.data], [pkhash1, pkhash2])
+        self.assertEqual([r['key'] for r in response.data], [key1, key2])
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         for x in data['files']:
@@ -98,7 +98,7 @@ class DataSampleViewTests(APITestCase):
         data_path = os.path.join(dir_path, '../../../../fixtures/chunantes/datasamples/datasample1/0024700.zip')
 
         # dir hash
-        pkhash = '24fb12ff87485f6b0bc5349e5bf7f36ccca4eb1353395417fdae7d8d787f178c'
+        key = '24fb12ff87485f6b0bc5349e5bf7f36ccca4eb1353395417fdae7d8d787f178c'
 
         data_manager_keys = [
             get_hash(os.path.join(dir_path, '../../../../fixtures/chunantes/datamanagers/datamanager0/opener.py'))]
@@ -115,10 +115,10 @@ class DataSampleViewTests(APITestCase):
                 mock.patch.object(LedgerDataSampleSerializer, 'create') as mcreate:
 
             mdatamanager.return_value = FakeFilterDataManager(1)
-            mcreate.return_value = {'keys': [pkhash]}
+            mcreate.return_value = {'keys': [key]}
             response = self.client.post(url, data=data, format='multipart', **self.extra)
 
-        self.assertEqual(response.data[0]['pkhash'], pkhash)
+        self.assertEqual(response.data[0]['key'], key)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         data['file'].close()
@@ -136,7 +136,7 @@ class DataSampleViewTests(APITestCase):
             uncompress_content(data_zip.read(), data_path)
 
         # dir hash
-        pkhash = '24fb12ff87485f6b0bc5349e5bf7f36ccca4eb1353395417fdae7d8d787f178c'
+        key = '24fb12ff87485f6b0bc5349e5bf7f36ccca4eb1353395417fdae7d8d787f178c'
 
         data_manager_keys = [
             get_hash(os.path.join(dir_path, '../../../../fixtures/chunantes/datamanagers/datamanager0/opener.py'))]
@@ -152,10 +152,10 @@ class DataSampleViewTests(APITestCase):
                 mock.patch.object(LedgerDataSampleSerializer, 'create') as mcreate:
 
             mdatamanager.return_value = FakeFilterDataManager(1)
-            mcreate.return_value = {'keys': [pkhash]}
+            mcreate.return_value = {'keys': [key]}
             response = self.client.post(url, data=data, format='json', **self.extra)
 
-        self.assertEqual(response.data[0]['pkhash'], pkhash)
+        self.assertEqual(response.data[0]['key'], key)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_data_create_path(self):
@@ -170,7 +170,7 @@ class DataSampleViewTests(APITestCase):
             uncompress_content(data_zip.read(), data_path)
 
         # dir hash
-        pkhash = '24fb12ff87485f6b0bc5349e5bf7f36ccca4eb1353395417fdae7d8d787f178c'
+        key = '24fb12ff87485f6b0bc5349e5bf7f36ccca4eb1353395417fdae7d8d787f178c'
 
         data_manager_keys = [
             get_hash(os.path.join(dir_path, '../../../../fixtures/chunantes/datamanagers/datamanager0/opener.py'))]
@@ -185,10 +185,10 @@ class DataSampleViewTests(APITestCase):
                 mock.patch.object(LedgerDataSampleSerializer, 'create') as mcreate:
 
             mdatamanager.return_value = FakeFilterDataManager(1)
-            mcreate.return_value = {'keys': [pkhash]}
+            mcreate.return_value = {'keys': [key]}
             response = self.client.post(url, data=data, format='json', **self.extra)
 
-        self.assertEqual(response.data[0]['pkhash'], pkhash)
+        self.assertEqual(response.data[0]['key'], key)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_datasamples_list(self):

--- a/backend/substrapp/tests/views/tests_views_model.py
+++ b/backend/substrapp/tests/views/tests_views_model.py
@@ -14,7 +14,7 @@ from substrapp.ledger_utils import LedgerError
 
 from substrapp.utils import get_hash
 
-from ..common import get_sample_model, AuthenticatedClient
+from ..common import get_sample_model, AuthenticatedClient, encode_filter
 from ..assets import objective, datamanager, algo, model
 
 MEDIA_ROOT = "/tmp/unittests_views/"
@@ -83,17 +83,18 @@ class ModelViewTests(APITestCase):
             self.assertEqual(len(r[0]), 1)
 
     def test_model_list_filter_datamanager(self):
+
         url = reverse('substrapp:model-list')
         with mock.patch('substrapp.views.model.query_ledger') as mquery_ledger, \
                 mock.patch('substrapp.views.filters_utils.query_ledger') as mquery_ledger2:
             mquery_ledger.return_value = model
             mquery_ledger2.return_value = datamanager
 
-            search_params = '?search=dataset%253Aname%253AISIC%25202018'
+            search_params = f'?search=dataset%253Aname%253A{encode_filter(datamanager[0]["name"])}'
             response = self.client.get(url + search_params, **self.extra)
             r = response.json()
 
-            self.assertEqual(len(r[0]), 5)
+            self.assertEqual(len(r[0]), 14)
 
     def test_model_list_filter_objective(self):
         url = reverse('substrapp:model-list')
@@ -102,11 +103,11 @@ class ModelViewTests(APITestCase):
             mquery_ledger.return_value = model
             mquery_ledger2.return_value = objective
 
-            search_params = '?search=objective%253Aname%253ASkin%2520Lesion%2520Classification%2520Objective'
+            search_params = f'?search=objective%253Aname%253A{encode_filter(objective[0]["name"])}'
             response = self.client.get(url + search_params, **self.extra)
             r = response.json()
 
-            self.assertEqual(len(r[0]), 1)
+            self.assertEqual(len(r[0]), 4)
 
     def test_model_list_filter_algo(self):
         url = reverse('substrapp:model-list')
@@ -115,11 +116,11 @@ class ModelViewTests(APITestCase):
             mquery_ledger.return_value = model
             mquery_ledger2.return_value = algo
 
-            search_params = '?search=algo%253Aname%253ALogistic%2520regression'
+            search_params = f'?search=algo%253Aname%253A{encode_filter(algo[0]["name"])}'
             response = self.client.get(url + search_params, **self.extra)
             r = response.json()
 
-            self.assertEqual(len(r[0]), 2)
+            self.assertEqual(len(r[0]), 3)
 
     def test_model_retrieve(self):
         done_model = [m for m in model if 'traintuple' in m and m['traintuple']['status'] == 'done'][0]

--- a/backend/substrapp/tests/views/tests_views_tuples.py
+++ b/backend/substrapp/tests/views/tests_views_tuples.py
@@ -107,12 +107,12 @@ class TraintupleViewTests(APITestCase):
         url = reverse('substrapp:traintuple-list')
         with mock.patch('substrapp.views.traintuple.query_ledger') as mquery_ledger:
             mquery_ledger.return_value = traintuple
-            target_tag = '(should fail) My super tag'
+            target_tag = 'foo'
             search_params = '?search=traintuple%253Atag%253A' + urllib.parse.quote_plus(target_tag)
             response = self.client.get(url + search_params, **self.extra)
             r = response.json()
 
-            self.assertEqual(len(r[0]), 1)
+            self.assertEqual(len(r[0]), 2)
 
     def test_traintuple_list_filter_compute_plan_id(self):
         url = reverse('substrapp:traintuple-list')
@@ -123,7 +123,7 @@ class TraintupleViewTests(APITestCase):
             response = self.client.get(url + search_params, **self.extra)
             r = response.json()
 
-            self.assertEqual(len(r[0]), 1)
+            self.assertEqual(len(r[0]), 2)
 
 
 # APITestCase
@@ -203,7 +203,7 @@ class TesttupleViewTests(APITestCase):
         with mock.patch('substrapp.views.testtuple.query_ledger') as mquery_ledger:
             mquery_ledger.return_value = testtuple
 
-            search_params = '?search=testtuple%253Atag%253Asubstra'
+            search_params = '?search=testtuple%253Atag%253Abar'
             response = self.client.get(url + search_params, **self.extra)
             r = response.json()
 

--- a/backend/substrapp/views/aggregatealgo.py
+++ b/backend/substrapp/views/aggregatealgo.py
@@ -151,7 +151,7 @@ class AggregateAlgoViewSet(mixins.CreateModelMixin,
                 # For security reason, do not give access to local file address
                 # Restrain data to some fields
                 # TODO: do we need to send creation date and/or last modified date ?
-                serializer = self.get_serializer(instance, fields=('owner', 'pkhash'))
+                serializer = self.get_serializer(instance, fields=('owner'))
                 data.update(serializer.data)
 
         replace_storage_addresses(request, data)

--- a/backend/substrapp/views/aggregatealgo.py
+++ b/backend/substrapp/views/aggregatealgo.py
@@ -14,7 +14,8 @@ from substrapp.utils import get_hash
 from substrapp.ledger_utils import query_ledger, get_object_from_ledger, LedgerError, LedgerTimeout, LedgerConflict
 from substrapp.views.utils import (PermissionMixin, find_primary_key_error,
                                    validate_pk, get_success_create_code, LedgerException, ValidationException,
-                                   get_remote_asset, node_has_process_permission, get_channel_name)
+                                   get_remote_asset, node_has_process_permission, get_channel_name,
+                                   data_to_data_response)
 from substrapp.views.filters_utils import filter_list
 
 
@@ -106,13 +107,15 @@ class AggregateAlgoViewSet(mixins.CreateModelMixin,
         try:
             data = self._create(request, file)
         except ValidationException as e:
-            return Response({'message': e.data, 'pkhash': e.pkhash}, status=e.st)
+            return Response({'message': e.data, 'key': e.pkhash}, status=e.st)
         except LedgerException as e:
             return Response({'message': e.data}, status=e.st)
         else:
             headers = self.get_success_headers(data)
             st = get_success_create_code()
-            return Response(data, status=st, headers=headers)
+            # Transform data to a data_response with only key
+            data_response = data_to_data_response(data)
+            return Response(data_response, status=st, headers=headers)
 
     def create_or_update_aggregate_algo(self, channel_name, aggregate_algo, pk):
         # get Aggregatealgo description from remote node

--- a/backend/substrapp/views/aggregatetuple.py
+++ b/backend/substrapp/views/aggregatetuple.py
@@ -5,7 +5,8 @@ from rest_framework.viewsets import GenericViewSet
 from substrapp.serializers import LedgerAggregateTupleSerializer
 from substrapp.ledger_utils import query_ledger, get_object_from_ledger, LedgerError, LedgerConflict
 from substrapp.views.filters_utils import filter_list
-from substrapp.views.utils import validate_pk, get_success_create_code, LedgerException, get_channel_name
+from substrapp.views.utils import (validate_pk, get_success_create_code, LedgerException, get_channel_name,
+                                   data_to_data_response)
 
 
 class AggregateTupleViewSet(mixins.CreateModelMixin,
@@ -50,7 +51,7 @@ class AggregateTupleViewSet(mixins.CreateModelMixin,
         try:
             data = query_ledger(get_channel_name(request), fcn='createAggregatetuple', args=args)
         except LedgerConflict as e:
-            raise LedgerException({'message': str(e.msg), 'pkhash': e.pkhash}, e.status)
+            raise LedgerException({'message': str(e.msg), 'key': e.pkhash}, e.status)
         except LedgerError as e:
             raise LedgerException({'message': str(e.msg)}, e.status)
         else:
@@ -65,7 +66,9 @@ class AggregateTupleViewSet(mixins.CreateModelMixin,
         else:
             headers = self.get_success_headers(data)
             st = get_success_create_code()
-            return Response(data, status=st, headers=headers)
+            # Transform data to a data_response with only key
+            data_response = data_to_data_response(data)
+            return Response(data_response, status=st, headers=headers)
 
     def list(self, request, *args, **kwargs):
         try:

--- a/backend/substrapp/views/algo.py
+++ b/backend/substrapp/views/algo.py
@@ -155,7 +155,7 @@ class AlgoViewSet(mixins.CreateModelMixin,
                 # For security reason, do not give access to local file address
                 # Restrain data to some fields
                 # TODO: do we need to send creation date and/or last modified date ?
-                serializer = self.get_serializer(instance, fields=('owner', 'pkhash'))
+                serializer = self.get_serializer(instance, fields=('owner'))
                 data.update(serializer.data)
 
         replace_storage_addresses(request, data)

--- a/backend/substrapp/views/algo.py
+++ b/backend/substrapp/views/algo.py
@@ -14,7 +14,8 @@ from substrapp.utils import get_hash
 from substrapp.ledger_utils import query_ledger, get_object_from_ledger, LedgerError, LedgerTimeout, LedgerConflict
 from substrapp.views.utils import (PermissionMixin, find_primary_key_error,
                                    validate_pk, get_success_create_code, LedgerException, ValidationException,
-                                   get_remote_asset, node_has_process_permission, get_channel_name)
+                                   get_remote_asset, node_has_process_permission, get_channel_name,
+                                   data_to_data_response)
 from substrapp.views.filters_utils import filter_list
 
 
@@ -116,7 +117,9 @@ class AlgoViewSet(mixins.CreateModelMixin,
         else:
             headers = self.get_success_headers(data)
             st = get_success_create_code()
-            return Response(data, status=st, headers=headers)
+            # Transform data to a data_response with only key
+            data_response = data_to_data_response(data)
+            return Response(data_response, status=st, headers=headers)
 
     def create_or_update_algo(self, channel_name, algo, pk):
         # get algo description from remote node

--- a/backend/substrapp/views/compositealgo.py
+++ b/backend/substrapp/views/compositealgo.py
@@ -14,7 +14,8 @@ from substrapp.utils import get_hash
 from substrapp.ledger_utils import query_ledger, get_object_from_ledger, LedgerError, LedgerTimeout, LedgerConflict
 from substrapp.views.utils import (PermissionMixin, find_primary_key_error,
                                    validate_pk, get_success_create_code, LedgerException, ValidationException,
-                                   get_remote_asset, node_has_process_permission, get_channel_name)
+                                   get_remote_asset, node_has_process_permission, get_channel_name,
+                                   data_to_data_response)
 from substrapp.views.filters_utils import filter_list
 
 
@@ -106,13 +107,15 @@ class CompositeAlgoViewSet(mixins.CreateModelMixin,
         try:
             data = self._create(request, file)
         except ValidationException as e:
-            return Response({'message': e.data, 'pkhash': e.pkhash}, status=e.st)
+            return Response({'message': e.data, 'key': e.pkhash}, status=e.st)
         except LedgerException as e:
             return Response({'message': e.data}, status=e.st)
         else:
             headers = self.get_success_headers(data)
             st = get_success_create_code()
-            return Response(data, status=st, headers=headers)
+            # Transform data to a data_response with only key
+            data_response = data_to_data_response(data)
+            return Response(data_response, status=st, headers=headers)
 
     def create_or_update_composite_algo(self, channel_name, composite_algo, pk):
         # get Compositealgo description from remote node

--- a/backend/substrapp/views/compositealgo.py
+++ b/backend/substrapp/views/compositealgo.py
@@ -151,7 +151,7 @@ class CompositeAlgoViewSet(mixins.CreateModelMixin,
                 # For security reason, do not give access to local file address
                 # Restrain data to some fields
                 # TODO: do we need to send creation date and/or last modified date ?
-                serializer = self.get_serializer(instance, fields=('owner', 'pkhash'))
+                serializer = self.get_serializer(instance, fields=('owner'))
                 data.update(serializer.data)
 
         replace_storage_addresses(request, data)

--- a/backend/substrapp/views/compositetraintuple.py
+++ b/backend/substrapp/views/compositetraintuple.py
@@ -5,7 +5,8 @@ from rest_framework.viewsets import GenericViewSet
 from substrapp.serializers import LedgerCompositeTraintupleSerializer
 from substrapp.ledger_utils import query_ledger, get_object_from_ledger, LedgerError, LedgerConflict
 from substrapp.views.filters_utils import filter_list
-from substrapp.views.utils import validate_pk, get_success_create_code, LedgerException, get_channel_name
+from substrapp.views.utils import (validate_pk, get_success_create_code, LedgerException, get_channel_name,
+                                   data_to_data_response)
 
 
 class CompositeTraintupleViewSet(mixins.CreateModelMixin,
@@ -53,7 +54,7 @@ class CompositeTraintupleViewSet(mixins.CreateModelMixin,
         try:
             data = query_ledger(get_channel_name(request), fcn='createCompositeTraintuple', args=args)
         except LedgerConflict as e:
-            raise LedgerException({'message': str(e.msg), 'pkhash': e.pkhash}, e.status)
+            raise LedgerException({'message': str(e.msg), 'key': e.pkhash}, e.status)
         except LedgerError as e:
             raise LedgerException({'message': str(e.msg)}, e.status)
         else:
@@ -68,7 +69,9 @@ class CompositeTraintupleViewSet(mixins.CreateModelMixin,
         else:
             headers = self.get_success_headers(data)
             st = get_success_create_code()
-            return Response(data, status=st, headers=headers)
+            # Transform data to a data_response with only key
+            data_response = data_to_data_response(data)
+            return Response(data_response, status=st, headers=headers)
 
     def list(self, request, *args, **kwargs):
         try:

--- a/backend/substrapp/views/datamanager.py
+++ b/backend/substrapp/views/datamanager.py
@@ -15,7 +15,8 @@ from substrapp.utils import get_hash
 from substrapp.ledger_utils import query_ledger, get_object_from_ledger, LedgerError, LedgerTimeout, LedgerConflict
 from substrapp.views.utils import (PermissionMixin, find_primary_key_error,
                                    validate_pk, get_success_create_code, ValidationException, LedgerException,
-                                   get_remote_asset, node_has_process_permission, get_channel_name)
+                                   get_remote_asset, node_has_process_permission, get_channel_name,
+                                   data_to_data_response)
 from substrapp.views.filters_utils import filter_list
 
 
@@ -116,13 +117,15 @@ class DataManagerViewSet(mixins.CreateModelMixin,
         try:
             data = self._create(request, data_opener)
         except ValidationException as e:
-            return Response({'message': e.data, 'pkhash': e.pkhash}, status=e.st)
+            return Response({'message': e.data, 'key': e.pkhash}, status=e.st)
         except LedgerException as e:
             return Response({'message': e.data}, status=e.st)
         else:
             headers = self.get_success_headers(data)
             st = get_success_create_code()
-            return Response(data, status=st, headers=headers)
+            # Transform data to a data_response with only key
+            data_response = data_to_data_response(data)
+            return Response(data_response, status=st, headers=headers)
 
     def create_or_update_datamanager(self, channel_name, instance, datamanager, pk):
 

--- a/backend/substrapp/views/datamanager.py
+++ b/backend/substrapp/views/datamanager.py
@@ -177,7 +177,7 @@ class DataManagerViewSet(mixins.CreateModelMixin,
                     instance = self.create_or_update_datamanager(get_channel_name(request), instance, data, pk)
 
                 # do not give access to local files address
-                serializer = self.get_serializer(instance, fields=('owner', 'pkhash', 'creation_date', 'last_modified'))
+                serializer = self.get_serializer(instance, fields=('owner'))
                 data.update(serializer.data)
 
         replace_storage_addresses(request, data)

--- a/backend/substrapp/views/filters_utils.py
+++ b/backend/substrapp/views/filters_utils.py
@@ -163,9 +163,11 @@ def filter_list(channel_name, object_type, data, query_params):
                                     _get_model_tuple(x)['outModel'][attribute] in val
                                 ) or (
                                     _get_model_tuple(x).get('outTrunkModel') and
+                                    _get_model_tuple(x)['outTrunkModel'].get('outModel') and
                                     _get_model_tuple(x)['outTrunkModel']['outModel'][attribute] in val
                                 ) or (
                                     _get_model_tuple(x).get('outHeadModel') and
+                                    _get_model_tuple(x)['outHeadModel'].get('outModel') and
                                     _get_model_tuple(x)['outHeadModel']['outModel'][attribute] in val
                                 )
                             )

--- a/backend/substrapp/views/objective.py
+++ b/backend/substrapp/views/objective.py
@@ -19,7 +19,8 @@ from substrapp.utils import get_hash
 from substrapp.views.utils import (PermissionMixin, find_primary_key_error, validate_pk,
                                    get_success_create_code, ValidationException,
                                    LedgerException, get_remote_asset, validate_sort,
-                                   node_has_process_permission, get_channel_name)
+                                   node_has_process_permission, get_channel_name,
+                                   data_to_data_response)
 from substrapp.views.filters_utils import filter_list
 
 
@@ -130,13 +131,15 @@ class ObjectiveViewSet(mixins.CreateModelMixin,
         try:
             data = self._create(request)
         except ValidationException as e:
-            return Response({'message': e.data, 'pkhash': e.pkhash}, status=e.st)
+            return Response({'message': e.data, 'key': e.pkhash}, status=e.st)
         except LedgerException as e:
             return Response({'message': e.data}, status=e.st)
         else:
             headers = self.get_success_headers(data)
             st = get_success_create_code()
-            return Response(data, status=st, headers=headers)
+            # Transform data to a data_response with only key
+            data_response = data_to_data_response(data)
+            return Response(data_response, status=st, headers=headers)
 
     def create_or_update_objective(self, channel_name, objective, pk):
         # get description from remote node

--- a/backend/substrapp/views/objective.py
+++ b/backend/substrapp/views/objective.py
@@ -173,7 +173,7 @@ class ObjectiveViewSet(mixins.CreateModelMixin,
             # For security reason, do not give access to local file address
             # Restrain data to some fields
             # TODO: do we need to send creation date and/or last modified date ?
-            serializer = self.get_serializer(instance, fields=('owner', 'pkhash'))
+            serializer = self.get_serializer(instance, fields=('owner'))
             data.update(serializer.data)
 
         replace_storage_addresses(request, data)

--- a/backend/substrapp/views/testtuple.py
+++ b/backend/substrapp/views/testtuple.py
@@ -5,7 +5,8 @@ from rest_framework.viewsets import GenericViewSet
 from substrapp.serializers import LedgerTestTupleSerializer
 from substrapp.ledger_utils import query_ledger, get_object_from_ledger, LedgerError, LedgerConflict
 from substrapp.views.filters_utils import filter_list
-from substrapp.views.utils import validate_pk, get_success_create_code, LedgerException, get_channel_name
+from substrapp.views.utils import (validate_pk, get_success_create_code, LedgerException, get_channel_name,
+                                   data_to_data_response)
 
 
 class TestTupleViewSet(mixins.CreateModelMixin,
@@ -49,7 +50,7 @@ class TestTupleViewSet(mixins.CreateModelMixin,
         try:
             data = query_ledger(get_channel_name(request), fcn='createTesttuple', args=args)
         except LedgerConflict as e:
-            raise LedgerException({'message': str(e.msg), 'pkhash': e.pkhash}, e.status)
+            raise LedgerException({'message': str(e.msg), 'key': e.pkhash}, e.status)
         except LedgerError as e:
             raise LedgerException({'message': str(e.msg)}, e.status)
         else:
@@ -64,7 +65,9 @@ class TestTupleViewSet(mixins.CreateModelMixin,
         else:
             headers = self.get_success_headers(data)
             st = get_success_create_code()
-            return Response(data, status=st, headers=headers)
+            # Transform data to a data_response with only key
+            data_response = data_to_data_response(data)
+            return Response(data_response, status=st, headers=headers)
 
     def list(self, request, *args, **kwargs):
         try:

--- a/backend/substrapp/views/traintuple.py
+++ b/backend/substrapp/views/traintuple.py
@@ -5,7 +5,8 @@ from rest_framework.viewsets import GenericViewSet
 from substrapp.serializers import LedgerTrainTupleSerializer
 from substrapp.ledger_utils import query_ledger, get_object_from_ledger, LedgerError, LedgerConflict
 from substrapp.views.filters_utils import filter_list
-from substrapp.views.utils import validate_pk, get_success_create_code, LedgerException, get_channel_name
+from substrapp.views.utils import (validate_pk, get_success_create_code, LedgerException, get_channel_name,
+                                   data_to_data_response)
 
 
 class TrainTupleViewSet(mixins.CreateModelMixin,
@@ -52,7 +53,7 @@ class TrainTupleViewSet(mixins.CreateModelMixin,
         try:
             data = query_ledger(get_channel_name(request), fcn='createTraintuple', args=args)
         except LedgerConflict as e:
-            raise LedgerException({'message': str(e.msg), 'pkhash': e.pkhash}, e.status)
+            raise LedgerException({'message': str(e.msg), 'key': e.pkhash}, e.status)
         except LedgerError as e:
             raise LedgerException({'message': str(e.msg)}, e.status)
         else:
@@ -67,7 +68,9 @@ class TrainTupleViewSet(mixins.CreateModelMixin,
         else:
             headers = self.get_success_headers(data)
             st = get_success_create_code()
-            return Response(data, status=st, headers=headers)
+            # Transform data to a data_response with only key
+            data_response = data_to_data_response(data)
+            return Response(data_response, status=st, headers=headers)
 
     def list(self, request, *args, **kwargs):
         try:

--- a/backend/substrapp/views/utils.py
+++ b/backend/substrapp/views/utils.py
@@ -217,3 +217,15 @@ def get_channel_name(request):
         return request.headers['Substra-Channel-Name']
 
     raise exceptions.BadRequestError('Could not determine channel name')
+
+
+def data_to_data_response(data):
+    # Transform data to a data_response with only key
+
+    if data and isinstance(data, list) and 'pkhash' in data[0]:
+        return [{'key': d['pkhash']} for d in data]
+
+    if 'pkhash' in data:
+        return {'key': data['pkhash']}
+
+    return data


### PR DESCRIPTION
The goal of this multi-repo PRs is to make sure that all the asset creation endpoints returns only the "key" of the asset. 
Indeed, currently `create` and 'get' an asset return, respectively, `pkhash` and `key`. As `pkhash` is only a substra-backend concept, we need to move from `pkhash` to `key` when dealing with substra cli/sdk and frontend.

Consequently, when client create a new asset, the substra-backend will now only return the `key` of the created asset.

There is an exception for compute plan which need to be returned in its complete form because client need to get the ID_to_key mapping and it’s returned only when client create this asset.

The client will take care of doing an extra GET in order to retrieve the complete asset.

PRs :
    https://github.com/SubstraFoundation/substra-backend/pull/312
    https://github.com/SubstraFoundation/substra/pull/220
    https://github.com/SubstraFoundation/substra-tests/pull/140

