### PR TITLE
Switch output from camel case to snake case

### DIFF
--- a/backend/events/apps.py
+++ b/backend/events/apps.py
@@ -19,7 +19,7 @@ from hfc.util.keyvaluestore import FileKeyValueStore
 
 from substrapp.tasks.tasks import prepare_tuple, on_compute_plan
 from substrapp.utils import get_owner
-from substrapp.ledger_utils import get_hfc
+from substrapp.ledger_utils import get_hfc, to_snake_case, _replace_dict_keys
 
 from celery.result import AsyncResult
 
@@ -90,7 +90,7 @@ def on_compute_plan_event(channel_name, block_number, tx_id, tx_status, asset):
 
     worker_queue = f"{LEDGER['name']}.worker"
 
-    key = asset['computePlanID']
+    key = asset['compute_plan_id']
 
     # Currently, we received this event on done, failed and canceled status
     # We apply the same behavior for those three status.
@@ -127,7 +127,7 @@ def on_event(channel_name, cc_event, block_number, tx_id, tx_status):
             continue
 
         for asset in assets:
-
+            asset = _replace_dict_keys(asset, to_snake_case)
             if event_type == 'computePlan':
                 on_compute_plan_event(channel_name, block_number, tx_id, tx_status, asset)
             else:

--- a/backend/node/tests/views/tests_views_node.py
+++ b/backend/node/tests/views/tests_views_node.py
@@ -44,6 +44,6 @@ class ModelViewTests(APITestCase):
                 response = self.client.get(url, **self.extra)
                 r = response.json()
                 self.assertEqual(r, [
-                    {'id': 'foo', 'isCurrent': True},
-                    {'id': 'bar', 'isCurrent': False}
+                    {'id': 'foo', 'is_current': True},
+                    {'id': 'bar', 'is_current': False}
                 ])

--- a/backend/node/views/node.py
+++ b/backend/node/views/node.py
@@ -23,6 +23,6 @@ class NodeViewSet(mixins.ListModelMixin,
         current_node_id = get_owner()
         for node in nodes:
             node.update({
-                'isCurrent': node['id'] == current_node_id,
+                'is_current': node['id'] == current_node_id,
             })
         return Response(nodes, status=status.HTTP_200_OK)

--- a/backend/substrapp/ledger_utils.py
+++ b/backend/substrapp/ledger_utils.py
@@ -176,11 +176,14 @@ def _replace_dict_keys(d, converter):
 
     new_d = {}
     for key, value in d.items():
-        if isinstance(value, dict):
-            value = _replace_dict_keys(value, converter)
-        elif isinstance(value, list):
-            if all([isinstance(v, dict) for v in value]):
-                value = [_replace_dict_keys(v, converter) for v in value]
+        # If key is 'metadata' we should not convert value to snake case
+        if key != 'metadata':
+            if isinstance(value, dict):
+                value = _replace_dict_keys(value, converter)
+
+            elif isinstance(value, list):
+                if all([isinstance(v, dict) for v in value]):
+                    value = [_replace_dict_keys(v, converter) for v in value]
 
         new_d[converter(key)] = value
     return new_d
@@ -194,7 +197,10 @@ def replace_dict_keys(d, converter):
     if isinstance(d, dict):
         return _replace_dict_keys(d, converter)
     elif isinstance(d, list):
-        return [_replace_dict_keys(sub_d, converter) for sub_d in d]
+        if all([isinstance(sub_d, dict) for sub_d in d]):
+            return [_replace_dict_keys(sub_d, converter) for sub_d in d]
+        else:
+            return d
     else:
         raise TypeError(f'd ({type(d)} is not a instance of dict or list')
 

--- a/backend/substrapp/tests/assets.py
+++ b/backend/substrapp/tests/assets.py
@@ -18,17 +18,17 @@ objective = [
         "name": "9224cad96c964b7b8ed2f7eb5872c27a_global - Objective 0",
         "description": {
             "hash": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
-            "storageAddress": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/description/"
+            "storage_address": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/description/"
         },
         "metrics": {
             "name": "test metrics",
             "hash": "0d64f855e07524da60203067713ab08fd6e479a02ebcb70364b2c6a2a29367e1",
-            "storageAddress": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
+            "storage_address": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
         },
         "owner": "MyOrg1MSP",
-        "testDataset": {
-            "dataManagerKey": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
-            "dataSampleKeys": [
+        "test_dataset": {
+            "data_manager_key": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "data_sample_keys": [
                 "ffed4147fffff2f18130b7332c1460ecccd8e1378765c415b82b948c19e98a68"
             ],
             "metadata": {},
@@ -37,7 +37,7 @@ objective = [
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "metadata": {}
@@ -47,17 +47,17 @@ objective = [
         "name": "9224cad96c964b7b8ed2f7eb5872c27a_global - Objective 1",
         "description": {
             "hash": "b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3",
-            "storageAddress": "http://testserver/objective/b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3/description/"
+            "storage_address": "http://testserver/objective/b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3/description/"
         },
         "metrics": {
             "name": "test metrics",
             "hash": "1a61bea02e3e75f8197d682cbaa6110c9709fbfbd4f16964acc390c70e7a22fe",
-            "storageAddress": "http://testserver/objective/b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3/metrics/"
+            "storage_address": "http://testserver/objective/b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3/metrics/"
         },
         "owner": "MyOrg2MSP",
-        "testDataset": {
-            "dataManagerKey": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
-            "dataSampleKeys": [
+        "test_dataset": {
+            "data_manager_key": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+            "data_sample_keys": [
                 "edaa4ccdfc9bcadda859498fbb550a6e1fc6baf176389c3eb18afc8a382b4145"
             ],
             "metadata": {},
@@ -66,7 +66,7 @@ objective = [
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "metadata": {}
@@ -75,45 +75,45 @@ objective = [
 
 datamanager = [
     {
-        "objectiveKey": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
+        "objective_key": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
         "description": {
             "hash": "8acac2e3b700de1e27ee00b8cc0b49a883476d4234015658cbff7a701332a498",
-            "storageAddress": "http://testserver/data_manager/e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204/description/"
+            "storage_address": "http://testserver/data_manager/e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204/description/"
         },
         "key": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
         "metadata": {},
         "name": "9224cad96c964b7b8ed2f7eb5872c27a_global - Dataset 0",
         "opener": {
             "hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
-            "storageAddress": "http://testserver/data_manager/e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204/opener/"
+            "storage_address": "http://testserver/data_manager/e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204/opener/"
         },
         "owner": "MyOrg1MSP",
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "type": "Test"
     },
     {
-        "objectiveKey": "b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3",
+        "objective_key": "b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3",
         "description": {
             "hash": "0b32ac306997ff74a6b24e79264133de33d841e546f3f88b26a18d46e18223d9",
-            "storageAddress": "http://testserver/data_manager/aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02/description/"
+            "storage_address": "http://testserver/data_manager/aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02/description/"
         },
         "key": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
         "metadata": {},
         "name": "9224cad96c964b7b8ed2f7eb5872c27a_global - Dataset 1",
         "opener": {
             "hash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
-            "storageAddress": "http://testserver/data_manager/aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02/opener/"
+            "storage_address": "http://testserver/data_manager/aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02/opener/"
         },
         "owner": "MyOrg2MSP",
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "type": "Test"
@@ -126,17 +126,17 @@ algo = [
         "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple - Algo 0",
         "content": {
             "hash": "4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be",
-            "storageAddress": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
+            "storage_address": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
         },
         "description": {
             "hash": "22b9af671a660afd001b15c5a85edaa81dc42fbda7aef03f2fd76aa10d2e5151",
-            "storageAddress": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/description/"
+            "storage_address": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/description/"
         },
         "owner": "MyOrg1MSP",
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "metadata": {}
@@ -146,17 +146,17 @@ algo = [
         "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_federated_learning_workflow - Algo 0",
         "content": {
             "hash": "59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30",
-            "storageAddress": "http://testserver/algo/59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30/file/"
+            "storage_address": "http://testserver/algo/59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30/file/"
         },
         "description": {
             "hash": "df548aab4b1a66e08021774e0b70e6f59b858ba41afa550396d213357326f891",
-            "storageAddress": "http://testserver/algo/59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30/description/"
+            "storage_address": "http://testserver/algo/59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30/description/"
         },
         "owner": "MyOrg1MSP",
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "metadata": {}
@@ -166,17 +166,17 @@ algo = [
         "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_same_node - Algo 0",
         "content": {
             "hash": "e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8",
-            "storageAddress": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
+            "storage_address": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
         },
         "description": {
             "hash": "851fc503e6136c86f4a0f4035aa6d59c44f017694757769b9b2d7d39a7f5dc3c",
-            "storageAddress": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/description/"
+            "storage_address": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/description/"
         },
         "owner": "MyOrg1MSP",
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "metadata": {}
@@ -186,17 +186,17 @@ algo = [
         "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_traintuple_execution_failure - Algo 0",
         "content": {
             "hash": "ebbd8c65dfe07d826d692f806deceffd296e715fa4db9e652304180dd7ee293d",
-            "storageAddress": "http://testserver/algo/ebbd8c65dfe07d826d692f806deceffd296e715fa4db9e652304180dd7ee293d/file/"
+            "storage_address": "http://testserver/algo/ebbd8c65dfe07d826d692f806deceffd296e715fa4db9e652304180dd7ee293d/file/"
         },
         "description": {
             "hash": "d0289ce5f4ec35ea5eff7dc76b36cdc93c90bc3d76f55a8707a701f699742292",
-            "storageAddress": "http://testserver/algo/ebbd8c65dfe07d826d692f806deceffd296e715fa4db9e652304180dd7ee293d/description/"
+            "storage_address": "http://testserver/algo/ebbd8c65dfe07d826d692f806deceffd296e715fa4db9e652304180dd7ee293d/description/"
         },
         "owner": "MyOrg1MSP",
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "metadata": {}
@@ -206,17 +206,17 @@ algo = [
         "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_different_nodes - Algo 0",
         "content": {
             "hash": "c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593",
-            "storageAddress": "http://testserver/algo/c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593/file/"
+            "storage_address": "http://testserver/algo/c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593/file/"
         },
         "description": {
             "hash": "9a56aa11bdb75a1b5c2641493d546d4a28ec4d9d60aa0df18f5c2a019f8518b7",
-            "storageAddress": "http://testserver/algo/c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593/description/"
+            "storage_address": "http://testserver/algo/c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593/description/"
         },
         "owner": "MyOrg2MSP",
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "metadata": {}
@@ -229,7 +229,7 @@ traintuple = [
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple - Algo 0",
             "hash": "4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be",
-            "storageAddress": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
+            "storage_address": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
         },
         "creator": "MyOrg1MSP",
         "dataset": {
@@ -237,21 +237,21 @@ traintuple = [
             "keys": [
                 "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f"
             ],
-            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
             "metadata": {}
         },
-        "computePlanID": "",
-        "inModels": None,
+        "compute_plan_id": "",
+        "in_models": None,
         "log": "",
         "metadata": {},
-        "outModel": {
+        "out_model": {
             "hash": "940262c35a6b33c2b7c8811fa785899b00e287ffa05e3cb5a23c857e9c89c760",
-            "storageAddress": "http://testserver/model/940262c35a6b33c2b7c8811fa785899b00e287ffa05e3cb5a23c857e9c89c760/file/"
+            "storage_address": "http://testserver/model/940262c35a6b33c2b7c8811fa785899b00e287ffa05e3cb5a23c857e9c89c760/file/"
         },
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "rank": 0,
@@ -263,7 +263,7 @@ traintuple = [
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple - Algo 0",
             "hash": "4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be",
-            "storageAddress": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
+            "storage_address": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
         },
         "creator": "MyOrg1MSP",
         "dataset": {
@@ -271,21 +271,21 @@ traintuple = [
             "keys": [
                 "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3"
             ],
-            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
             "metadata": {}
         },
-        "computePlanID": "",
-        "inModels": None,
+        "compute_plan_id": "",
+        "in_models": None,
         "log": "",
         "metadata": {},
-        "outModel": {
+        "out_model": {
             "hash": "f33d3c7a21e97f5f0edd636f3b313c6a7757cc458614e49da74d58af7fc0c4c2",
-            "storageAddress": "http://testserver/model/f33d3c7a21e97f5f0edd636f3b313c6a7757cc458614e49da74d58af7fc0c4c2/file/"
+            "storage_address": "http://testserver/model/f33d3c7a21e97f5f0edd636f3b313c6a7757cc458614e49da74d58af7fc0c4c2/file/"
         },
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "rank": 0,
@@ -297,7 +297,7 @@ traintuple = [
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple - Algo 0",
             "hash": "4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be",
-            "storageAddress": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
+            "storage_address": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
         },
         "creator": "MyOrg1MSP",
         "dataset": {
@@ -305,21 +305,21 @@ traintuple = [
             "keys": [
                 "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135"
             ],
-            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
             "metadata": {}
         },
-        "computePlanID": "",
-        "inModels": None,
+        "compute_plan_id": "",
+        "in_models": None,
         "log": "",
         "metadata": {},
-        "outModel": {
+        "out_model": {
             "hash": "02ccc4eeb426f7bbfe746a06a4c63a2023a8f2ea2c72f92242cc5f7f1164383c",
-            "storageAddress": "http://testserver/model/02ccc4eeb426f7bbfe746a06a4c63a2023a8f2ea2c72f92242cc5f7f1164383c/file/"
+            "storage_address": "http://testserver/model/02ccc4eeb426f7bbfe746a06a4c63a2023a8f2ea2c72f92242cc5f7f1164383c/file/"
         },
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "rank": 0,
@@ -331,7 +331,7 @@ traintuple = [
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_federated_learning_workflow - Algo 0",
             "hash": "59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30",
-            "storageAddress": "http://testserver/algo/59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30/file/"
+            "storage_address": "http://testserver/algo/59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30/file/"
         },
         "creator": "MyOrg1MSP",
         "dataset": {
@@ -342,27 +342,27 @@ traintuple = [
                 "88608067e903a7b5cbfed480e7c4ee9eaf7eb37994cb2fec045497f324508a33",
                 "e453da42246d9be33204fa30fb91755b989bbdeee2559dd93e14f57b57d1847f"
             ],
-            "openerHash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+            "opener_hash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
             "metadata": {}
         },
-        "computePlanID": "4a7f743fd9a5ccaa6f8366a10f92955486ab15116a1e43f6c1ba1b9504f6b157",
-        "inModels": [
+        "compute_plan_id": "4a7f743fd9a5ccaa6f8366a10f92955486ab15116a1e43f6c1ba1b9504f6b157",
+        "in_models": [
             {
-                "traintupleKey": "49dedc3b4e763a2d09e39f4e5eee3d4910beee8b4e3ba666f9c6ef00f1632ec3",
+                "traintuple_key": "49dedc3b4e763a2d09e39f4e5eee3d4910beee8b4e3ba666f9c6ef00f1632ec3",
                 "hash": "714ee81465576b09f1e4c6e0f28e82189501c46ed36569c9867eff851a285888",
-                "storageAddress": "http://testserver/model/714ee81465576b09f1e4c6e0f28e82189501c46ed36569c9867eff851a285888/file/"
+                "storage_address": "http://testserver/model/714ee81465576b09f1e4c6e0f28e82189501c46ed36569c9867eff851a285888/file/"
             }
         ],
         "log": "",
         "metadata": {},
-        "outModel": {
+        "out_model": {
             "hash": "4672cd5a9e134a6f6c54144c3a8e8330b2147fa10264ca8e9fbac9b9075cacd0",
-            "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/model/4672cd5a9e134a6f6c54144c3a8e8330b2147fa10264ca8e9fbac9b9075cacd0/file/"
+            "storage_address": "http://backend-org-2-substra-backend-server.org-2:8000/model/4672cd5a9e134a6f6c54144c3a8e8330b2147fa10264ca8e9fbac9b9075cacd0/file/"
         },
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "rank": 1,
@@ -374,7 +374,7 @@ traintuple = [
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_federated_learning_workflow - Algo 0",
             "hash": "59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30",
-            "storageAddress": "http://testserver/algo/59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30/file/"
+            "storage_address": "http://testserver/algo/59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30/file/"
         },
         "creator": "MyOrg1MSP",
         "dataset": {
@@ -385,21 +385,21 @@ traintuple = [
                 "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
                 "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
             ],
-            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
             "metadata": {}
         },
-        "computePlanID": "4a7f743fd9a5ccaa6f8366a10f92955486ab15116a1e43f6c1ba1b9504f6b157",
-        "inModels": None,
+        "compute_plan_id": "4a7f743fd9a5ccaa6f8366a10f92955486ab15116a1e43f6c1ba1b9504f6b157",
+        "in_models": None,
         "log": "",
         "metadata": {},
-        "outModel": {
+        "out_model": {
             "hash": "714ee81465576b09f1e4c6e0f28e82189501c46ed36569c9867eff851a285888",
-            "storageAddress": "http://testserver/model/714ee81465576b09f1e4c6e0f28e82189501c46ed36569c9867eff851a285888/file/"
+            "storage_address": "http://testserver/model/714ee81465576b09f1e4c6e0f28e82189501c46ed36569c9867eff851a285888/file/"
         },
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "rank": 0,
@@ -411,7 +411,7 @@ traintuple = [
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_different_nodes - Algo 0",
             "hash": "c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593",
-            "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/algo/c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593/file/"
+            "storage_address": "http://backend-org-2-substra-backend-server.org-2:8000/algo/c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593/file/"
         },
         "creator": "MyOrg1MSP",
         "dataset": {
@@ -422,21 +422,21 @@ traintuple = [
                 "88608067e903a7b5cbfed480e7c4ee9eaf7eb37994cb2fec045497f324508a33",
                 "e453da42246d9be33204fa30fb91755b989bbdeee2559dd93e14f57b57d1847f"
             ],
-            "openerHash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+            "opener_hash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
             "metadata": {}
         },
-        "computePlanID": "",
-        "inModels": None,
+        "compute_plan_id": "",
+        "in_models": None,
         "log": "",
         "metadata": {},
-        "outModel": {
+        "out_model": {
             "hash": "d771446f0be15ebaa66db902f5a98a5005611de4ea44d3a5fe77c50ee34ff114",
-            "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/model/d771446f0be15ebaa66db902f5a98a5005611de4ea44d3a5fe77c50ee34ff114/file/"
+            "storage_address": "http://backend-org-2-substra-backend-server.org-2:8000/model/d771446f0be15ebaa66db902f5a98a5005611de4ea44d3a5fe77c50ee34ff114/file/"
         },
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "rank": 0,
@@ -448,7 +448,7 @@ traintuple = [
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_same_node - Algo 0",
             "hash": "e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8",
-            "storageAddress": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
+            "storage_address": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
         },
         "creator": "MyOrg1MSP",
         "dataset": {
@@ -459,23 +459,23 @@ traintuple = [
                 "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
                 "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
             ],
-            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
             "metadata": {}
         },
-        "computePlanID": "",
-        "inModels": None,
+        "compute_plan_id": "",
+        "in_models": None,
         "log": "",
         "metadata": {
             "foo": "bar"
         },
-        "outModel": {
+        "out_model": {
             "hash": "420ce592a42e0c78e644447173b54046163a2afeadd37227cef6866fc7d4c4f7",
-            "storageAddress": "http://testserver/model/420ce592a42e0c78e644447173b54046163a2afeadd37227cef6866fc7d4c4f7/file/"
+            "storage_address": "http://testserver/model/420ce592a42e0c78e644447173b54046163a2afeadd37227cef6866fc7d4c4f7/file/"
         },
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "rank": 0,
@@ -487,7 +487,7 @@ traintuple = [
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_same_node - Algo 0",
             "hash": "e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8",
-            "storageAddress": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
+            "storage_address": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
         },
         "creator": "MyOrg1MSP",
         "dataset": {
@@ -498,27 +498,27 @@ traintuple = [
                 "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
                 "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
             ],
-            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
             "metadata": {}
         },
-        "computePlanID": "",
-        "inModels": [
+        "compute_plan_id": "",
+        "in_models": [
             {
-                "traintupleKey": "e3aab7fe0c51e970edecdfa1f780fd529e437d92603e66e57f230d926c7808b6",
+                "traintuple_key": "e3aab7fe0c51e970edecdfa1f780fd529e437d92603e66e57f230d926c7808b6",
                 "hash": "420ce592a42e0c78e644447173b54046163a2afeadd37227cef6866fc7d4c4f7",
-                "storageAddress": "http://testserver/model/420ce592a42e0c78e644447173b54046163a2afeadd37227cef6866fc7d4c4f7/file/"
+                "storage_address": "http://testserver/model/420ce592a42e0c78e644447173b54046163a2afeadd37227cef6866fc7d4c4f7/file/"
             }
         ],
         "log": "",
         "metadata": {},
-        "outModel": {
+        "out_model": {
             "hash": "7b3183a99222df2b18de11c8f767fdca2c7ebb0d4fa8bfe03c4f169cfea2aba2",
-            "storageAddress": "http://testserver/model/7b3183a99222df2b18de11c8f767fdca2c7ebb0d4fa8bfe03c4f169cfea2aba2/file/"
+            "storage_address": "http://testserver/model/7b3183a99222df2b18de11c8f767fdca2c7ebb0d4fa8bfe03c4f169cfea2aba2/file/"
         },
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "rank": 0,
@@ -530,7 +530,7 @@ traintuple = [
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_traintuple_execution_failure - Algo 0",
             "hash": "ebbd8c65dfe07d826d692f806deceffd296e715fa4db9e652304180dd7ee293d",
-            "storageAddress": "http://testserver/algo/ebbd8c65dfe07d826d692f806deceffd296e715fa4db9e652304180dd7ee293d/file/"
+            "storage_address": "http://testserver/algo/ebbd8c65dfe07d826d692f806deceffd296e715fa4db9e652304180dd7ee293d/file/"
         },
         "creator": "MyOrg1MSP",
         "dataset": {
@@ -541,18 +541,18 @@ traintuple = [
                 "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
                 "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
             ],
-            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
             "metadata": {}
         },
-        "computePlanID": "",
-        "inModels": None,
+        "compute_plan_id": "",
+        "in_models": None,
         "log": "[00-01-0117-d64af6f]",
         "metadata": {},
-        "outModel": None,
+        "out_model": None,
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "rank": 0,
@@ -566,17 +566,17 @@ testtuple = [
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_composite_traintuples_execution - Algo 0",
             "hash": "09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf",
-            "storageAddress": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
+            "storage_address": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
         },
         "certified": True,
-        "computePlanID": "",
+        "compute_plan_id": "",
         "creator": "MyOrg1MSP",
         "dataset": {
             "worker": "MyOrg1MSP",
             "keys": [
                 "ffed4147fffff2f18130b7332c1460ecccd8e1378765c415b82b948c19e98a68"
             ],
-            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
             "perf": 32
         },
         "key": "8cd0eb9ae2349fc33b36ebb689963840bdfd3ffe4f24392d77dba85c4c087d02",
@@ -586,30 +586,30 @@ testtuple = [
             "hash": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
             "metrics": {
                 "hash": "0d64f855e07524da60203067713ab08fd6e479a02ebcb70364b2c6a2a29367e1",
-                "storageAddress": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
+                "storage_address": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
             }
         },
         "rank": 0,
         "status": "done",
         "tag": "bar",
-        "traintupleKey": "2978ca1f7d5520ef42a82c86a2e24d5b00f04c73013febdb5ed35d32dc606e92",
-        "traintupleType": "compositeTraintuple"
+        "traintuple_key": "2978ca1f7d5520ef42a82c86a2e24d5b00f04c73013febdb5ed35d32dc606e92",
+        "traintuple_type": "compositeTraintuple"
     },
     {
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
             "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
-            "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+            "storage_address": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
         },
         "certified": True,
-        "computePlanID": "",
+        "compute_plan_id": "",
         "creator": "MyOrg1MSP",
         "dataset": {
             "worker": "MyOrg2MSP",
             "keys": [
                 "edaa4ccdfc9bcadda859498fbb550a6e1fc6baf176389c3eb18afc8a382b4145"
             ],
-            "openerHash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+            "opener_hash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
             "perf": 32
         },
         "key": "87e835650d84ca0cf26ac332bad4f4d732a30606505f57f1817fb6580f16adc5",
@@ -619,30 +619,30 @@ testtuple = [
             "hash": "b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3",
             "metrics": {
                 "hash": "1a61bea02e3e75f8197d682cbaa6110c9709fbfbd4f16964acc390c70e7a22fe",
-                "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/objective/b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3/metrics/"
+                "storage_address": "http://backend-org-2-substra-backend-server.org-2:8000/objective/b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3/metrics/"
             }
         },
         "rank": 0,
         "status": "done",
         "tag": "",
-        "traintupleKey": "3be92d96d1abdabfbe6a4ff612d70f7f867f450c38ea344bd98d0775bec826fd",
-        "traintupleType": "compositeTraintuple"
+        "traintuple_key": "3be92d96d1abdabfbe6a4ff612d70f7f867f450c38ea344bd98d0775bec826fd",
+        "traintuple_type": "compositeTraintuple"
     },
     {
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
             "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
-            "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+            "storage_address": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
         },
         "certified": True,
-        "computePlanID": "",
+        "compute_plan_id": "",
         "creator": "MyOrg1MSP",
         "dataset": {
             "worker": "MyOrg1MSP",
             "keys": [
                 "ffed4147fffff2f18130b7332c1460ecccd8e1378765c415b82b948c19e98a68"
             ],
-            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
             "perf": 32
         },
         "key": "6075c796cc470f1e1de7b98d8a4d28b19e48c1d662ee9bdb982c0354088d2f2a",
@@ -652,30 +652,30 @@ testtuple = [
             "hash": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
             "metrics": {
                 "hash": "0d64f855e07524da60203067713ab08fd6e479a02ebcb70364b2c6a2a29367e1",
-                "storageAddress": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
+                "storage_address": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
             }
         },
         "rank": 0,
         "status": "done",
         "tag": "",
-        "traintupleKey": "5adbd24ea21cb23b1ffc65151038a62c97f2d745d7df0928e683707f15a09556",
-        "traintupleType": "compositeTraintuple"
+        "traintuple_key": "5adbd24ea21cb23b1ffc65151038a62c97f2d745d7df0928e683707f15a09556",
+        "traintuple_type": "compositeTraintuple"
     },
     {
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_same_node - Algo 0",
             "hash": "e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8",
-            "storageAddress": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
+            "storage_address": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
         },
         "certified": True,
-        "computePlanID": "",
+        "compute_plan_id": "",
         "creator": "MyOrg1MSP",
         "dataset": {
             "worker": "MyOrg1MSP",
             "keys": [
                 "ffed4147fffff2f18130b7332c1460ecccd8e1378765c415b82b948c19e98a68"
             ],
-            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
             "perf": 2
         },
         "key": "e2f386a88a1702cecf0270742a31cdf0be4a9d9b083467679058d00aaff55ac4",
@@ -685,30 +685,30 @@ testtuple = [
             "hash": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
             "metrics": {
                 "hash": "0d64f855e07524da60203067713ab08fd6e479a02ebcb70364b2c6a2a29367e1",
-                "storageAddress": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
+                "storage_address": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
             }
         },
         "rank": 0,
         "status": "done",
         "tag": "",
-        "traintupleKey": "e3aab7fe0c51e970edecdfa1f780fd529e437d92603e66e57f230d926c7808b6",
-        "traintupleType": "traintuple"
+        "traintuple_key": "e3aab7fe0c51e970edecdfa1f780fd529e437d92603e66e57f230d926c7808b6",
+        "traintuple_type": "traintuple"
     },
     {
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_different_nodes - Algo 0",
             "hash": "c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593",
-            "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/algo/c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593/file/"
+            "storage_address": "http://backend-org-2-substra-backend-server.org-2:8000/algo/c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593/file/"
         },
         "certified": True,
-        "computePlanID": "",
+        "compute_plan_id": "",
         "creator": "MyOrg1MSP",
         "dataset": {
             "worker": "MyOrg1MSP",
             "keys": [
                 "ffed4147fffff2f18130b7332c1460ecccd8e1378765c415b82b948c19e98a68"
             ],
-            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
             "perf": 2
         },
         "key": "0599697085f343a8298ee3a87bd0000285e944fa4a05f541aa985d3eab50c04d",
@@ -718,34 +718,34 @@ testtuple = [
             "hash": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
             "metrics": {
                 "hash": "0d64f855e07524da60203067713ab08fd6e479a02ebcb70364b2c6a2a29367e1",
-                "storageAddress": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
+                "storage_address": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
             }
         },
         "rank": 0,
         "status": "done",
         "tag": "",
-        "traintupleKey": "e623fe67c0dc4ed78d4e34f9f0fad0ac3a5fa7aafb819a3e1961f978d7540b2a",
-        "traintupleType": "traintuple"
+        "traintuple_key": "e623fe67c0dc4ed78d4e34f9f0fad0ac3a5fa7aafb819a3e1961f978d7540b2a",
+        "traintuple_type": "traintuple"
     }
 ]
 
 computeplan = [
     {
-        "computePlanID": "4a7f743fd9a5ccaa6f8366a10f92955486ab15116a1e43f6c1ba1b9504f6b157",
-        "traintupleKeys": [
+        "compute_plan_id": "4a7f743fd9a5ccaa6f8366a10f92955486ab15116a1e43f6c1ba1b9504f6b157",
+        "traintuple_keys": [
             "49dedc3b4e763a2d09e39f4e5eee3d4910beee8b4e3ba666f9c6ef00f1632ec3",
             "137804ca8660878062e419e340efd2826ce0d528c47a40879e30cdc1e77da1b0"
         ],
-        "aggregatetupleKeys": None,
-        "compositeTraintupleKeys": None,
-        "testtupleKeys": None,
-        "cleanModels": False,
+        "aggregatetuple_keys": None,
+        "composite_traintuple_keys": None,
+        "testtuple_keys": None,
+        "clean_models": False,
         "tag": "",
         "metadata": {},
         "status": "done",
-        "tupleCount": 2,
-        "doneCount": 2,
-        "IDToKey": {}
+        "tuple_count": 2,
+        "done_count": 2,
+        "id_to_key": {}
     }
 ]
 
@@ -755,7 +755,7 @@ compositetraintuple = [
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_composite_traintuples_execution - Algo 0",
             "hash": "09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf",
-            "storageAddress": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
+            "storage_address": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
         },
         "creator": "MyOrg1MSP",
         "dataset": {
@@ -766,44 +766,44 @@ compositetraintuple = [
                 "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
                 "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
             ],
-            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
             "metadata": {}
         },
-        "computePlanID": "",
-        "inHeadModel": {
-            "traintupleKey": "aa9be143edc6ef051ea255fd77bb54ba40c71bb39afa3ece502dd36782d02a71",
+        "compute_plan_id": "",
+        "in_head_model": {
+            "traintuple_key": "aa9be143edc6ef051ea255fd77bb54ba40c71bb39afa3ece502dd36782d02a71",
             "hash": "64c72dc39772e122ef552d10ff101ef6cee94935a84678a0125f7c3fd044dff8",
-            "storageAddress": ""
+            "storage_address": ""
         },
-        "inTrunkModel": {
-            "traintupleKey": "aa9be143edc6ef051ea255fd77bb54ba40c71bb39afa3ece502dd36782d02a71",
+        "in_trunk_model": {
+            "traintuple_key": "aa9be143edc6ef051ea255fd77bb54ba40c71bb39afa3ece502dd36782d02a71",
             "hash": "00009a1256f8ce55ed907221000035daf1ac28111b5a3a03289da2f0601edf8f",
-            "storageAddress": "http://testserver/model/00009a1256f8ce55ed907221000035daf1ac28111b5a3a03289da2f0601edf8f/file/"
+            "storage_address": "http://testserver/model/00009a1256f8ce55ed907221000035daf1ac28111b5a3a03289da2f0601edf8f/file/"
         },
         "log": "",
         "metadata": {},
-        "outHeadModel": {
-            "outModel": {
+        "out_head_model": {
+            "out_model": {
                 "hash": "349b475ebd9458739af8685b8b75d7aeb1290209eabadad1b9b8afaa2b05c8d5"
             },
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg1MSP"
                     ]
                 }
             }
         },
-        "outTrunkModel": {
-            "outModel": {
+        "out_trunk_model": {
+            "out_model": {
                 "hash": "692e3f70b9ebfca3c2e51e2a92c18092cc24dda547debefd6eb4bdd38ca6d803",
-                "storageAddress": "http://testserver/model/692e3f70b9ebfca3c2e51e2a92c18092cc24dda547debefd6eb4bdd38ca6d803/file/"
+                "storage_address": "http://testserver/model/692e3f70b9ebfca3c2e51e2a92c18092cc24dda547debefd6eb4bdd38ca6d803/file/"
             },
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg1MSP"
                     ]
                 }
@@ -818,7 +818,7 @@ compositetraintuple = [
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_composite_traintuples_execution - Algo 0",
             "hash": "09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf",
-            "storageAddress": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
+            "storage_address": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
         },
         "creator": "MyOrg1MSP",
         "dataset": {
@@ -829,36 +829,36 @@ compositetraintuple = [
                 "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
                 "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
             ],
-            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
             "metadata": {}
         },
-        "computePlanID": "",
-        "inHeadModel": None,
-        "inTrunkModel": None,
+        "compute_plan_id": "",
+        "in_head_model": None,
+        "in_trunk_model": None,
         "log": "",
         "metadata": {},
-        "outHeadModel": {
-            "outModel": {
+        "out_head_model": {
+            "out_model": {
                 "hash": "64c72dc39772e122ef552d10ff101ef6cee94935a84678a0125f7c3fd044dff8"
             },
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg1MSP"
                     ]
                 }
             }
         },
-        "outTrunkModel": {
-            "outModel": {
+        "out_trunk_model": {
+            "out_model": {
                 "hash": "00009a1256f8ce55ed907221000035daf1ac28111b5a3a03289da2f0601edf8f",
-                "storageAddress": "http://testserver/model/00009a1256f8ce55ed907221000035daf1ac28111b5a3a03289da2f0601edf8f/file/"
+                "storage_address": "http://testserver/model/00009a1256f8ce55ed907221000035daf1ac28111b5a3a03289da2f0601edf8f/file/"
             },
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg1MSP"
                     ]
                 }
@@ -873,7 +873,7 @@ compositetraintuple = [
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_composite_traintuple_execution_failure - Algo 0",
             "hash": "0fbb505a32ae8785c08d37fe7bf7476d7365c3a0cef7c6e05c61c06db3267593",
-            "storageAddress": "http://testserver/composite_algo/0fbb505a32ae8785c08d37fe7bf7476d7365c3a0cef7c6e05c61c06db3267593/file/"
+            "storage_address": "http://testserver/composite_algo/0fbb505a32ae8785c08d37fe7bf7476d7365c3a0cef7c6e05c61c06db3267593/file/"
         },
         "creator": "MyOrg1MSP",
         "dataset": {
@@ -884,31 +884,31 @@ compositetraintuple = [
                 "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
                 "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
             ],
-            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
             "metadata": {}
         },
-        "computePlanID": "",
-        "inHeadModel": None,
-        "inTrunkModel": None,
+        "compute_plan_id": "",
+        "in_head_model": None,
+        "in_trunk_model": None,
         "log": "[00-01-0117-d390d32]",
         "metadata": {},
-        "outHeadModel": {
-            "outModel": None,
+        "out_head_model": {
+            "out_model": None,
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg1MSP"
                     ]
                 }
             }
         },
-        "outTrunkModel": {
-            "outModel": None,
+        "out_trunk_model": {
+            "out_model": None,
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg1MSP"
                     ]
                 }
@@ -923,7 +923,7 @@ compositetraintuple = [
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple_execution_failure - Algo 0",
             "hash": "5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c",
-            "storageAddress": "http://testserver/composite_algo/5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c/file/"
+            "storage_address": "http://testserver/composite_algo/5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c/file/"
         },
         "creator": "MyOrg1MSP",
         "dataset": {
@@ -931,36 +931,36 @@ compositetraintuple = [
             "keys": [
                 "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f"
             ],
-            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
             "metadata": {}
         },
-        "computePlanID": "",
-        "inHeadModel": None,
-        "inTrunkModel": None,
+        "compute_plan_id": "",
+        "in_head_model": None,
+        "in_trunk_model": None,
         "log": "",
         "metadata": {},
-        "outHeadModel": {
-            "outModel": {
+        "out_head_model": {
+            "out_model": {
                 "hash": "8b87222907027a470d6d99409b0de9a9ced07142d026ab875d6ddfdecf9db96d"
             },
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg1MSP"
                     ]
                 }
             }
         },
-        "outTrunkModel": {
-            "outModel": {
+        "out_trunk_model": {
+            "out_model": {
                 "hash": "fcfcaa4f3be73940006fc54566b2946fabd5ee677496a5dd43e4b8c0c3c3d54d",
-                "storageAddress": "http://testserver/model/fcfcaa4f3be73940006fc54566b2946fabd5ee677496a5dd43e4b8c0c3c3d54d/file/"
+                "storage_address": "http://testserver/model/fcfcaa4f3be73940006fc54566b2946fabd5ee677496a5dd43e4b8c0c3c3d54d/file/"
             },
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg1MSP"
                     ]
                 }
@@ -975,7 +975,7 @@ compositetraintuple = [
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple_execution_failure - Algo 0",
             "hash": "5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c",
-            "storageAddress": "http://testserver/composite_algo/5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c/file/"
+            "storage_address": "http://testserver/composite_algo/5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c/file/"
         },
         "creator": "MyOrg1MSP",
         "dataset": {
@@ -983,36 +983,36 @@ compositetraintuple = [
             "keys": [
                 "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135"
             ],
-            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
             "metadata": {}
         },
-        "computePlanID": "",
-        "inHeadModel": None,
-        "inTrunkModel": None,
+        "compute_plan_id": "",
+        "in_head_model": None,
+        "in_trunk_model": None,
         "log": "",
         "metadata": {},
-        "outHeadModel": {
-            "outModel": {
+        "out_head_model": {
+            "out_model": {
                 "hash": "bffb89749a253de1d451a836748dc813035dbcacb01fb85911b97c577c10ea6d"
             },
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg1MSP"
                     ]
                 }
             }
         },
-        "outTrunkModel": {
-            "outModel": {
+        "out_trunk_model": {
+            "out_model": {
                 "hash": "682d31d9e95654ed0aaf81184136d87c7ff2a0046c3d24181508f112d58b330d",
-                "storageAddress": "http://testserver/model/682d31d9e95654ed0aaf81184136d87c7ff2a0046c3d24181508f112d58b330d/file/"
+                "storage_address": "http://testserver/model/682d31d9e95654ed0aaf81184136d87c7ff2a0046c3d24181508f112d58b330d/file/"
             },
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg1MSP"
                     ]
                 }
@@ -1027,7 +1027,7 @@ compositetraintuple = [
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
             "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
-            "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+            "storage_address": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
         },
         "creator": "MyOrg1MSP",
         "dataset": {
@@ -1035,36 +1035,36 @@ compositetraintuple = [
             "keys": [
                 "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f"
             ],
-            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
             "metadata": {}
         },
-        "computePlanID": "",
-        "inHeadModel": None,
-        "inTrunkModel": None,
+        "compute_plan_id": "",
+        "in_head_model": None,
+        "in_trunk_model": None,
         "log": "",
         "metadata": {},
-        "outHeadModel": {
-            "outModel": {
+        "out_head_model": {
+            "out_model": {
                 "hash": "7d7ed2eac5e822ea90058387dd35d1270639ecc4982a6d72b619b8659813163a"
             },
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg1MSP"
                     ]
                 }
             }
         },
-        "outTrunkModel": {
-            "outModel": {
+        "out_trunk_model": {
+            "out_model": {
                 "hash": "b312a262592aa7ed56a07d0eb02bec0548745eb7316d4ea86b3719b2497d8cb2",
-                "storageAddress": "http://testserver/model/b312a262592aa7ed56a07d0eb02bec0548745eb7316d4ea86b3719b2497d8cb2/file/"
+                "storage_address": "http://testserver/model/b312a262592aa7ed56a07d0eb02bec0548745eb7316d4ea86b3719b2497d8cb2/file/"
             },
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg1MSP",
                         "MyOrg2MSP"
                     ]
@@ -1080,7 +1080,7 @@ compositetraintuple = [
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
             "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
-            "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+            "storage_address": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
         },
         "creator": "MyOrg1MSP",
         "dataset": {
@@ -1088,44 +1088,44 @@ compositetraintuple = [
             "keys": [
                 "704740917e35b36648b80d9826e1f24d2082bf113f1693ba08975c7c405cb01f"
             ],
-            "openerHash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+            "opener_hash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
             "metadata": {}
         },
-        "computePlanID": "",
-        "inHeadModel": {
-            "traintupleKey": "e7b96818eadcdce6940c16b388bbd264549646a45bb8ea75e8f218d224c18162",
+        "compute_plan_id": "",
+        "in_head_model": {
+            "traintuple_key": "e7b96818eadcdce6940c16b388bbd264549646a45bb8ea75e8f218d224c18162",
             "hash": "3af8f86ed9fe07237497e52d1ced195d7e4752f7d130327929f96ea688d60a41",
-            "storageAddress": ""
+            "storage_address": ""
         },
-        "inTrunkModel": {
-            "traintupleKey": "9cb5582fc3e822b9ddabbf7479097df05381294e3559f31a35c20f2e46e4885c",
+        "in_trunk_model": {
+            "traintuple_key": "9cb5582fc3e822b9ddabbf7479097df05381294e3559f31a35c20f2e46e4885c",
             "hash": "4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688",
-            "storageAddress": "http://testserver/model/4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688/file/"
+            "storage_address": "http://testserver/model/4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688/file/"
         },
         "log": "",
         "metadata": {},
-        "outHeadModel": {
-            "outModel": {
+        "out_head_model": {
+            "out_model": {
                 "hash": "8b6a7f3b7feef0a2c157bf2acfd2596fd7815a0a69b0a41b7451bab47d022eaa"
             },
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg2MSP"
                     ]
                 }
             }
         },
-        "outTrunkModel": {
-            "outModel": {
+        "out_trunk_model": {
+            "out_model": {
                 "hash": "66392ca3e6a5935fb8e22a5ee5b8af31dbec5655ff087b98f071abf7e4f3ce74",
-                "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/model/66392ca3e6a5935fb8e22a5ee5b8af31dbec5655ff087b98f071abf7e4f3ce74/file/"
+                "storage_address": "http://backend-org-2-substra-backend-server.org-2:8000/model/66392ca3e6a5935fb8e22a5ee5b8af31dbec5655ff087b98f071abf7e4f3ce74/file/"
             },
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg1MSP",
                         "MyOrg2MSP"
                     ]
@@ -1141,7 +1141,7 @@ compositetraintuple = [
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
             "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
-            "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+            "storage_address": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
         },
         "creator": "MyOrg1MSP",
         "dataset": {
@@ -1149,44 +1149,44 @@ compositetraintuple = [
             "keys": [
                 "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135"
             ],
-            "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+            "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
             "metadata": {}
         },
-        "computePlanID": "",
-        "inHeadModel": {
-            "traintupleKey": "3197bd6c56bc47089864c76b47b6115eb3551901ba304722ce581561c37b0c7b",
+        "compute_plan_id": "",
+        "in_head_model": {
+            "traintuple_key": "3197bd6c56bc47089864c76b47b6115eb3551901ba304722ce581561c37b0c7b",
             "hash": "7d7ed2eac5e822ea90058387dd35d1270639ecc4982a6d72b619b8659813163a",
-            "storageAddress": ""
+            "storage_address": ""
         },
-        "inTrunkModel": {
-            "traintupleKey": "9cb5582fc3e822b9ddabbf7479097df05381294e3559f31a35c20f2e46e4885c",
+        "in_trunk_model": {
+            "traintuple_key": "9cb5582fc3e822b9ddabbf7479097df05381294e3559f31a35c20f2e46e4885c",
             "hash": "4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688",
-            "storageAddress": "http://testserver/model/4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688/file/"
+            "storage_address": "http://testserver/model/4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688/file/"
         },
         "log": "",
         "metadata": {},
-        "outHeadModel": {
-            "outModel": {
+        "out_head_model": {
+            "out_model": {
                 "hash": "28a705e08e765569bd89262f821e1c7285e43fa1e82df2f833464b8ff890c7bd"
             },
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg1MSP"
                     ]
                 }
             }
         },
-        "outTrunkModel": {
-            "outModel": {
+        "out_trunk_model": {
+            "out_model": {
                 "hash": "14b7e3254896db4f43c582695c39d096f33e1390e3ecaa8b0e6e7619bf827044",
-                "storageAddress": "http://testserver/model/14b7e3254896db4f43c582695c39d096f33e1390e3ecaa8b0e6e7619bf827044/file/"
+                "storage_address": "http://testserver/model/14b7e3254896db4f43c582695c39d096f33e1390e3ecaa8b0e6e7619bf827044/file/"
             },
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg1MSP",
                         "MyOrg2MSP"
                     ]
@@ -1202,7 +1202,7 @@ compositetraintuple = [
         "algo": {
             "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
             "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
-            "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+            "storage_address": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
         },
         "creator": "MyOrg1MSP",
         "dataset": {
@@ -1210,36 +1210,36 @@ compositetraintuple = [
             "keys": [
                 "26e52856b27261fc12e9615d5914027dc5986cd8bb37ccf1da4c7aa47b74a8ea"
             ],
-            "openerHash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+            "opener_hash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
             "metadata": {}
         },
-        "computePlanID": "",
-        "inHeadModel": None,
-        "inTrunkModel": None,
+        "compute_plan_id": "",
+        "in_head_model": None,
+        "in_trunk_model": None,
         "log": "",
         "metadata": {},
-        "outHeadModel": {
-            "outModel": {
+        "out_head_model": {
+            "out_model": {
                 "hash": "3af8f86ed9fe07237497e52d1ced195d7e4752f7d130327929f96ea688d60a41"
             },
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg2MSP"
                     ]
                 }
             }
         },
-        "outTrunkModel": {
-            "outModel": {
+        "out_trunk_model": {
+            "out_model": {
                 "hash": "cd8a895a9b604ccbb2e2bf9f081d0560bfd86f4a98beabd833d4c7c36f35cd9d",
-                "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/model/cd8a895a9b604ccbb2e2bf9f081d0560bfd86f4a98beabd833d4c7c36f35cd9d/file/"
+                "storage_address": "http://backend-org-2-substra-backend-server.org-2:8000/model/cd8a895a9b604ccbb2e2bf9f081d0560bfd86f4a98beabd833d4c7c36f35cd9d/file/"
             },
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg1MSP",
                         "MyOrg2MSP"
                     ]
@@ -1258,17 +1258,17 @@ compositealgo = [
         "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_composite_traintuples_execution - Algo 0",
         "content": {
             "hash": "09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf",
-            "storageAddress": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
+            "storage_address": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
         },
         "description": {
             "hash": "aa444b9dc8cac0c80263b3970ddc403757abc6bcb546eb322a1711f1b8ec294d",
-            "storageAddress": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/description/"
+            "storage_address": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/description/"
         },
         "owner": "MyOrg1MSP",
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "metadata": {}
@@ -1278,17 +1278,17 @@ compositealgo = [
         "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_composite_traintuple_execution_failure - Algo 0",
         "content": {
             "hash": "0fbb505a32ae8785c08d37fe7bf7476d7365c3a0cef7c6e05c61c06db3267593",
-            "storageAddress": "http://testserver/composite_algo/0fbb505a32ae8785c08d37fe7bf7476d7365c3a0cef7c6e05c61c06db3267593/file/"
+            "storage_address": "http://testserver/composite_algo/0fbb505a32ae8785c08d37fe7bf7476d7365c3a0cef7c6e05c61c06db3267593/file/"
         },
         "description": {
             "hash": "6d184a2e6d8097cc55e4b435bbd5b9c6d7211274472585448411cd435149e941",
-            "storageAddress": "http://testserver/composite_algo/0fbb505a32ae8785c08d37fe7bf7476d7365c3a0cef7c6e05c61c06db3267593/description/"
+            "storage_address": "http://testserver/composite_algo/0fbb505a32ae8785c08d37fe7bf7476d7365c3a0cef7c6e05c61c06db3267593/description/"
         },
         "owner": "MyOrg1MSP",
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "metadata": {}
@@ -1298,17 +1298,17 @@ compositealgo = [
         "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple_execution_failure - Algo 0",
         "content": {
             "hash": "5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c",
-            "storageAddress": "http://testserver/composite_algo/5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c/file/"
+            "storage_address": "http://testserver/composite_algo/5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c/file/"
         },
         "description": {
             "hash": "61cc1c0f3962bc4d60151041e02b55ca9788ea7a8a848dfc67f3fc3194b5a202",
-            "storageAddress": "http://testserver/composite_algo/5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c/description/"
+            "storage_address": "http://testserver/composite_algo/5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c/description/"
         },
         "owner": "MyOrg1MSP",
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "metadata": {}
@@ -1318,17 +1318,17 @@ compositealgo = [
         "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
         "content": {
             "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
-            "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+            "storage_address": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
         },
         "description": {
             "hash": "066d354d20dfa689cd5ca22f99445dc47589971c6d958bd6841beeae585f1054",
-            "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/description/"
+            "storage_address": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/description/"
         },
         "owner": "MyOrg1MSP",
         "permissions": {
             "process": {
                 "public": True,
-                "authorizedIDs": []
+                "authorized_ids": []
             }
         },
         "metadata": {}
@@ -1342,7 +1342,7 @@ model = [
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple - Algo 0",
                 "hash": "4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be",
-                "storageAddress": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
+                "storage_address": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
             },
             "creator": "MyOrg1MSP",
             "dataset": {
@@ -1350,21 +1350,21 @@ model = [
                 "keys": [
                     "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f"
                 ],
-                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
                 "metadata": {}
             },
-            "computePlanID": "",
-            "inModels": None,
+            "compute_plan_id": "",
+            "in_models": None,
             "log": "",
             "metadata": {},
-            "outModel": {
+            "out_model": {
                 "hash": "940262c35a6b33c2b7c8811fa785899b00e287ffa05e3cb5a23c857e9c89c760",
-                "storageAddress": "http://testserver/model/940262c35a6b33c2b7c8811fa785899b00e287ffa05e3cb5a23c857e9c89c760/file/"
+                "storage_address": "http://testserver/model/940262c35a6b33c2b7c8811fa785899b00e287ffa05e3cb5a23c857e9c89c760/file/"
             },
             "permissions": {
                 "process": {
                     "public": True,
-                    "authorizedIDs": []
+                    "authorized_ids": []
                 }
             },
             "rank": 0,
@@ -1374,7 +1374,7 @@ model = [
         "testtuple": {
             "algo": None,
             "certified": False,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "",
             "dataset": None,
             "key": "",
@@ -1384,10 +1384,10 @@ model = [
             "rank": 0,
             "status": "",
             "tag": "",
-            "traintupleKey": "",
-            "traintupleType": ""
+            "traintuple_key": "",
+            "traintuple_type": ""
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
         "traintuple": {
@@ -1395,7 +1395,7 @@ model = [
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple - Algo 0",
                 "hash": "4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be",
-                "storageAddress": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
+                "storage_address": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
             },
             "creator": "MyOrg1MSP",
             "dataset": {
@@ -1403,21 +1403,21 @@ model = [
                 "keys": [
                     "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3"
                 ],
-                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
                 "metadata": {}
             },
-            "computePlanID": "",
-            "inModels": None,
+            "compute_plan_id": "",
+            "in_models": None,
             "log": "",
             "metadata": {},
-            "outModel": {
+            "out_model": {
                 "hash": "f33d3c7a21e97f5f0edd636f3b313c6a7757cc458614e49da74d58af7fc0c4c2",
-                "storageAddress": "http://testserver/model/f33d3c7a21e97f5f0edd636f3b313c6a7757cc458614e49da74d58af7fc0c4c2/file/"
+                "storage_address": "http://testserver/model/f33d3c7a21e97f5f0edd636f3b313c6a7757cc458614e49da74d58af7fc0c4c2/file/"
             },
             "permissions": {
                 "process": {
                     "public": True,
-                    "authorizedIDs": []
+                    "authorized_ids": []
                 }
             },
             "rank": 0,
@@ -1427,7 +1427,7 @@ model = [
         "testtuple": {
             "algo": None,
             "certified": False,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "",
             "dataset": None,
             "key": "",
@@ -1437,10 +1437,10 @@ model = [
             "rank": 0,
             "status": "",
             "tag": "",
-            "traintupleKey": "",
-            "traintupleType": ""
+            "traintuple_key": "",
+            "traintuple_type": ""
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
         "traintuple": {
@@ -1448,7 +1448,7 @@ model = [
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple - Algo 0",
                 "hash": "4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be",
-                "storageAddress": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
+                "storage_address": "http://testserver/algo/4942edc447b414391d0047fb6379c2dfbcd96a68bbe3071c756dc4c2b2c951be/file/"
             },
             "creator": "MyOrg1MSP",
             "dataset": {
@@ -1456,21 +1456,21 @@ model = [
                 "keys": [
                     "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135"
                 ],
-                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
                 "metadata": {}
             },
-            "computePlanID": "",
-            "inModels": None,
+            "compute_plan_id": "",
+            "in_models": None,
             "log": "",
             "metadata": {},
-            "outModel": {
+            "out_model": {
                 "hash": "02ccc4eeb426f7bbfe746a06a4c63a2023a8f2ea2c72f92242cc5f7f1164383c",
-                "storageAddress": "http://testserver/model/02ccc4eeb426f7bbfe746a06a4c63a2023a8f2ea2c72f92242cc5f7f1164383c/file/"
+                "storage_address": "http://testserver/model/02ccc4eeb426f7bbfe746a06a4c63a2023a8f2ea2c72f92242cc5f7f1164383c/file/"
             },
             "permissions": {
                 "process": {
                     "public": True,
-                    "authorizedIDs": []
+                    "authorized_ids": []
                 }
             },
             "rank": 0,
@@ -1480,7 +1480,7 @@ model = [
         "testtuple": {
             "algo": None,
             "certified": False,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "",
             "dataset": None,
             "key": "",
@@ -1490,10 +1490,10 @@ model = [
             "rank": 0,
             "status": "",
             "tag": "",
-            "traintupleKey": "",
-            "traintupleType": ""
+            "traintuple_key": "",
+            "traintuple_type": ""
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
         "traintuple": {
@@ -1501,7 +1501,7 @@ model = [
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_federated_learning_workflow - Algo 0",
                 "hash": "59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30",
-                "storageAddress": "http://testserver/algo/59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30/file/"
+                "storage_address": "http://testserver/algo/59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30/file/"
             },
             "creator": "MyOrg1MSP",
             "dataset": {
@@ -1512,27 +1512,27 @@ model = [
                     "88608067e903a7b5cbfed480e7c4ee9eaf7eb37994cb2fec045497f324508a33",
                     "e453da42246d9be33204fa30fb91755b989bbdeee2559dd93e14f57b57d1847f"
                 ],
-                "openerHash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+                "opener_hash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
                 "metadata": {}
             },
-            "computePlanID": "4a7f743fd9a5ccaa6f8366a10f92955486ab15116a1e43f6c1ba1b9504f6b157",
-            "inModels": [
+            "compute_plan_id": "4a7f743fd9a5ccaa6f8366a10f92955486ab15116a1e43f6c1ba1b9504f6b157",
+            "in_models": [
                 {
-                    "traintupleKey": "49dedc3b4e763a2d09e39f4e5eee3d4910beee8b4e3ba666f9c6ef00f1632ec3",
+                    "traintuple_key": "49dedc3b4e763a2d09e39f4e5eee3d4910beee8b4e3ba666f9c6ef00f1632ec3",
                     "hash": "714ee81465576b09f1e4c6e0f28e82189501c46ed36569c9867eff851a285888",
-                    "storageAddress": "http://testserver/model/714ee81465576b09f1e4c6e0f28e82189501c46ed36569c9867eff851a285888/file/"
+                    "storage_address": "http://testserver/model/714ee81465576b09f1e4c6e0f28e82189501c46ed36569c9867eff851a285888/file/"
                 }
             ],
             "log": "",
             "metadata": {},
-            "outModel": {
+            "out_model": {
                 "hash": "4672cd5a9e134a6f6c54144c3a8e8330b2147fa10264ca8e9fbac9b9075cacd0",
-                "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/model/4672cd5a9e134a6f6c54144c3a8e8330b2147fa10264ca8e9fbac9b9075cacd0/file/"
+                "storage_address": "http://backend-org-2-substra-backend-server.org-2:8000/model/4672cd5a9e134a6f6c54144c3a8e8330b2147fa10264ca8e9fbac9b9075cacd0/file/"
             },
             "permissions": {
                 "process": {
                     "public": True,
-                    "authorizedIDs": []
+                    "authorized_ids": []
                 }
             },
             "rank": 1,
@@ -1542,7 +1542,7 @@ model = [
         "testtuple": {
             "algo": None,
             "certified": False,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "",
             "dataset": None,
             "key": "",
@@ -1552,10 +1552,10 @@ model = [
             "rank": 0,
             "status": "",
             "tag": "",
-            "traintupleKey": "",
-            "traintupleType": ""
+            "traintuple_key": "",
+            "traintuple_type": ""
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
         "traintuple": {
@@ -1563,7 +1563,7 @@ model = [
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_federated_learning_workflow - Algo 0",
                 "hash": "59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30",
-                "storageAddress": "http://testserver/algo/59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30/file/"
+                "storage_address": "http://testserver/algo/59eb383497c337e280f2d7c6805cb80bb623dfe581b6289eeee4fc62aefd9c30/file/"
             },
             "creator": "MyOrg1MSP",
             "dataset": {
@@ -1574,21 +1574,21 @@ model = [
                     "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
                     "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
                 ],
-                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
                 "metadata": {}
             },
-            "computePlanID": "4a7f743fd9a5ccaa6f8366a10f92955486ab15116a1e43f6c1ba1b9504f6b157",
-            "inModels": None,
+            "compute_plan_id": "4a7f743fd9a5ccaa6f8366a10f92955486ab15116a1e43f6c1ba1b9504f6b157",
+            "in_models": None,
             "log": "",
             "metadata": {},
-            "outModel": {
+            "out_model": {
                 "hash": "714ee81465576b09f1e4c6e0f28e82189501c46ed36569c9867eff851a285888",
-                "storageAddress": "http://testserver/model/714ee81465576b09f1e4c6e0f28e82189501c46ed36569c9867eff851a285888/file/"
+                "storage_address": "http://testserver/model/714ee81465576b09f1e4c6e0f28e82189501c46ed36569c9867eff851a285888/file/"
             },
             "permissions": {
                 "process": {
                     "public": True,
-                    "authorizedIDs": []
+                    "authorized_ids": []
                 }
             },
             "rank": 0,
@@ -1598,7 +1598,7 @@ model = [
         "testtuple": {
             "algo": None,
             "certified": False,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "",
             "dataset": None,
             "key": "",
@@ -1608,10 +1608,10 @@ model = [
             "rank": 0,
             "status": "",
             "tag": "",
-            "traintupleKey": "",
-            "traintupleType": ""
+            "traintuple_key": "",
+            "traintuple_type": ""
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
         "traintuple": {
@@ -1619,7 +1619,7 @@ model = [
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_different_nodes - Algo 0",
                 "hash": "c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593",
-                "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/algo/c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593/file/"
+                "storage_address": "http://backend-org-2-substra-backend-server.org-2:8000/algo/c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593/file/"
             },
             "creator": "MyOrg1MSP",
             "dataset": {
@@ -1630,21 +1630,21 @@ model = [
                     "88608067e903a7b5cbfed480e7c4ee9eaf7eb37994cb2fec045497f324508a33",
                     "e453da42246d9be33204fa30fb91755b989bbdeee2559dd93e14f57b57d1847f"
                 ],
-                "openerHash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+                "opener_hash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
                 "metadata": {}
             },
-            "computePlanID": "",
-            "inModels": None,
+            "compute_plan_id": "",
+            "in_models": None,
             "log": "",
             "metadata": {},
-            "outModel": {
+            "out_model": {
                 "hash": "d771446f0be15ebaa66db902f5a98a5005611de4ea44d3a5fe77c50ee34ff114",
-                "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/model/d771446f0be15ebaa66db902f5a98a5005611de4ea44d3a5fe77c50ee34ff114/file/"
+                "storage_address": "http://backend-org-2-substra-backend-server.org-2:8000/model/d771446f0be15ebaa66db902f5a98a5005611de4ea44d3a5fe77c50ee34ff114/file/"
             },
             "permissions": {
                 "process": {
                     "public": True,
-                    "authorizedIDs": []
+                    "authorized_ids": []
                 }
             },
             "rank": 0,
@@ -1655,17 +1655,17 @@ model = [
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_different_nodes - Algo 0",
                 "hash": "c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593",
-                "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/algo/c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593/file/"
+                "storage_address": "http://backend-org-2-substra-backend-server.org-2:8000/algo/c8efb021f79c5adc96e9ba8407c368a5a3e76f2b37164176059855cc9daae593/file/"
             },
             "certified": True,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "MyOrg1MSP",
             "dataset": {
                 "worker": "MyOrg1MSP",
                 "keys": [
                     "ffed4147fffff2f18130b7332c1460ecccd8e1378765c415b82b948c19e98a68"
                 ],
-                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
                 "perf": 2
             },
             "key": "0599697085f343a8298ee3a87bd0000285e944fa4a05f541aa985d3eab50c04d",
@@ -1675,16 +1675,16 @@ model = [
                 "hash": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
                 "metrics": {
                     "hash": "0d64f855e07524da60203067713ab08fd6e479a02ebcb70364b2c6a2a29367e1",
-                    "storageAddress": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
+                    "storage_address": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
                 }
             },
             "rank": 0,
             "status": "done",
             "tag": "",
-            "traintupleKey": "e623fe67c0dc4ed78d4e34f9f0fad0ac3a5fa7aafb819a3e1961f978d7540b2a",
-            "traintupleType": "traintuple"
+            "traintuple_key": "e623fe67c0dc4ed78d4e34f9f0fad0ac3a5fa7aafb819a3e1961f978d7540b2a",
+            "traintuple_type": "traintuple"
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
         "traintuple": {
@@ -1692,7 +1692,7 @@ model = [
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_same_node - Algo 0",
                 "hash": "e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8",
-                "storageAddress": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
+                "storage_address": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
             },
             "creator": "MyOrg1MSP",
             "dataset": {
@@ -1703,23 +1703,23 @@ model = [
                     "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
                     "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
                 ],
-                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
                 "metadata": {}
             },
-            "computePlanID": "",
-            "inModels": None,
+            "compute_plan_id": "",
+            "in_models": None,
             "log": "",
             "metadata": {
                 "foo": "bar"
             },
-            "outModel": {
+            "out_model": {
                 "hash": "420ce592a42e0c78e644447173b54046163a2afeadd37227cef6866fc7d4c4f7",
-                "storageAddress": "http://testserver/model/420ce592a42e0c78e644447173b54046163a2afeadd37227cef6866fc7d4c4f7/file/"
+                "storage_address": "http://testserver/model/420ce592a42e0c78e644447173b54046163a2afeadd37227cef6866fc7d4c4f7/file/"
             },
             "permissions": {
                 "process": {
                     "public": True,
-                    "authorizedIDs": []
+                    "authorized_ids": []
                 }
             },
             "rank": 0,
@@ -1730,17 +1730,17 @@ model = [
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_same_node - Algo 0",
                 "hash": "e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8",
-                "storageAddress": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
+                "storage_address": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
             },
             "certified": True,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "MyOrg1MSP",
             "dataset": {
                 "worker": "MyOrg1MSP",
                 "keys": [
                     "ffed4147fffff2f18130b7332c1460ecccd8e1378765c415b82b948c19e98a68"
                 ],
-                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
                 "perf": 2
             },
             "key": "e2f386a88a1702cecf0270742a31cdf0be4a9d9b083467679058d00aaff55ac4",
@@ -1750,16 +1750,16 @@ model = [
                 "hash": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
                 "metrics": {
                     "hash": "0d64f855e07524da60203067713ab08fd6e479a02ebcb70364b2c6a2a29367e1",
-                    "storageAddress": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
+                    "storage_address": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
                 }
             },
             "rank": 0,
             "status": "done",
             "tag": "",
-            "traintupleKey": "e3aab7fe0c51e970edecdfa1f780fd529e437d92603e66e57f230d926c7808b6",
-            "traintupleType": "traintuple"
+            "traintuple_key": "e3aab7fe0c51e970edecdfa1f780fd529e437d92603e66e57f230d926c7808b6",
+            "traintuple_type": "traintuple"
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
         "traintuple": {
@@ -1767,7 +1767,7 @@ model = [
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_tuples_execution_on_same_node - Algo 0",
                 "hash": "e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8",
-                "storageAddress": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
+                "storage_address": "http://testserver/algo/e9481a81278d988f3d7cc8ba095b88f33d7cc0da3f0c0a30ca942ba34f235ff8/file/"
             },
             "creator": "MyOrg1MSP",
             "dataset": {
@@ -1778,27 +1778,27 @@ model = [
                     "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
                     "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
                 ],
-                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
                 "metadata": {}
             },
-            "computePlanID": "",
-            "inModels": [
+            "compute_plan_id": "",
+            "in_models": [
                 {
-                    "traintupleKey": "e3aab7fe0c51e970edecdfa1f780fd529e437d92603e66e57f230d926c7808b6",
+                    "traintuple_key": "e3aab7fe0c51e970edecdfa1f780fd529e437d92603e66e57f230d926c7808b6",
                     "hash": "420ce592a42e0c78e644447173b54046163a2afeadd37227cef6866fc7d4c4f7",
-                    "storageAddress": "http://testserver/model/420ce592a42e0c78e644447173b54046163a2afeadd37227cef6866fc7d4c4f7/file/"
+                    "storage_address": "http://testserver/model/420ce592a42e0c78e644447173b54046163a2afeadd37227cef6866fc7d4c4f7/file/"
                 }
             ],
             "log": "",
             "metadata": {},
-            "outModel": {
+            "out_model": {
                 "hash": "7b3183a99222df2b18de11c8f767fdca2c7ebb0d4fa8bfe03c4f169cfea2aba2",
-                "storageAddress": "http://testserver/model/7b3183a99222df2b18de11c8f767fdca2c7ebb0d4fa8bfe03c4f169cfea2aba2/file/"
+                "storage_address": "http://testserver/model/7b3183a99222df2b18de11c8f767fdca2c7ebb0d4fa8bfe03c4f169cfea2aba2/file/"
             },
             "permissions": {
                 "process": {
                     "public": True,
-                    "authorizedIDs": []
+                    "authorized_ids": []
                 }
             },
             "rank": 0,
@@ -1808,7 +1808,7 @@ model = [
         "testtuple": {
             "algo": None,
             "certified": False,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "",
             "dataset": None,
             "key": "",
@@ -1818,10 +1818,10 @@ model = [
             "rank": 0,
             "status": "",
             "tag": "",
-            "traintupleKey": "",
-            "traintupleType": ""
+            "traintuple_key": "",
+            "traintuple_type": ""
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
         "traintuple": {
@@ -1829,7 +1829,7 @@ model = [
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_traintuple_execution_failure - Algo 0",
                 "hash": "ebbd8c65dfe07d826d692f806deceffd296e715fa4db9e652304180dd7ee293d",
-                "storageAddress": "http://testserver/algo/ebbd8c65dfe07d826d692f806deceffd296e715fa4db9e652304180dd7ee293d/file/"
+                "storage_address": "http://testserver/algo/ebbd8c65dfe07d826d692f806deceffd296e715fa4db9e652304180dd7ee293d/file/"
             },
             "creator": "MyOrg1MSP",
             "dataset": {
@@ -1840,18 +1840,18 @@ model = [
                     "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
                     "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
                 ],
-                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
                 "metadata": {}
             },
-            "computePlanID": "",
-            "inModels": None,
+            "compute_plan_id": "",
+            "in_models": None,
             "log": "[00-01-0117-d64af6f]",
             "metadata": {},
-            "outModel": None,
+            "out_model": None,
             "permissions": {
                 "process": {
                     "public": True,
-                    "authorizedIDs": []
+                    "authorized_ids": []
                 }
             },
             "rank": 0,
@@ -1861,7 +1861,7 @@ model = [
         "testtuple": {
             "algo": None,
             "certified": False,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "",
             "dataset": None,
             "key": "",
@@ -1871,18 +1871,18 @@ model = [
             "rank": 0,
             "status": "",
             "tag": "",
-            "traintupleKey": "",
-            "traintupleType": ""
+            "traintuple_key": "",
+            "traintuple_type": ""
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
-        "compositeTraintuple": {
+        "composite_traintuple": {
             "key": "2978ca1f7d5520ef42a82c86a2e24d5b00f04c73013febdb5ed35d32dc606e92",
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_composite_traintuples_execution - Algo 0",
                 "hash": "09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf",
-                "storageAddress": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
+                "storage_address": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
             },
             "creator": "MyOrg1MSP",
             "dataset": {
@@ -1893,44 +1893,44 @@ model = [
                     "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
                     "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
                 ],
-                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
                 "metadata": {}
             },
-            "computePlanID": "",
-            "inHeadModel": {
-                "traintupleKey": "aa9be143edc6ef051ea255fd77bb54ba40c71bb39afa3ece502dd36782d02a71",
+            "compute_plan_id": "",
+            "in_head_model": {
+                "traintuple_key": "aa9be143edc6ef051ea255fd77bb54ba40c71bb39afa3ece502dd36782d02a71",
                 "hash": "64c72dc39772e122ef552d10ff101ef6cee94935a84678a0125f7c3fd044dff8",
-                "storageAddress": ""
+                "storage_address": ""
             },
-            "inTrunkModel": {
-                "traintupleKey": "aa9be143edc6ef051ea255fd77bb54ba40c71bb39afa3ece502dd36782d02a71",
+            "in_trunk_model": {
+                "traintuple_key": "aa9be143edc6ef051ea255fd77bb54ba40c71bb39afa3ece502dd36782d02a71",
                 "hash": "00009a1256f8ce55ed907221000035daf1ac28111b5a3a03289da2f0601edf8f",
-                "storageAddress": "http://testserver/model/00009a1256f8ce55ed907221000035daf1ac28111b5a3a03289da2f0601edf8f/file/"
+                "storage_address": "http://testserver/model/00009a1256f8ce55ed907221000035daf1ac28111b5a3a03289da2f0601edf8f/file/"
             },
             "log": "",
             "metadata": {},
-            "outHeadModel": {
-                "outModel": {
+            "out_head_model": {
+                "out_model": {
                     "hash": "349b475ebd9458739af8685b8b75d7aeb1290209eabadad1b9b8afaa2b05c8d5"
                 },
                 "permissions": {
                     "process": {
                         "public": False,
-                        "authorizedIDs": [
+                        "authorized_ids": [
                             "MyOrg1MSP"
                         ]
                     }
                 }
             },
-            "outTrunkModel": {
-                "outModel": {
+            "out_trunk_model": {
+                "out_model": {
                     "hash": "692e3f70b9ebfca3c2e51e2a92c18092cc24dda547debefd6eb4bdd38ca6d803",
-                    "storageAddress": "http://testserver/model/692e3f70b9ebfca3c2e51e2a92c18092cc24dda547debefd6eb4bdd38ca6d803/file/"
+                    "storage_address": "http://testserver/model/692e3f70b9ebfca3c2e51e2a92c18092cc24dda547debefd6eb4bdd38ca6d803/file/"
                 },
                 "permissions": {
                     "process": {
                         "public": False,
-                        "authorizedIDs": [
+                        "authorized_ids": [
                             "MyOrg1MSP"
                         ]
                     }
@@ -1944,17 +1944,17 @@ model = [
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_composite_traintuples_execution - Algo 0",
                 "hash": "09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf",
-                "storageAddress": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
+                "storage_address": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
             },
             "certified": True,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "MyOrg1MSP",
             "dataset": {
                 "worker": "MyOrg1MSP",
                 "keys": [
                     "ffed4147fffff2f18130b7332c1460ecccd8e1378765c415b82b948c19e98a68"
                 ],
-                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
                 "perf": 32
             },
             "key": "8cd0eb9ae2349fc33b36ebb689963840bdfd3ffe4f24392d77dba85c4c087d02",
@@ -1964,24 +1964,24 @@ model = [
                 "hash": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
                 "metrics": {
                     "hash": "0d64f855e07524da60203067713ab08fd6e479a02ebcb70364b2c6a2a29367e1",
-                    "storageAddress": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
+                    "storage_address": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
                 }
             },
             "rank": 0,
             "status": "done",
             "tag": "",
-            "traintupleKey": "2978ca1f7d5520ef42a82c86a2e24d5b00f04c73013febdb5ed35d32dc606e92",
-            "traintupleType": "compositeTraintuple"
+            "traintuple_key": "2978ca1f7d5520ef42a82c86a2e24d5b00f04c73013febdb5ed35d32dc606e92",
+            "traintuple_type": "compositeTraintuple"
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
-        "compositeTraintuple": {
+        "composite_traintuple": {
             "key": "aa9be143edc6ef051ea255fd77bb54ba40c71bb39afa3ece502dd36782d02a71",
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_composite_traintuples_execution - Algo 0",
                 "hash": "09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf",
-                "storageAddress": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
+                "storage_address": "http://testserver/composite_algo/09abcf99a672c0b95b3d2431169e34ec6bcc5154629db86c5d6aebb94377cbbf/file/"
             },
             "creator": "MyOrg1MSP",
             "dataset": {
@@ -1992,36 +1992,36 @@ model = [
                     "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
                     "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
                 ],
-                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
                 "metadata": {}
             },
-            "computePlanID": "",
-            "inHeadModel": None,
-            "inTrunkModel": None,
+            "compute_plan_id": "",
+            "in_head_model": None,
+            "in_trunk_model": None,
             "log": "",
             "metadata": {},
-            "outHeadModel": {
-                "outModel": {
+            "out_head_model": {
+                "out_model": {
                     "hash": "64c72dc39772e122ef552d10ff101ef6cee94935a84678a0125f7c3fd044dff8"
                 },
                 "permissions": {
                     "process": {
                         "public": False,
-                        "authorizedIDs": [
+                        "authorized_ids": [
                             "MyOrg1MSP"
                         ]
                     }
                 }
             },
-            "outTrunkModel": {
-                "outModel": {
+            "out_trunk_model": {
+                "out_model": {
                     "hash": "00009a1256f8ce55ed907221000035daf1ac28111b5a3a03289da2f0601edf8f",
-                    "storageAddress": "http://testserver/model/00009a1256f8ce55ed907221000035daf1ac28111b5a3a03289da2f0601edf8f/file/"
+                    "storage_address": "http://testserver/model/00009a1256f8ce55ed907221000035daf1ac28111b5a3a03289da2f0601edf8f/file/"
                 },
                 "permissions": {
                     "process": {
                         "public": False,
-                        "authorizedIDs": [
+                        "authorized_ids": [
                             "MyOrg1MSP"
                         ]
                     }
@@ -2034,7 +2034,7 @@ model = [
         "testtuple": {
             "algo": None,
             "certified": False,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "",
             "dataset": None,
             "key": "",
@@ -2044,18 +2044,18 @@ model = [
             "rank": 0,
             "status": "",
             "tag": "",
-            "traintupleKey": "",
-            "traintupleType": ""
+            "traintuple_key": "",
+            "traintuple_type": ""
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
-        "compositeTraintuple": {
+        "composite_traintuple": {
             "key": "2d3e98fbeafebf1995db3ab205b9f803b18a1be8b4af72e242faceee3dd7d224",
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_composite_traintuple_execution_failure - Algo 0",
                 "hash": "0fbb505a32ae8785c08d37fe7bf7476d7365c3a0cef7c6e05c61c06db3267593",
-                "storageAddress": "http://testserver/composite_algo/0fbb505a32ae8785c08d37fe7bf7476d7365c3a0cef7c6e05c61c06db3267593/file/"
+                "storage_address": "http://testserver/composite_algo/0fbb505a32ae8785c08d37fe7bf7476d7365c3a0cef7c6e05c61c06db3267593/file/"
             },
             "creator": "MyOrg1MSP",
             "dataset": {
@@ -2066,31 +2066,31 @@ model = [
                     "5702a4f561da782735e2e5d7b03605ee7bdb27d6bfc3187965e64cc0603bc0e3",
                     "8524b404cc1b25314fce92b8c31da7b1c9f1bab2ffd48e2c28382730bf8fe49f"
                 ],
-                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
                 "metadata": {}
             },
-            "computePlanID": "",
-            "inHeadModel": None,
-            "inTrunkModel": None,
+            "compute_plan_id": "",
+            "in_head_model": None,
+            "in_trunk_model": None,
             "log": "[00-01-0117-d390d32]",
             "metadata": {},
-            "outHeadModel": {
-                "outModel": None,
+            "out_head_model": {
+                "out_model": None,
                 "permissions": {
                     "process": {
                         "public": False,
-                        "authorizedIDs": [
+                        "authorized_ids": [
                             "MyOrg1MSP"
                         ]
                     }
                 }
             },
-            "outTrunkModel": {
-                "outModel": None,
+            "out_trunk_model": {
+                "out_model": None,
                 "permissions": {
                     "process": {
                         "public": False,
-                        "authorizedIDs": [
+                        "authorized_ids": [
                             "MyOrg1MSP"
                         ]
                     }
@@ -2103,7 +2103,7 @@ model = [
         "testtuple": {
             "algo": None,
             "certified": False,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "",
             "dataset": None,
             "key": "",
@@ -2113,18 +2113,18 @@ model = [
             "rank": 0,
             "status": "",
             "tag": "",
-            "traintupleKey": "",
-            "traintupleType": ""
+            "traintuple_key": "",
+            "traintuple_type": ""
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
-        "compositeTraintuple": {
+        "composite_traintuple": {
             "key": "7dbd4b2ac9e81b6dedd775809e0903d8fa55ce2cb8094bd6c4c20c2b0448b716",
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple_execution_failure - Algo 0",
                 "hash": "5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c",
-                "storageAddress": "http://testserver/composite_algo/5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c/file/"
+                "storage_address": "http://testserver/composite_algo/5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c/file/"
             },
             "creator": "MyOrg1MSP",
             "dataset": {
@@ -2132,36 +2132,36 @@ model = [
                 "keys": [
                     "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f"
                 ],
-                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
                 "metadata": {}
             },
-            "computePlanID": "",
-            "inHeadModel": None,
-            "inTrunkModel": None,
+            "compute_plan_id": "",
+            "in_head_model": None,
+            "in_trunk_model": None,
             "log": "",
             "metadata": {},
-            "outHeadModel": {
-                "outModel": {
+            "out_head_model": {
+                "out_model": {
                     "hash": "8b87222907027a470d6d99409b0de9a9ced07142d026ab875d6ddfdecf9db96d"
                 },
                 "permissions": {
                     "process": {
                         "public": False,
-                        "authorizedIDs": [
+                        "authorized_ids": [
                             "MyOrg1MSP"
                         ]
                     }
                 }
             },
-            "outTrunkModel": {
-                "outModel": {
+            "out_trunk_model": {
+                "out_model": {
                     "hash": "fcfcaa4f3be73940006fc54566b2946fabd5ee677496a5dd43e4b8c0c3c3d54d",
-                    "storageAddress": "http://testserver/model/fcfcaa4f3be73940006fc54566b2946fabd5ee677496a5dd43e4b8c0c3c3d54d/file/"
+                    "storage_address": "http://testserver/model/fcfcaa4f3be73940006fc54566b2946fabd5ee677496a5dd43e4b8c0c3c3d54d/file/"
                 },
                 "permissions": {
                     "process": {
                         "public": False,
-                        "authorizedIDs": [
+                        "authorized_ids": [
                             "MyOrg1MSP"
                         ]
                     }
@@ -2174,7 +2174,7 @@ model = [
         "testtuple": {
             "algo": None,
             "certified": False,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "",
             "dataset": None,
             "key": "",
@@ -2184,18 +2184,18 @@ model = [
             "rank": 0,
             "status": "",
             "tag": "",
-            "traintupleKey": "",
-            "traintupleType": ""
+            "traintuple_key": "",
+            "traintuple_type": ""
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
-        "compositeTraintuple": {
+        "composite_traintuple": {
             "key": "df3e19426496a5b8a79d8f1b96e52de9fe3a07b6a81a9b5d9a34a824d52c1841",
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple_execution_failure - Algo 0",
                 "hash": "5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c",
-                "storageAddress": "http://testserver/composite_algo/5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c/file/"
+                "storage_address": "http://testserver/composite_algo/5a9fc1032bd97c9ebaafeaf7d2e5d81f375f1ff8e13ad3000e43f135eb47810c/file/"
             },
             "creator": "MyOrg1MSP",
             "dataset": {
@@ -2203,36 +2203,36 @@ model = [
                 "keys": [
                     "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135"
                 ],
-                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
                 "metadata": {}
             },
-            "computePlanID": "",
-            "inHeadModel": None,
-            "inTrunkModel": None,
+            "compute_plan_id": "",
+            "in_head_model": None,
+            "in_trunk_model": None,
             "log": "",
             "metadata": {},
-            "outHeadModel": {
-                "outModel": {
+            "out_head_model": {
+                "out_model": {
                     "hash": "bffb89749a253de1d451a836748dc813035dbcacb01fb85911b97c577c10ea6d"
                 },
                 "permissions": {
                     "process": {
                         "public": False,
-                        "authorizedIDs": [
+                        "authorized_ids": [
                             "MyOrg1MSP"
                         ]
                     }
                 }
             },
-            "outTrunkModel": {
-                "outModel": {
+            "out_trunk_model": {
+                "out_model": {
                     "hash": "682d31d9e95654ed0aaf81184136d87c7ff2a0046c3d24181508f112d58b330d",
-                    "storageAddress": "http://testserver/model/682d31d9e95654ed0aaf81184136d87c7ff2a0046c3d24181508f112d58b330d/file/"
+                    "storage_address": "http://testserver/model/682d31d9e95654ed0aaf81184136d87c7ff2a0046c3d24181508f112d58b330d/file/"
                 },
                 "permissions": {
                     "process": {
                         "public": False,
-                        "authorizedIDs": [
+                        "authorized_ids": [
                             "MyOrg1MSP"
                         ]
                     }
@@ -2245,7 +2245,7 @@ model = [
         "testtuple": {
             "algo": None,
             "certified": False,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "",
             "dataset": None,
             "key": "",
@@ -2255,18 +2255,18 @@ model = [
             "rank": 0,
             "status": "",
             "tag": "",
-            "traintupleKey": "",
-            "traintupleType": ""
+            "traintuple_key": "",
+            "traintuple_type": ""
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
-        "compositeTraintuple": {
+        "composite_traintuple": {
             "key": "3197bd6c56bc47089864c76b47b6115eb3551901ba304722ce581561c37b0c7b",
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
                 "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
-                "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+                "storage_address": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
             },
             "creator": "MyOrg1MSP",
             "dataset": {
@@ -2274,36 +2274,36 @@ model = [
                 "keys": [
                     "265f1e2639598c42bbf9aba8d223c6a5d6cc1ad5066254b908eb49ac1e43577f"
                 ],
-                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
                 "metadata": {}
             },
-            "computePlanID": "",
-            "inHeadModel": None,
-            "inTrunkModel": None,
+            "compute_plan_id": "",
+            "in_head_model": None,
+            "in_trunk_model": None,
             "log": "",
             "metadata": {},
-            "outHeadModel": {
-                "outModel": {
+            "out_head_model": {
+                "out_model": {
                     "hash": "7d7ed2eac5e822ea90058387dd35d1270639ecc4982a6d72b619b8659813163a"
                 },
                 "permissions": {
                     "process": {
                         "public": False,
-                        "authorizedIDs": [
+                        "authorized_ids": [
                             "MyOrg1MSP"
                         ]
                     }
                 }
             },
-            "outTrunkModel": {
-                "outModel": {
+            "out_trunk_model": {
+                "out_model": {
                     "hash": "b312a262592aa7ed56a07d0eb02bec0548745eb7316d4ea86b3719b2497d8cb2",
-                    "storageAddress": "http://testserver/model/b312a262592aa7ed56a07d0eb02bec0548745eb7316d4ea86b3719b2497d8cb2/file/"
+                    "storage_address": "http://testserver/model/b312a262592aa7ed56a07d0eb02bec0548745eb7316d4ea86b3719b2497d8cb2/file/"
                 },
                 "permissions": {
                     "process": {
                         "public": False,
-                        "authorizedIDs": [
+                        "authorized_ids": [
                             "MyOrg1MSP",
                             "MyOrg2MSP"
                         ]
@@ -2317,7 +2317,7 @@ model = [
         "testtuple": {
             "algo": None,
             "certified": False,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "",
             "dataset": None,
             "key": "",
@@ -2327,18 +2327,18 @@ model = [
             "rank": 0,
             "status": "",
             "tag": "",
-            "traintupleKey": "",
-            "traintupleType": ""
+            "traintuple_key": "",
+            "traintuple_type": ""
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
-        "compositeTraintuple": {
+        "composite_traintuple": {
             "key": "3be92d96d1abdabfbe6a4ff612d70f7f867f450c38ea344bd98d0775bec826fd",
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
                 "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
-                "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+                "storage_address": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
             },
             "creator": "MyOrg1MSP",
             "dataset": {
@@ -2346,44 +2346,44 @@ model = [
                 "keys": [
                     "704740917e35b36648b80d9826e1f24d2082bf113f1693ba08975c7c405cb01f"
                 ],
-                "openerHash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+                "opener_hash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
                 "metadata": {}
             },
-            "computePlanID": "",
-            "inHeadModel": {
-                "traintupleKey": "e7b96818eadcdce6940c16b388bbd264549646a45bb8ea75e8f218d224c18162",
+            "compute_plan_id": "",
+            "in_head_model": {
+                "traintuple_key": "e7b96818eadcdce6940c16b388bbd264549646a45bb8ea75e8f218d224c18162",
                 "hash": "3af8f86ed9fe07237497e52d1ced195d7e4752f7d130327929f96ea688d60a41",
-                "storageAddress": ""
+                "storage_address": ""
             },
-            "inTrunkModel": {
-                "traintupleKey": "9cb5582fc3e822b9ddabbf7479097df05381294e3559f31a35c20f2e46e4885c",
+            "in_trunk_model": {
+                "traintuple_key": "9cb5582fc3e822b9ddabbf7479097df05381294e3559f31a35c20f2e46e4885c",
                 "hash": "4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688",
-                "storageAddress": "http://testserver/model/4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688/file/"
+                "storage_address": "http://testserver/model/4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688/file/"
             },
             "log": "",
             "metadata": {},
-            "outHeadModel": {
-                "outModel": {
+            "out_head_model": {
+                "out_model": {
                     "hash": "8b6a7f3b7feef0a2c157bf2acfd2596fd7815a0a69b0a41b7451bab47d022eaa"
                 },
                 "permissions": {
                     "process": {
                         "public": False,
-                        "authorizedIDs": [
+                        "authorized_ids": [
                             "MyOrg2MSP"
                         ]
                     }
                 }
             },
-            "outTrunkModel": {
-                "outModel": {
+            "out_trunk_model": {
+                "out_model": {
                     "hash": "66392ca3e6a5935fb8e22a5ee5b8af31dbec5655ff087b98f071abf7e4f3ce74",
-                    "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/model/66392ca3e6a5935fb8e22a5ee5b8af31dbec5655ff087b98f071abf7e4f3ce74/file/"
+                    "storage_address": "http://backend-org-2-substra-backend-server.org-2:8000/model/66392ca3e6a5935fb8e22a5ee5b8af31dbec5655ff087b98f071abf7e4f3ce74/file/"
                 },
                 "permissions": {
                     "process": {
                         "public": False,
-                        "authorizedIDs": [
+                        "authorized_ids": [
                             "MyOrg1MSP",
                             "MyOrg2MSP"
                         ]
@@ -2398,17 +2398,17 @@ model = [
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
                 "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
-                "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+                "storage_address": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
             },
             "certified": True,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "MyOrg1MSP",
             "dataset": {
                 "worker": "MyOrg2MSP",
                 "keys": [
                     "edaa4ccdfc9bcadda859498fbb550a6e1fc6baf176389c3eb18afc8a382b4145"
                 ],
-                "openerHash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+                "opener_hash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
                 "perf": 32
             },
             "key": "87e835650d84ca0cf26ac332bad4f4d732a30606505f57f1817fb6580f16adc5",
@@ -2418,24 +2418,24 @@ model = [
                 "hash": "b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3",
                 "metrics": {
                     "hash": "1a61bea02e3e75f8197d682cbaa6110c9709fbfbd4f16964acc390c70e7a22fe",
-                    "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/objective/b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3/metrics/"
+                    "storage_address": "http://backend-org-2-substra-backend-server.org-2:8000/objective/b61067adc59fb1aabe21eab767d986cccccdcfd8c64ea90a0bef59999051cea3/metrics/"
                 }
             },
             "rank": 0,
             "status": "done",
             "tag": "",
-            "traintupleKey": "3be92d96d1abdabfbe6a4ff612d70f7f867f450c38ea344bd98d0775bec826fd",
-            "traintupleType": "compositeTraintuple"
+            "traintuple_key": "3be92d96d1abdabfbe6a4ff612d70f7f867f450c38ea344bd98d0775bec826fd",
+            "traintuple_type": "compositeTraintuple"
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
-        "compositeTraintuple": {
+        "composite_traintuple": {
             "key": "5adbd24ea21cb23b1ffc65151038a62c97f2d745d7df0928e683707f15a09556",
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
                 "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
-                "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+                "storage_address": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
             },
             "creator": "MyOrg1MSP",
             "dataset": {
@@ -2443,44 +2443,44 @@ model = [
                 "keys": [
                     "51d906cc10b29eb81c935550b750811933bec25cb28ff88ea2549de2765db135"
                 ],
-                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
                 "metadata": {}
             },
-            "computePlanID": "",
-            "inHeadModel": {
-                "traintupleKey": "3197bd6c56bc47089864c76b47b6115eb3551901ba304722ce581561c37b0c7b",
+            "compute_plan_id": "",
+            "in_head_model": {
+                "traintuple_key": "3197bd6c56bc47089864c76b47b6115eb3551901ba304722ce581561c37b0c7b",
                 "hash": "7d7ed2eac5e822ea90058387dd35d1270639ecc4982a6d72b619b8659813163a",
-                "storageAddress": ""
+                "storage_address": ""
             },
-            "inTrunkModel": {
-                "traintupleKey": "9cb5582fc3e822b9ddabbf7479097df05381294e3559f31a35c20f2e46e4885c",
+            "in_trunk_model": {
+                "traintuple_key": "9cb5582fc3e822b9ddabbf7479097df05381294e3559f31a35c20f2e46e4885c",
                 "hash": "4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688",
-                "storageAddress": "http://testserver/model/4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688/file/"
+                "storage_address": "http://testserver/model/4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688/file/"
             },
             "log": "",
             "metadata": {},
-            "outHeadModel": {
-                "outModel": {
+            "out_head_model": {
+                "out_model": {
                     "hash": "28a705e08e765569bd89262f821e1c7285e43fa1e82df2f833464b8ff890c7bd"
                 },
                 "permissions": {
                     "process": {
                         "public": False,
-                        "authorizedIDs": [
+                        "authorized_ids": [
                             "MyOrg1MSP"
                         ]
                     }
                 }
             },
-            "outTrunkModel": {
-                "outModel": {
+            "out_trunk_model": {
+                "out_model": {
                     "hash": "14b7e3254896db4f43c582695c39d096f33e1390e3ecaa8b0e6e7619bf827044",
-                    "storageAddress": "http://testserver/model/14b7e3254896db4f43c582695c39d096f33e1390e3ecaa8b0e6e7619bf827044/file/"
+                    "storage_address": "http://testserver/model/14b7e3254896db4f43c582695c39d096f33e1390e3ecaa8b0e6e7619bf827044/file/"
                 },
                 "permissions": {
                     "process": {
                         "public": False,
-                        "authorizedIDs": [
+                        "authorized_ids": [
                             "MyOrg1MSP",
                             "MyOrg2MSP"
                         ]
@@ -2495,17 +2495,17 @@ model = [
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
                 "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
-                "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+                "storage_address": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
             },
             "certified": True,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "MyOrg1MSP",
             "dataset": {
                 "worker": "MyOrg1MSP",
                 "keys": [
                     "ffed4147fffff2f18130b7332c1460ecccd8e1378765c415b82b948c19e98a68"
                 ],
-                "openerHash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
+                "opener_hash": "e25a6ac0b4966c72a33945bdeb1f9f6f870df595ebf9273fe61c7e5c2bc77204",
                 "perf": 32
             },
             "key": "6075c796cc470f1e1de7b98d8a4d28b19e48c1d662ee9bdb982c0354088d2f2a",
@@ -2515,24 +2515,24 @@ model = [
                 "hash": "48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8",
                 "metrics": {
                     "hash": "0d64f855e07524da60203067713ab08fd6e479a02ebcb70364b2c6a2a29367e1",
-                    "storageAddress": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
+                    "storage_address": "http://testserver/objective/48cc5ce4d352b859e202adb0d639ee092c78cae7a2a1df0fccd88c63b3466ad8/metrics/"
                 }
             },
             "rank": 0,
             "status": "done",
             "tag": "",
-            "traintupleKey": "5adbd24ea21cb23b1ffc65151038a62c97f2d745d7df0928e683707f15a09556",
-            "traintupleType": "compositeTraintuple"
+            "traintuple_key": "5adbd24ea21cb23b1ffc65151038a62c97f2d745d7df0928e683707f15a09556",
+            "traintuple_type": "compositeTraintuple"
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
-        "compositeTraintuple": {
+        "composite_traintuple": {
             "key": "e7b96818eadcdce6940c16b388bbd264549646a45bb8ea75e8f218d224c18162",
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 0",
                 "hash": "fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87",
-                "storageAddress": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
+                "storage_address": "http://testserver/composite_algo/fe2eba4566fac967ef847cbb3a8eba75fa7c03291e4db621bf3bc27b54b7ed87/file/"
             },
             "creator": "MyOrg1MSP",
             "dataset": {
@@ -2540,36 +2540,36 @@ model = [
                 "keys": [
                     "26e52856b27261fc12e9615d5914027dc5986cd8bb37ccf1da4c7aa47b74a8ea"
                 ],
-                "openerHash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
+                "opener_hash": "aa572a964b024435d48a73aacb86e3d195614a4f335e739116bad2c427a1fb02",
                 "metadata": {}
             },
-            "computePlanID": "",
-            "inHeadModel": None,
-            "inTrunkModel": None,
+            "compute_plan_id": "",
+            "in_head_model": None,
+            "in_trunk_model": None,
             "log": "",
             "metadata": {},
-            "outHeadModel": {
-                "outModel": {
+            "out_head_model": {
+                "out_model": {
                     "hash": "3af8f86ed9fe07237497e52d1ced195d7e4752f7d130327929f96ea688d60a41"
                 },
                 "permissions": {
                     "process": {
                         "public": False,
-                        "authorizedIDs": [
+                        "authorized_ids": [
                             "MyOrg2MSP"
                         ]
                     }
                 }
             },
-            "outTrunkModel": {
-                "outModel": {
+            "out_trunk_model": {
+                "out_model": {
                     "hash": "cd8a895a9b604ccbb2e2bf9f081d0560bfd86f4a98beabd833d4c7c36f35cd9d",
-                    "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/model/cd8a895a9b604ccbb2e2bf9f081d0560bfd86f4a98beabd833d4c7c36f35cd9d/file/"
+                    "storage_address": "http://backend-org-2-substra-backend-server.org-2:8000/model/cd8a895a9b604ccbb2e2bf9f081d0560bfd86f4a98beabd833d4c7c36f35cd9d/file/"
                 },
                 "permissions": {
                     "process": {
                         "public": False,
-                        "authorizedIDs": [
+                        "authorized_ids": [
                             "MyOrg1MSP",
                             "MyOrg2MSP"
                         ]
@@ -2583,7 +2583,7 @@ model = [
         "testtuple": {
             "algo": None,
             "certified": False,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "",
             "dataset": None,
             "key": "",
@@ -2593,10 +2593,10 @@ model = [
             "rank": 0,
             "status": "",
             "tag": "",
-            "traintupleKey": "",
-            "traintupleType": ""
+            "traintuple_key": "",
+            "traintuple_type": ""
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
         "aggregatetuple": {
@@ -2604,32 +2604,32 @@ model = [
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple_execution_failure - Algo 1",
                 "hash": "16acae7a5d702a97c4cce626bbe5c44d367d73617ee42e81660bce7494379986",
-                "storageAddress": "http://testserver/aggregate_algo/16acae7a5d702a97c4cce626bbe5c44d367d73617ee42e81660bce7494379986/file/"
+                "storage_address": "http://testserver/aggregate_algo/16acae7a5d702a97c4cce626bbe5c44d367d73617ee42e81660bce7494379986/file/"
             },
             "creator": "MyOrg1MSP",
-            "computePlanID": "",
+            "compute_plan_id": "",
             "log": "[00-01-0117-a45d457]",
             "metadata": {},
-            "inModels": [
+            "in_models": [
                 {
-                    "traintupleKey": "7dbd4b2ac9e81b6dedd775809e0903d8fa55ce2cb8094bd6c4c20c2b0448b716",
+                    "traintuple_key": "7dbd4b2ac9e81b6dedd775809e0903d8fa55ce2cb8094bd6c4c20c2b0448b716",
                     "hash": "fcfcaa4f3be73940006fc54566b2946fabd5ee677496a5dd43e4b8c0c3c3d54d",
-                    "storageAddress": "http://testserver/model/fcfcaa4f3be73940006fc54566b2946fabd5ee677496a5dd43e4b8c0c3c3d54d/file/"
+                    "storage_address": "http://testserver/model/fcfcaa4f3be73940006fc54566b2946fabd5ee677496a5dd43e4b8c0c3c3d54d/file/"
                 },
                 {
-                    "traintupleKey": "df3e19426496a5b8a79d8f1b96e52de9fe3a07b6a81a9b5d9a34a824d52c1841",
+                    "traintuple_key": "df3e19426496a5b8a79d8f1b96e52de9fe3a07b6a81a9b5d9a34a824d52c1841",
                     "hash": "682d31d9e95654ed0aaf81184136d87c7ff2a0046c3d24181508f112d58b330d",
-                    "storageAddress": "http://testserver/model/682d31d9e95654ed0aaf81184136d87c7ff2a0046c3d24181508f112d58b330d/file/"
+                    "storage_address": "http://testserver/model/682d31d9e95654ed0aaf81184136d87c7ff2a0046c3d24181508f112d58b330d/file/"
                 }
             ],
-            "outModel": None,
+            "out_model": None,
             "rank": 0,
             "status": "failed",
             "tag": "",
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg1MSP"
                     ]
                 }
@@ -2639,7 +2639,7 @@ model = [
         "testtuple": {
             "algo": None,
             "certified": False,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "",
             "dataset": None,
             "key": "",
@@ -2649,10 +2649,10 @@ model = [
             "rank": 0,
             "status": "",
             "tag": "",
-            "traintupleKey": "",
-            "traintupleType": ""
+            "traintuple_key": "",
+            "traintuple_type": ""
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
         "aggregatetuple": {
@@ -2660,32 +2660,32 @@ model = [
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregatetuple - Algo 1",
                 "hash": "25081cda2aab5915fe1d732c6483e24ef8fb2484a6e856c8ed912b36577d3d9a",
-                "storageAddress": "http://testserver/aggregate_algo/25081cda2aab5915fe1d732c6483e24ef8fb2484a6e856c8ed912b36577d3d9a/file/"
+                "storage_address": "http://testserver/aggregate_algo/25081cda2aab5915fe1d732c6483e24ef8fb2484a6e856c8ed912b36577d3d9a/file/"
             },
             "creator": "MyOrg1MSP",
-            "computePlanID": "",
+            "compute_plan_id": "",
             "log": "",
             "metadata": {},
-            "inModels": [
+            "in_models": [
                 {
-                    "traintupleKey": "3169bb172502f67556a6f12b856a5d653441227842aded24ade6b7866d3b624d",
+                    "traintuple_key": "3169bb172502f67556a6f12b856a5d653441227842aded24ade6b7866d3b624d",
                     "hash": "940262c35a6b33c2b7c8811fa785899b00e287ffa05e3cb5a23c857e9c89c760",
-                    "storageAddress": "http://testserver/model/940262c35a6b33c2b7c8811fa785899b00e287ffa05e3cb5a23c857e9c89c760/file/"
+                    "storage_address": "http://testserver/model/940262c35a6b33c2b7c8811fa785899b00e287ffa05e3cb5a23c857e9c89c760/file/"
                 },
                 {
-                    "traintupleKey": "ea7180ccc125dcceff10400fd2943f1e02fc915262c67f19986b3a9edbd765fb",
+                    "traintuple_key": "ea7180ccc125dcceff10400fd2943f1e02fc915262c67f19986b3a9edbd765fb",
                     "hash": "02ccc4eeb426f7bbfe746a06a4c63a2023a8f2ea2c72f92242cc5f7f1164383c",
-                    "storageAddress": "http://testserver/model/02ccc4eeb426f7bbfe746a06a4c63a2023a8f2ea2c72f92242cc5f7f1164383c/file/"
+                    "storage_address": "http://testserver/model/02ccc4eeb426f7bbfe746a06a4c63a2023a8f2ea2c72f92242cc5f7f1164383c/file/"
                 },
                 {
-                    "traintupleKey": "a9c586b72c9c11412b0c9f81d599651a964d04934bca9f1886dd2d084f438a70",
+                    "traintuple_key": "a9c586b72c9c11412b0c9f81d599651a964d04934bca9f1886dd2d084f438a70",
                     "hash": "f33d3c7a21e97f5f0edd636f3b313c6a7757cc458614e49da74d58af7fc0c4c2",
-                    "storageAddress": "http://testserver/model/f33d3c7a21e97f5f0edd636f3b313c6a7757cc458614e49da74d58af7fc0c4c2/file/"
+                    "storage_address": "http://testserver/model/f33d3c7a21e97f5f0edd636f3b313c6a7757cc458614e49da74d58af7fc0c4c2/file/"
                 }
             ],
-            "outModel": {
+            "out_model": {
                 "hash": "bd2e6a510edc11974e3d8b5459f0d4bd9b3169afe1fa47643147351f51fb18ac",
-                "storageAddress": "http://testserver/model/bd2e6a510edc11974e3d8b5459f0d4bd9b3169afe1fa47643147351f51fb18ac/file/"
+                "storage_address": "http://testserver/model/bd2e6a510edc11974e3d8b5459f0d4bd9b3169afe1fa47643147351f51fb18ac/file/"
             },
             "rank": 0,
             "status": "done",
@@ -2693,7 +2693,7 @@ model = [
             "permissions": {
                 "process": {
                     "public": True,
-                    "authorizedIDs": []
+                    "authorized_ids": []
                 }
             },
             "worker": "MyOrg1MSP"
@@ -2701,7 +2701,7 @@ model = [
         "testtuple": {
             "algo": None,
             "certified": False,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "",
             "dataset": None,
             "key": "",
@@ -2711,10 +2711,10 @@ model = [
             "rank": 0,
             "status": "",
             "tag": "",
-            "traintupleKey": "",
-            "traintupleType": ""
+            "traintuple_key": "",
+            "traintuple_type": ""
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
         "aggregatetuple": {
@@ -2722,27 +2722,27 @@ model = [
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 1",
                 "hash": "576485095a2f9bc78ed6238b847c9c679fb755b822c0cc6e08e60ea227ec0648",
-                "storageAddress": "http://testserver/aggregate_algo/576485095a2f9bc78ed6238b847c9c679fb755b822c0cc6e08e60ea227ec0648/file/"
+                "storage_address": "http://testserver/aggregate_algo/576485095a2f9bc78ed6238b847c9c679fb755b822c0cc6e08e60ea227ec0648/file/"
             },
             "creator": "MyOrg1MSP",
-            "computePlanID": "",
+            "compute_plan_id": "",
             "log": "",
             "metadata": {},
-            "inModels": [
+            "in_models": [
                 {
-                    "traintupleKey": "3197bd6c56bc47089864c76b47b6115eb3551901ba304722ce581561c37b0c7b",
+                    "traintuple_key": "3197bd6c56bc47089864c76b47b6115eb3551901ba304722ce581561c37b0c7b",
                     "hash": "b312a262592aa7ed56a07d0eb02bec0548745eb7316d4ea86b3719b2497d8cb2",
-                    "storageAddress": "http://testserver/model/b312a262592aa7ed56a07d0eb02bec0548745eb7316d4ea86b3719b2497d8cb2/file/"
+                    "storage_address": "http://testserver/model/b312a262592aa7ed56a07d0eb02bec0548745eb7316d4ea86b3719b2497d8cb2/file/"
                 },
                 {
-                    "traintupleKey": "e7b96818eadcdce6940c16b388bbd264549646a45bb8ea75e8f218d224c18162",
+                    "traintuple_key": "e7b96818eadcdce6940c16b388bbd264549646a45bb8ea75e8f218d224c18162",
                     "hash": "cd8a895a9b604ccbb2e2bf9f081d0560bfd86f4a98beabd833d4c7c36f35cd9d",
-                    "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/model/cd8a895a9b604ccbb2e2bf9f081d0560bfd86f4a98beabd833d4c7c36f35cd9d/file/"
+                    "storage_address": "http://backend-org-2-substra-backend-server.org-2:8000/model/cd8a895a9b604ccbb2e2bf9f081d0560bfd86f4a98beabd833d4c7c36f35cd9d/file/"
                 }
             ],
-            "outModel": {
+            "out_model": {
                 "hash": "4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688",
-                "storageAddress": "http://testserver/model/4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688/file/"
+                "storage_address": "http://testserver/model/4e9f3d4b8575c5cda47188043bd8e0f43fef42e2cf92f2476ac78bda096f2688/file/"
             },
             "rank": 0,
             "status": "done",
@@ -2750,7 +2750,7 @@ model = [
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg1MSP",
                         "MyOrg2MSP"
                     ]
@@ -2761,7 +2761,7 @@ model = [
         "testtuple": {
             "algo": None,
             "certified": False,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "",
             "dataset": None,
             "key": "",
@@ -2771,10 +2771,10 @@ model = [
             "rank": 0,
             "status": "",
             "tag": "",
-            "traintupleKey": "",
-            "traintupleType": ""
+            "traintuple_key": "",
+            "traintuple_type": ""
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     },
     {
         "aggregatetuple": {
@@ -2782,27 +2782,27 @@ model = [
             "algo": {
                 "name": "9224cad96c964b7b8ed2f7eb5872c27a_test_aggregate_composite_traintuples - Algo 1",
                 "hash": "576485095a2f9bc78ed6238b847c9c679fb755b822c0cc6e08e60ea227ec0648",
-                "storageAddress": "http://testserver/aggregate_algo/576485095a2f9bc78ed6238b847c9c679fb755b822c0cc6e08e60ea227ec0648/file/"
+                "storage_address": "http://testserver/aggregate_algo/576485095a2f9bc78ed6238b847c9c679fb755b822c0cc6e08e60ea227ec0648/file/"
             },
             "creator": "MyOrg1MSP",
-            "computePlanID": "",
+            "compute_plan_id": "",
             "log": "",
             "metadata": {},
-            "inModels": [
+            "in_models": [
                 {
-                    "traintupleKey": "5adbd24ea21cb23b1ffc65151038a62c97f2d745d7df0928e683707f15a09556",
+                    "traintuple_key": "5adbd24ea21cb23b1ffc65151038a62c97f2d745d7df0928e683707f15a09556",
                     "hash": "14b7e3254896db4f43c582695c39d096f33e1390e3ecaa8b0e6e7619bf827044",
-                    "storageAddress": "http://testserver/model/14b7e3254896db4f43c582695c39d096f33e1390e3ecaa8b0e6e7619bf827044/file/"
+                    "storage_address": "http://testserver/model/14b7e3254896db4f43c582695c39d096f33e1390e3ecaa8b0e6e7619bf827044/file/"
                 },
                 {
-                    "traintupleKey": "3be92d96d1abdabfbe6a4ff612d70f7f867f450c38ea344bd98d0775bec826fd",
+                    "traintuple_key": "3be92d96d1abdabfbe6a4ff612d70f7f867f450c38ea344bd98d0775bec826fd",
                     "hash": "66392ca3e6a5935fb8e22a5ee5b8af31dbec5655ff087b98f071abf7e4f3ce74",
-                    "storageAddress": "http://backend-org-2-substra-backend-server.org-2:8000/model/66392ca3e6a5935fb8e22a5ee5b8af31dbec5655ff087b98f071abf7e4f3ce74/file/"
+                    "storage_address": "http://backend-org-2-substra-backend-server.org-2:8000/model/66392ca3e6a5935fb8e22a5ee5b8af31dbec5655ff087b98f071abf7e4f3ce74/file/"
                 }
             ],
-            "outModel": {
+            "out_model": {
                 "hash": "d62bd637d4223726e96c46337539da3bbd94dc3a3b4f233f1c7152dd3b02364d",
-                "storageAddress": "http://testserver/model/d62bd637d4223726e96c46337539da3bbd94dc3a3b4f233f1c7152dd3b02364d/file/"
+                "storage_address": "http://testserver/model/d62bd637d4223726e96c46337539da3bbd94dc3a3b4f233f1c7152dd3b02364d/file/"
             },
             "rank": 0,
             "status": "done",
@@ -2810,7 +2810,7 @@ model = [
             "permissions": {
                 "process": {
                     "public": False,
-                    "authorizedIDs": [
+                    "authorized_ids": [
                         "MyOrg1MSP",
                         "MyOrg2MSP"
                     ]
@@ -2821,7 +2821,7 @@ model = [
         "testtuple": {
             "algo": None,
             "certified": False,
-            "computePlanID": "",
+            "compute_plan_id": "",
             "creator": "",
             "dataset": None,
             "key": "",
@@ -2831,10 +2831,10 @@ model = [
             "rank": 0,
             "status": "",
             "tag": "",
-            "traintupleKey": "",
-            "traintupleType": ""
+            "traintuple_key": "",
+            "traintuple_type": ""
         },
-        "nonCertifiedTesttuples": None
+        "non_certified_testtuples": None
     }
 ]
 

--- a/backend/substrapp/tests/common.py
+++ b/backend/substrapp/tests/common.py
@@ -215,7 +215,7 @@ def get_sample_model():
 DEFAULT_PERMISSIONS = {
     'process': {
         'public': True,
-        'authorizedIDs': [],
+        'authorized_ids': [],
     }
 }
 

--- a/backend/substrapp/tests/query/tests_query_compositetraintuple.py
+++ b/backend/substrapp/tests/query/tests_query_compositetraintuple.py
@@ -154,7 +154,7 @@ class CompositeTraintupleQueryTests(APITestCase):
         permissions = {
             "process": {
                 "public": False,
-                "authorizedIDs": ['substra']
+                "authorized_ids": ['substra']
             }
         }
         with mock.patch('substrapp.views.utils.get_owner', return_value='foo'), \
@@ -177,7 +177,7 @@ class CompositeTraintupleQueryTests(APITestCase):
         permissions = {
             "process": {
                 "public": False,
-                "authorizedIDs": ['substra']
+                "authorized_ids": ['substra']
             }
         }
         with mock.patch('substrapp.views.utils.get_owner', return_value='foo'), \
@@ -197,7 +197,7 @@ class CompositeTraintupleQueryTests(APITestCase):
         permissions = {
             "process": {
                 "public": False,
-                "authorizedIDs": ['owkin']
+                "authorized_ids": ['owkin']
             }
         }
         with mock.patch('substrapp.views.utils.get_owner', return_value='foo'), \

--- a/backend/substrapp/tests/tests_misc.py
+++ b/backend/substrapp/tests/tests_misc.py
@@ -88,7 +88,7 @@ class MiscTests(TestCase):
             mupdate_ledger.return_value = None
             res = {
                 'end_model_file_hash': 'hash',
-                'end_model_file': 'storageAddress',
+                'end_model_file': 'storage_address',
                 'job_task_log': 'log',
             }
             log_success_tuple(CHANNEL, 'traintuple', 'pk', res)

--- a/backend/substrapp/tests/tests_tasks.py
+++ b/backend/substrapp/tests/tests_tasks.py
@@ -74,7 +74,7 @@ class TasksTests(APITestCase):
     def test_get_remote_file_content(self):
         content = str(self.script.read())
         pkhash = compute_hash(content)
-        remote_file = {'storageAddress': 'localhost',
+        remote_file = {'storage_address': 'localhost',
                        'hash': pkhash,
                        'owner': 'external_node_id',
                        }
@@ -150,10 +150,10 @@ class TasksTests(APITestCase):
 
             # test fail
             with self.assertRaises(Exception):
-                prepare_opener(self.subtuple_path, {'dataset': {'openerHash': 'HASH'}})
+                prepare_opener(self.subtuple_path, {'dataset': {'opener_hash': 'HASH'}})
 
             # test work
-            prepare_opener(self.subtuple_path, {'dataset': {'openerHash': opener_hash}})
+            prepare_opener(self.subtuple_path, {'dataset': {'opener_hash': opener_hash}})
 
             opener_path = os.path.join(opener_directory, '__init__.py')
             self.assertTrue(os.path.exists(opener_path))
@@ -168,7 +168,7 @@ class TasksTests(APITestCase):
                 f.write('corrupted')
 
             with self.assertRaises(Exception):
-                prepare_opener(self.subtuple_path, {'dataset': {'openerHash': opener_hash}})
+                prepare_opener(self.subtuple_path, {'dataset': {'opener_hash': opener_hash}})
 
     def test_prepare_data_sample_zip(self):
 
@@ -270,7 +270,7 @@ class TasksTests(APITestCase):
 
         subtuple = {
             'algo': {
-                'storageAddress': assets.algo[0]['content']['storageAddress'],
+                'storage_address': assets.algo[0]['content']['storage_address'],
                 'owner': assets.algo[0]['owner'],
                 'hash': algo_hash
             }
@@ -333,7 +333,7 @@ class TasksTests(APITestCase):
 
                 self.MEDIA_ROOT = MEDIA_ROOT
 
-        subtuple = [{'key': 'subtuple_test', 'computePlanID': 'flkey', 'status': 'todo'}]
+        subtuple = [{'key': 'subtuple_test', 'compute_plan_id': 'flkey', 'status': 'todo'}]
 
         with mock.patch('substrapp.tasks.tasks.settings') as msettings, \
                 mock.patch.object(TaskResult.objects, 'filter') as mtaskresult, \
@@ -391,7 +391,7 @@ class TasksTests(APITestCase):
                 self.MEDIA_ROOT = MEDIA_ROOT
 
         subtuple_key = 'test_owkin'
-        subtuple = {'key': subtuple_key, 'inModels': None, 'algo': {'hash': 'myhash'}}
+        subtuple = {'key': subtuple_key, 'in_models': None, 'algo': {'hash': 'myhash'}}
         subtuple_directory = build_subtuple_folders(subtuple)
 
         with mock.patch('substrapp.tasks.tasks.settings') as msettings, \
@@ -417,7 +417,7 @@ class TasksTests(APITestCase):
     def test_compute_task(self):
 
         subtuple_key = 'test_owkin'
-        subtuple = {'key': subtuple_key, 'inModels': None}
+        subtuple = {'key': subtuple_key, 'in_models': None}
         subtuple_directory = build_subtuple_folders(subtuple)
 
         with mock.patch('substrapp.tasks.tasks.log_start_tuple') as mlog_start_tuple:
@@ -468,9 +468,9 @@ class TasksTests(APITestCase):
 
         subtuple = [{
             'key': 'subtuple_test',
-            'computePlanID': 'flkey',
-            'traintupleKey': 'subtuple_test',
-            'traintupleType': 'traintuple'
+            'compute_plan_id': 'flkey',
+            'traintuple_key': 'subtuple_test',
+            'traintuple_type': 'traintuple'
         }]
 
         with mock.patch('substrapp.tasks.tasks.settings') as msettings, \

--- a/backend/substrapp/tests/views/tests_utils.py
+++ b/backend/substrapp/tests/views/tests_utils.py
@@ -23,7 +23,7 @@ def with_permission_mixin(remote, same_file_property, has_access):
             ledger_value = {
                 'owner': 'owner-foo',
                 'file_property' if same_file_property else 'ledger_file_property': {
-                    'storageAddress': 'foo'
+                    'storage_address': 'foo'
                 }
             }
             with mock.patch('substrapp.views.utils.get_object_from_ledger',

--- a/backend/substrapp/tests/views/tests_views_algo.py
+++ b/backend/substrapp/tests/views/tests_views_algo.py
@@ -140,7 +140,7 @@ class AlgoViewTests(APITestCase):
             mquery_ledger.return_value = algo
             mquery_ledger2.return_value = model
 
-            pkhash = done_model['traintuple']['outModel']['hash']
+            pkhash = done_model['traintuple']['out_model']['hash']
             search_params = f'?search=model%253Ahash%253A{pkhash}'
             response = self.client.get(url + search_params, **self.extra)
             r = response.json()
@@ -237,9 +237,9 @@ class AlgoViewTests(APITestCase):
             ledger_algos = copy.deepcopy(algo)
             for ledger_algo in ledger_algos:
                 for field in ('description', 'content'):
-                    ledger_algo[field]['storageAddress'] = \
-                        ledger_algo[field]['storageAddress'].replace('http://testserver',
-                                                                     'http://remotetestserver')
+                    ledger_algo[field]['storage_address'] = \
+                        ledger_algo[field]['storage_address'].replace('http://testserver',
+                                                                      'http://remotetestserver')
             mquery_ledger.return_value = ledger_algos
 
             # actual test
@@ -248,8 +248,8 @@ class AlgoViewTests(APITestCase):
             self.assertEqual(len(res_algos), len(algo))
             for i, res_algo in enumerate(res_algos):
                 for field in ('description', 'content'):
-                    self.assertEqual(res_algo[field]['storageAddress'],
-                                     algo[i][field]['storageAddress'])
+                    self.assertEqual(res_algo[field]['storage_address'],
+                                     algo[i][field]['storage_address'])
 
     def test_algo_retrieve_storage_addresses_update_with_cache(self):
         url = reverse('substrapp:algo-detail', args=[algo[0]['key']])
@@ -262,16 +262,16 @@ class AlgoViewTests(APITestCase):
             mget_remote_asset.return_value = b'dummy binary content'
             ledger_algo = copy.deepcopy(algo[0])
             for field in ('description', 'content'):
-                ledger_algo[field]['storageAddress'] = \
-                    ledger_algo[field]['storageAddress'].replace('http://testserver',
-                                                                 'http://remotetestserver')
+                ledger_algo[field]['storage_address'] = \
+                    ledger_algo[field]['storage_address'].replace('http://testserver',
+                                                                  'http://remotetestserver')
             mquery_ledger.return_value = ledger_algo
 
             # actual test
             res = self.client.get(url, **self.extra)
             for field in ('description', 'content'):
-                self.assertEqual(res.data[field]['storageAddress'],
-                                 algo[0][field]['storageAddress'])
+                self.assertEqual(res.data[field]['storage_address'],
+                                 algo[0][field]['storage_address'])
 
     def test_algo_retrieve_storage_addresses_update_without_cache(self):
         url = reverse('substrapp:algo-detail', args=[algo[0]['key']])
@@ -284,13 +284,13 @@ class AlgoViewTests(APITestCase):
             mget_remote_asset.return_value = b'dummy binary content'
             ledger_algo = copy.deepcopy(algo[0])
             for field in ('description', 'content'):
-                ledger_algo[field]['storageAddress'] = \
-                    ledger_algo[field]['storageAddress'].replace('http://testserver',
-                                                                 'http://remotetestserver')
+                ledger_algo[field]['storage_address'] = \
+                    ledger_algo[field]['storage_address'].replace('http://testserver',
+                                                                  'http://remotetestserver')
             mquery_ledger.return_value = ledger_algo
 
             # actual test
             res = self.client.get(url, **self.extra)
             for field in ('description', 'content'):
-                self.assertEqual(res.data[field]['storageAddress'],
-                                 algo[0][field]['storageAddress'])
+                self.assertEqual(res.data[field]['storage_address'],
+                                 algo[0][field]['storage_address'])

--- a/backend/substrapp/tests/views/tests_views_compositealgo.py
+++ b/backend/substrapp/tests/views/tests_views_compositealgo.py
@@ -146,7 +146,7 @@ class CompositeAlgoViewTests(APITestCase):
     def test_composite_algo_list_filter_model(self):
         url = reverse('substrapp:composite_algo-list')
         done_model = [
-            m for m in model if 'compositeTraintuple' in m and m['compositeTraintuple']['status'] == 'done'
+            m for m in model if 'composite_traintuple' in m and m['composite_traintuple']['status'] == 'done'
         ][0]
 
         with mock.patch('substrapp.views.compositealgo.query_ledger') as mquery_ledger, \
@@ -154,7 +154,7 @@ class CompositeAlgoViewTests(APITestCase):
             mquery_ledger.return_value = compositealgo
             mquery_ledger2.return_value = model
 
-            pkhash = done_model['compositeTraintuple']['outTrunkModel']['outModel']['hash']
+            pkhash = done_model['composite_traintuple']['out_trunk_model']['out_model']['hash']
             search_params = f'?search=model%253Ahash%253A{pkhash}'
             response = self.client.get(url + search_params, **self.extra)
             r = response.json()
@@ -254,9 +254,9 @@ class CompositeAlgoViewTests(APITestCase):
             ledger_composite_algos = copy.deepcopy(compositealgo)
             for ledger_composite_algo in ledger_composite_algos:
                 for field in ('description', 'content'):
-                    ledger_composite_algo[field]['storageAddress'] = \
-                        ledger_composite_algo[field]['storageAddress'].replace('http://testserver',
-                                                                               'http://remotetestserver')
+                    ledger_composite_algo[field]['storage_address'] = \
+                        ledger_composite_algo[field]['storage_address'].replace('http://testserver',
+                                                                                'http://remotetestserver')
             mquery_ledger.return_value = ledger_composite_algos
 
             # actual test
@@ -265,8 +265,8 @@ class CompositeAlgoViewTests(APITestCase):
             self.assertEqual(len(res_composite_algos), len(compositealgo))
             for i, res_composite_algo in enumerate(res_composite_algos):
                 for field in ('description', 'content'):
-                    self.assertEqual(res_composite_algo[field]['storageAddress'],
-                                     compositealgo[i][field]['storageAddress'])
+                    self.assertEqual(res_composite_algo[field]['storage_address'],
+                                     compositealgo[i][field]['storage_address'])
 
     def test_composite_algo_retrieve_storage_addresses_update_with_cache(self):
         url = reverse('substrapp:composite_algo-detail', args=[compositealgo[0]['key']])
@@ -279,16 +279,16 @@ class CompositeAlgoViewTests(APITestCase):
             mget_remote_asset.return_value = b'dummy binary content'
             ledger_composite_algo = copy.deepcopy(compositealgo[0])
             for field in ('description', 'content'):
-                ledger_composite_algo[field]['storageAddress'] = \
-                    ledger_composite_algo[field]['storageAddress'].replace('http://testserver',
-                                                                           'http://remotetestserver')
+                ledger_composite_algo[field]['storage_address'] = \
+                    ledger_composite_algo[field]['storage_address'].replace('http://testserver',
+                                                                            'http://remotetestserver')
             mquery_ledger.return_value = ledger_composite_algo
 
             # actual test
             res = self.client.get(url, **self.extra)
             for field in ('description', 'content'):
-                self.assertEqual(res.data[field]['storageAddress'],
-                                 compositealgo[0][field]['storageAddress'])
+                self.assertEqual(res.data[field]['storage_address'],
+                                 compositealgo[0][field]['storage_address'])
 
     def test_composite_algo_retrieve_storage_addresses_update_without_cache(self):
         url = reverse('substrapp:composite_algo-detail', args=[compositealgo[0]['key']])
@@ -301,13 +301,13 @@ class CompositeAlgoViewTests(APITestCase):
             mget_remote_asset.return_value = b'dummy binary content'
             ledger_composite_algo = copy.deepcopy(compositealgo[0])
             for field in ('description', 'content'):
-                ledger_composite_algo[field]['storageAddress'] = \
-                    ledger_composite_algo[field]['storageAddress'].replace('http://testserver',
-                                                                           'http://remotetestserver')
+                ledger_composite_algo[field]['storage_address'] = \
+                    ledger_composite_algo[field]['storage_address'].replace('http://testserver',
+                                                                            'http://remotetestserver')
             mquery_ledger.return_value = ledger_composite_algo
 
             # actual test
             res = self.client.get(url, **self.extra)
             for field in ('description', 'content'):
-                self.assertEqual(res.data[field]['storageAddress'],
-                                 compositealgo[0][field]['storageAddress'])
+                self.assertEqual(res.data[field]['storage_address'],
+                                 compositealgo[0][field]['storage_address'])

--- a/backend/substrapp/tests/views/tests_views_compositetraintuples.py
+++ b/backend/substrapp/tests/views/tests_views_compositetraintuples.py
@@ -24,7 +24,7 @@ MEDIA_ROOT = "/tmp/unittests_views/"
 
 def get_compute_plan_id(assets):
     for asset in assets:
-        compute_plan_id = asset.get('computePlanID')
+        compute_plan_id = asset.get('compute_plan_id')
         if compute_plan_id:
             return compute_plan_id
     raise Exception('Could not find a compute plan ID')

--- a/backend/substrapp/tests/views/tests_views_computeplan.py
+++ b/backend/substrapp/tests/views/tests_views_computeplan.py
@@ -87,7 +87,7 @@ class ComputePlanViewTests(APITestCase):
         with mock.patch('substrapp.views.computeplan.get_object_from_ledger') as mget_object_from_ledger:
             mget_object_from_ledger.return_value = computeplan[0]
 
-            url = reverse('substrapp:compute_plan-detail', args=[computeplan[0]['computePlanID']])
+            url = reverse('substrapp:compute_plan-detail', args=[computeplan[0]['compute_plan_id']])
             response = self.client.get(url, **self.extra)
             r = response.json()
 
@@ -109,13 +109,13 @@ class ComputePlanViewTests(APITestCase):
         with mock.patch('substrapp.views.computeplan.get_object_from_ledger') as mget_object_from_ledger:
             mget_object_from_ledger.side_effect = LedgerError('TEST')
 
-            search_params = computeplan[0]['computePlanID']
+            search_params = computeplan[0]['compute_plan_id']
             response = self.client.get(url + search_params + '/', **self.extra)
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_computeplan_cancel(self):
         cp = computeplan[0]
-        key = cp['computePlanID']
+        key = cp['compute_plan_id']
         with mock.patch('substrapp.views.computeplan.invoke_ledger') as minvoke_ledger:
             minvoke_ledger.return_value = cp
 
@@ -126,7 +126,7 @@ class ComputePlanViewTests(APITestCase):
 
     def test_computeplan_update(self):
         cp = computeplan[0]
-        compute_plan_id = cp['computePlanID']
+        compute_plan_id = cp['compute_plan_id']
         url = reverse('substrapp:compute_plan-update-ledger', args=[compute_plan_id])
 
         with mock.patch('substrapp.ledger.update_computeplan', return_value=cp):

--- a/backend/substrapp/tests/views/tests_views_datamanager.py
+++ b/backend/substrapp/tests/views/tests_views_datamanager.py
@@ -94,7 +94,7 @@ class DataManagerViewTests(APITestCase):
     def test_datamanager_list_filter_objective(self):
         url = reverse('substrapp:data_manager-list')
 
-        objective_key = datamanager[0]['objectiveKey']
+        objective_key = datamanager[0]['objective_key']
         objective_to_filter = encode_filter([o for o in objective
                                              if o['key'] == objective_key].pop()['name'])
 
@@ -113,14 +113,14 @@ class DataManagerViewTests(APITestCase):
         url = reverse('substrapp:data_manager-list')
         done_model = [
             m for m in model
-            if 'traintuple' in m and m['traintuple']['status'] == 'done' and m['testtuple']['traintupleKey']
+            if 'traintuple' in m and m['traintuple']['status'] == 'done' and m['testtuple']['traintuple_key']
         ][0]
 
         with mock.patch('substrapp.views.datamanager.query_ledger') as mquery_ledger, \
                 mock.patch('substrapp.views.filters_utils.query_ledger') as mquery_ledger2:
             mquery_ledger.return_value = datamanager
             mquery_ledger2.return_value = model
-            pkhash = done_model['traintuple']['outModel']['hash']
+            pkhash = done_model['traintuple']['out_model']['hash']
             search_params = f'?search=model%253Ahash%253A{pkhash}'
             response = self.client.get(url + search_params, **self.extra)
             r = response.json()
@@ -186,8 +186,8 @@ class DataManagerViewTests(APITestCase):
             ledger_datamanagers = copy.deepcopy(datamanager)
             for ledger_datamanager in ledger_datamanagers:
                 for field in ('description', 'opener'):
-                    ledger_datamanager[field]['storageAddress'] = \
-                        ledger_datamanager[field]['storageAddress'] \
+                    ledger_datamanager[field]['storage_address'] = \
+                        ledger_datamanager[field]['storage_address'] \
                         .replace('http://testserver', 'http://remotetestserver')
             mquery_ledger.return_value = ledger_datamanagers
 
@@ -197,8 +197,8 @@ class DataManagerViewTests(APITestCase):
             self.assertEqual(len(res_datamanagers), len(datamanager))
             for i, res_datamanager in enumerate(res_datamanagers):
                 for field in ('description', 'opener'):
-                    self.assertEqual(res_datamanager[field]['storageAddress'],
-                                     datamanager[i][field]['storageAddress'])
+                    self.assertEqual(res_datamanager[field]['storage_address'],
+                                     datamanager[i][field]['storage_address'])
 
     def test_datamanager_retrieve_storage_addresses_update_with_cache(self):
         url = reverse('substrapp:data_manager-detail', args=[datamanager[0]['key']])
@@ -211,16 +211,16 @@ class DataManagerViewTests(APITestCase):
             mget_remote_asset.return_value = b'dummy binary content'
             ledger_datamanager = copy.deepcopy(datamanager[0])
             for field in ('description', 'opener'):
-                ledger_datamanager[field]['storageAddress'] = \
-                    ledger_datamanager[field]['storageAddress'].replace('http://testserver',
-                                                                        'http://remotetestserver')
+                ledger_datamanager[field]['storage_address'] = \
+                    ledger_datamanager[field]['storage_address'].replace('http://testserver',
+                                                                         'http://remotetestserver')
             mquery_ledger.return_value = ledger_datamanager
 
             # actual test
             res = self.client.get(url, **self.extra)
             for field in ('description', 'opener'):
-                self.assertEqual(res.data[field]['storageAddress'],
-                                 datamanager[0][field]['storageAddress'])
+                self.assertEqual(res.data[field]['storage_address'],
+                                 datamanager[0][field]['storage_address'])
 
     def test_datamanager_retrieve_storage_addresses_update_without_cache(self):
         url = reverse('substrapp:data_manager-detail', args=[datamanager[0]['key']])
@@ -233,13 +233,13 @@ class DataManagerViewTests(APITestCase):
             mget_remote_asset.return_value = b'dummy binary content'
             ledger_datamanager = copy.deepcopy(datamanager[0])
             for field in ('description', 'opener'):
-                ledger_datamanager[field]['storageAddress'] = \
-                    ledger_datamanager[field]['storageAddress'].replace('http://testserver',
-                                                                        'http://remotetestserver')
+                ledger_datamanager[field]['storage_address'] = \
+                    ledger_datamanager[field]['storage_address'].replace('http://testserver',
+                                                                         'http://remotetestserver')
             mquery_ledger.return_value = ledger_datamanager
 
             # actual test
             res = self.client.get(url, **self.extra)
             for field in ('description', 'opener'):
-                self.assertEqual(res.data[field]['storageAddress'],
-                                 datamanager[0][field]['storageAddress'])
+                self.assertEqual(res.data[field]['storage_address'],
+                                 datamanager[0][field]['storage_address'])

--- a/backend/substrapp/tests/views/tests_views_model.py
+++ b/backend/substrapp/tests/views/tests_views_model.py
@@ -132,7 +132,7 @@ class ModelViewTests(APITestCase):
             get_remote_asset.return_value = self.model.read().encode()
 
             url = reverse('substrapp:model-list')
-            search_params = done_model['traintuple']['outModel']['hash'] + '/'
+            search_params = done_model['traintuple']['out_model']['hash'] + '/'
             response = self.client.get(url + search_params, **self.extra)
             r = response.json()
             self.assertEqual(r, done_model)

--- a/backend/substrapp/tests/views/tests_views_objective.py
+++ b/backend/substrapp/tests/views/tests_views_objective.py
@@ -126,7 +126,7 @@ class ObjectiveViewTests(APITestCase):
     def test_objective_list_filter_datamanager(self):
         url = reverse('substrapp:objective-list')
 
-        datamanager_key = objective[0]['testDataset']['dataManagerKey']
+        datamanager_key = objective[0]['test_dataset']['data_manager_key']
         datamanager_to_filter = encode_filter([dm for dm in datamanager
                                                if dm['key'] == datamanager_key].pop()['name'])
         with mock.patch('substrapp.views.objective.query_ledger') as mquery_ledger, \
@@ -151,7 +151,7 @@ class ObjectiveViewTests(APITestCase):
             mquery_ledger.return_value = objective
             mquery_ledger2.return_value = model
 
-            pkhash = done_model['traintuple']['outModel']['hash']
+            pkhash = done_model['traintuple']['out_model']['hash']
             search_params = f'?search=model%253Ahash%253A{pkhash}'
             response = self.client.get(url + search_params, **self.extra)
             r = response.json()
@@ -285,8 +285,8 @@ class ObjectiveViewTests(APITestCase):
             ledger_objectives = copy.deepcopy(objective)
             for ledger_objective in ledger_objectives:
                 for field in ('description', 'metrics'):
-                    ledger_objective[field]['storageAddress'] = \
-                        ledger_objective[field]['storageAddress'] \
+                    ledger_objective[field]['storage_address'] = \
+                        ledger_objective[field]['storage_address'] \
                         .replace('http://testserver', 'http://remotetestserver')
             mquery_ledger.return_value = ledger_objectives
 
@@ -296,8 +296,8 @@ class ObjectiveViewTests(APITestCase):
             self.assertEqual(len(res_objectives), len(objective))
             for i, res_objective in enumerate(res_objectives):
                 for field in ('description', 'metrics'):
-                    self.assertEqual(res_objective[field]['storageAddress'],
-                                     objective[i][field]['storageAddress'])
+                    self.assertEqual(res_objective[field]['storage_address'],
+                                     objective[i][field]['storage_address'])
 
     def test_objective_retrieve_storage_addresses_update_with_cache(self):
         url = reverse('substrapp:objective-detail', args=[objective[0]['key']])
@@ -310,16 +310,16 @@ class ObjectiveViewTests(APITestCase):
             mget_remote_asset.return_value = b'dummy binary content'
             ledger_objective = copy.deepcopy(objective[0])
             for field in ('description', 'metrics'):
-                ledger_objective[field]['storageAddress'] = \
-                    ledger_objective[field]['storageAddress'].replace('http://testserver',
-                                                                      'http://remotetestserver')
+                ledger_objective[field]['storage_address'] = \
+                    ledger_objective[field]['storage_address'].replace('http://testserver',
+                                                                       'http://remotetestserver')
             mquery_ledger.return_value = ledger_objective
 
             # actual test
             res = self.client.get(url, **self.extra)
             for field in ('description', 'metrics'):
-                self.assertEqual(res.data[field]['storageAddress'],
-                                 objective[0][field]['storageAddress'])
+                self.assertEqual(res.data[field]['storage_address'],
+                                 objective[0][field]['storage_address'])
 
     def test_objective_retrieve_storage_addresses_update_without_cache(self):
         url = reverse('substrapp:objective-detail', args=[objective[0]['key']])
@@ -332,13 +332,13 @@ class ObjectiveViewTests(APITestCase):
             mget_remote_asset.return_value = b'dummy binary content'
             ledger_objective = copy.deepcopy(objective[0])
             for field in ('description', 'metrics'):
-                ledger_objective[field]['storageAddress'] = \
-                    ledger_objective[field]['storageAddress'].replace('http://testserver',
-                                                                      'http://remotetestserver')
+                ledger_objective[field]['storage_address'] = \
+                    ledger_objective[field]['storage_address'].replace('http://testserver',
+                                                                       'http://remotetestserver')
             mquery_ledger.return_value = ledger_objective
 
             # actual test
             res = self.client.get(url, **self.extra)
             for field in ('description', 'metrics'):
-                self.assertEqual(res.data[field]['storageAddress'],
-                                 objective[0][field]['storageAddress'])
+                self.assertEqual(res.data[field]['storage_address'],
+                                 objective[0][field]['storage_address'])

--- a/backend/substrapp/tests/views/tests_views_tuples.py
+++ b/backend/substrapp/tests/views/tests_views_tuples.py
@@ -25,7 +25,7 @@ MEDIA_ROOT = "/tmp/unittests_views/"
 
 def get_compute_plan_id(assets):
     for asset in assets:
-        compute_plan_id = asset.get('computePlanID')
+        compute_plan_id = asset.get('compute_plan_id')
         if compute_plan_id:
             return compute_plan_id
     raise Exception('Could not find a compute plan ID')
@@ -119,7 +119,7 @@ class TraintupleViewTests(APITestCase):
         with mock.patch('substrapp.views.traintuple.query_ledger') as mquery_ledger:
             mquery_ledger.return_value = traintuple
             compute_plan_id = get_compute_plan_id(traintuple)
-            search_params = f'?search=traintuple%253AcomputePlanID%253A{compute_plan_id}'
+            search_params = f'?search=traintuple%253Acompute_plan_id%253A{compute_plan_id}'
             response = self.client.get(url + search_params, **self.extra)
             r = response.json()
 

--- a/backend/substrapp/views/aggregatealgo.py
+++ b/backend/substrapp/views/aggregatealgo.py
@@ -20,9 +20,9 @@ from substrapp.views.filters_utils import filter_list
 
 
 def replace_storage_addresses(request, aggregate_algo):
-    aggregate_algo['description']['storageAddress'] = request.build_absolute_uri(
+    aggregate_algo['description']['storage_address'] = request.build_absolute_uri(
         reverse('substrapp:aggregate_algo-description', args=[aggregate_algo['key']]))
-    aggregate_algo['content']['storageAddress'] = request.build_absolute_uri(
+    aggregate_algo['content']['storage_address'] = request.build_absolute_uri(
         reverse('substrapp:aggregate_algo-file', args=[aggregate_algo['key']])
     )
 
@@ -119,7 +119,7 @@ class AggregateAlgoViewSet(mixins.CreateModelMixin,
 
     def create_or_update_aggregate_algo(self, channel_name, aggregate_algo, pk):
         # get Aggregatealgo description from remote node
-        url = aggregate_algo['description']['storageAddress']
+        url = aggregate_algo['description']['storage_address']
 
         content = get_remote_asset(channel_name, url, aggregate_algo['owner'], aggregate_algo['description']['hash'])
 

--- a/backend/substrapp/views/algo.py
+++ b/backend/substrapp/views/algo.py
@@ -20,9 +20,9 @@ from substrapp.views.filters_utils import filter_list
 
 
 def replace_storage_addresses(request, algo):
-    algo['description']['storageAddress'] = request.build_absolute_uri(
+    algo['description']['storage_address'] = request.build_absolute_uri(
         reverse('substrapp:algo-description', args=[algo['key']]))
-    algo['content']['storageAddress'] = request.build_absolute_uri(
+    algo['content']['storage_address'] = request.build_absolute_uri(
         reverse('substrapp:algo-file', args=[algo['key']])
     )
 
@@ -123,7 +123,7 @@ class AlgoViewSet(mixins.CreateModelMixin,
 
     def create_or_update_algo(self, channel_name, algo, pk):
         # get algo description from remote node
-        url = algo['description']['storageAddress']
+        url = algo['description']['storage_address']
 
         content = get_remote_asset(channel_name, url, algo['owner'], algo['description']['hash'])
 

--- a/backend/substrapp/views/compositealgo.py
+++ b/backend/substrapp/views/compositealgo.py
@@ -20,9 +20,9 @@ from substrapp.views.filters_utils import filter_list
 
 
 def replace_storage_addresses(request, composite_algo):
-    composite_algo['description']['storageAddress'] = request.build_absolute_uri(
+    composite_algo['description']['storage_address'] = request.build_absolute_uri(
         reverse('substrapp:composite_algo-description', args=[composite_algo['key']]))
-    composite_algo['content']['storageAddress'] = request.build_absolute_uri(
+    composite_algo['content']['storage_address'] = request.build_absolute_uri(
         reverse('substrapp:composite_algo-file', args=[composite_algo['key']])
     )
 
@@ -119,7 +119,7 @@ class CompositeAlgoViewSet(mixins.CreateModelMixin,
 
     def create_or_update_composite_algo(self, channel_name, composite_algo, pk):
         # get Compositealgo description from remote node
-        url = composite_algo['description']['storageAddress']
+        url = composite_algo['description']['storage_address']
 
         content = get_remote_asset(channel_name, url, composite_algo['owner'], composite_algo['description']['hash'])
 

--- a/backend/substrapp/views/computeplan.py
+++ b/backend/substrapp/views/computeplan.py
@@ -34,11 +34,11 @@ class ComputePlanViewSet(mixins.CreateModelMixin,
             return Response(error, status=e.status)
 
         # create compute plan in ledger
-        compute_plan_id = ledger_response.get('computePlanID')
+        compute_plan_id = ledger_response.get('compute_plan_id')
         try:
             data = serializer.create(get_channel_name(request), serializer.validated_data)
         except LedgerError as e:
-            error = {'message': str(e.msg), 'computePlanID': compute_plan_id}
+            error = {'message': str(e.msg), 'compute_plan_id': compute_plan_id}
             return Response(error, status=e.status)
 
         # send successful response
@@ -106,7 +106,7 @@ class ComputePlanViewSet(mixins.CreateModelMixin,
         try:
             data = serializer.update(get_channel_name(request), compute_plan_id, serializer.validated_data)
         except LedgerError as e:
-            error = {'message': str(e.msg), 'computePlanID': compute_plan_id}
+            error = {'message': str(e.msg), 'compute_plan_id': compute_plan_id}
             return Response(error, status=e.status)
 
         # send successful response

--- a/backend/substrapp/views/datamanager.py
+++ b/backend/substrapp/views/datamanager.py
@@ -21,9 +21,9 @@ from substrapp.views.filters_utils import filter_list
 
 
 def replace_storage_addresses(request, data_manager):
-    data_manager['description']['storageAddress'] = request.build_absolute_uri(
+    data_manager['description']['storage_address'] = request.build_absolute_uri(
         reverse('substrapp:data_manager-description', args=[data_manager['key']]))
-    data_manager['opener']['storageAddress'] = request.build_absolute_uri(
+    data_manager['opener']['storage_address'] = request.build_absolute_uri(
         reverse('substrapp:data_manager-opener', args=[data_manager['key']])
     )
 
@@ -135,7 +135,7 @@ class DataManagerViewSet(mixins.CreateModelMixin,
                 pkhash=pk, name=datamanager['name'], validated=True)
 
         if not instance.data_opener:
-            url = datamanager['opener']['storageAddress']
+            url = datamanager['opener']['storage_address']
 
             content = get_remote_asset(channel_name, url, datamanager['owner'], datamanager['opener']['hash'])
 
@@ -147,7 +147,7 @@ class DataManagerViewSet(mixins.CreateModelMixin,
 
         # do the same for description
         if not instance.description:
-            url = datamanager['description']['storageAddress']
+            url = datamanager['description']['storage_address']
 
             content = get_remote_asset(channel_name, url, datamanager['owner'], datamanager['description']['hash'])
 

--- a/backend/substrapp/views/filters_utils.py
+++ b/backend/substrapp/views/filters_utils.py
@@ -86,11 +86,12 @@ def _get_model_tuple(model):
 
         model:attribute:value
 
-    Where "attribute" is actually an attribute of the model's traintuple or compositeTraintuple (depending on its type).
+    Where "attribute" is actually an attribute of the model's traintuple or
+    composite_traintuple (depending on its type).
     """
 
-    if 'compositeTraintuple' in model:
-        return model['compositeTraintuple']
+    if 'composite_traintuple' in model:
+        return model['composite_traintuple']
     elif 'aggregatetuple' in model:
         return model['aggregatetuple']
     elif 'traintuple' in model:
@@ -159,16 +160,16 @@ def filter_list(channel_name, object_type, data, query_params):
                             x for x in filtering_data
                             if (
                                 (
-                                    _get_model_tuple(x).get('outModel') and
-                                    _get_model_tuple(x)['outModel'][attribute] in val
+                                    _get_model_tuple(x).get('out_model') and
+                                    _get_model_tuple(x)['out_model'][attribute] in val
                                 ) or (
-                                    _get_model_tuple(x).get('outTrunkModel') and
-                                    _get_model_tuple(x)['outTrunkModel'].get('outModel') and
-                                    _get_model_tuple(x)['outTrunkModel']['outModel'][attribute] in val
+                                    _get_model_tuple(x).get('out_trunk_model') and
+                                    _get_model_tuple(x)['out_trunk_model'].get('out_model') and
+                                    _get_model_tuple(x)['out_trunk_model']['out_model'][attribute] in val
                                 ) or (
-                                    _get_model_tuple(x).get('outHeadModel') and
-                                    _get_model_tuple(x)['outHeadModel'].get('outModel') and
-                                    _get_model_tuple(x)['outHeadModel']['outModel'][attribute] in val
+                                    _get_model_tuple(x).get('out_head_model') and
+                                    _get_model_tuple(x)['out_head_model'].get('out_model') and
+                                    _get_model_tuple(x)['out_head_model']['out_model'][attribute] in val
                                 )
                             )
                         ]
@@ -181,11 +182,11 @@ def filter_list(channel_name, object_type, data, query_params):
                             hashes = []
                             for x in filtering_data:
                                 try:
-                                    hashes.append(x['testtuple']['dataset']['openerHash'])
+                                    hashes.append(x['testtuple']['dataset']['opener_hash'])
                                 except KeyError:
                                     pass
                                 try:
-                                    hashes.append(_get_model_tuple(x)['dataset']['openerHash'])
+                                    hashes.append(_get_model_tuple(x)['dataset']['opener_hash'])
                                 except KeyError:
                                     pass
 
@@ -208,12 +209,12 @@ def filter_list(channel_name, object_type, data, query_params):
 
                         if object_type == 'model':
                             filtered_list = [x for x in filtered_list
-                                             if _get_model_tuple(x).get('dataset', {}).get('openerHash') in hashes]
+                                             if _get_model_tuple(x).get('dataset', {}).get('opener_hash') in hashes]
                         elif object_type == 'objective':
-                            objective_keys = [x['objectiveKey'] for x in filtering_data]
+                            objective_keys = [x['objective_key'] for x in filtering_data]
                             filtered_list = [x for x in filtered_list
                                              if x['key'] in objective_keys or
-                                             (x['testDataset'] and x['testDataset']['dataManagerKey'] in hashes)]
+                                             (x['test_dataset'] and x['test_dataset']['data_manager_key'] in hashes)]
 
                 elif filter_key == 'objective':
                     for attribute, val in subfilters.items():
@@ -232,7 +233,7 @@ def filter_list(channel_name, object_type, data, query_params):
                             ]
                         elif object_type == 'dataset':
                             filtered_list = [x for x in filtered_list
-                                             if x['objectiveKey'] in hashes]
+                                             if x['objective_key'] in hashes]
 
             object_list.append(filtered_list)
 

--- a/backend/substrapp/views/filters_utils.py
+++ b/backend/substrapp/views/filters_utils.py
@@ -174,7 +174,7 @@ def filter_list(channel_name, object_type, data, query_params):
                             )
                         ]
 
-                        if object_type in ['algo', 'composite_algo', 'aggregatealgo']:
+                        if object_type in ['algo', 'composite_algo', 'aggregate_algo']:
                             hashes = [_get_model_tuple(x)['algo']['hash'] for x in filtering_data]
                             filtered_list = [x for x in filtered_list if x['key'] in hashes]
 

--- a/backend/substrapp/views/model.py
+++ b/backend/substrapp/views/model.py
@@ -46,12 +46,12 @@ class ModelViewSet(mixins.RetrieveModelMixin,
 
         data = get_object_from_ledger(channel_name, pk, self.ledger_query_call)
 
-        compatible_tuple_types = ['traintuple', 'compositeTraintuple', 'aggregatetuple']
+        compatible_tuple_types = ['traintuple', 'composite_traintuple', 'aggregatetuple']
         any_data = any(list(map(lambda x: x in data, compatible_tuple_types)))
 
         if not any_data:
             raise Exception(
-                'Invalid model: missing traintuple, compositeTraintuple or aggregatetuple field'
+                'Invalid model: missing traintuple, composite_traintuple or aggregatetuple field'
             )
 
         return data

--- a/backend/substrapp/views/model.py
+++ b/backend/substrapp/views/model.py
@@ -124,7 +124,7 @@ class ModelPermissionViewSet(PermissionMixin,
         permissions = asset['process']
         node_id = user.username
 
-        return permissions['public'] or node_id in permissions['authorizedIDs']
+        return permissions['public'] or node_id in permissions['authorized_ids']
 
     @gzip_action
     @action(detail=True)

--- a/backend/substrapp/views/model.py
+++ b/backend/substrapp/views/model.py
@@ -25,11 +25,11 @@ class ModelViewSet(mixins.RetrieveModelMixin,
     # permission_classes = (permissions.IsAuthenticated,)
 
     def create_or_update_model(self, channel_name, traintuple, pk):
-        if traintuple['outModel'] is None:
-            raise Exception(f'This traintuple related to this model key {pk} does not have a outModel')
+        if traintuple['out_model'] is None:
+            raise Exception(f'This traintuple related to this model key {pk} does not have a out_model')
 
         # get model from remote node
-        url = traintuple['outModel']['storageAddress']
+        url = traintuple['out_model']['storage_address']
 
         content = get_remote_asset(channel_name, url, traintuple['creator'], traintuple['key'])
 

--- a/backend/substrapp/views/objective.py
+++ b/backend/substrapp/views/objective.py
@@ -25,9 +25,9 @@ from substrapp.views.filters_utils import filter_list
 
 
 def replace_storage_addresses(request, objective):
-    objective['description']['storageAddress'] = request.build_absolute_uri(
+    objective['description']['storage_address'] = request.build_absolute_uri(
         reverse('substrapp:objective-description', args=[objective['key']]))
-    objective['metrics']['storageAddress'] = request.build_absolute_uri(
+    objective['metrics']['storage_address'] = request.build_absolute_uri(
         reverse('substrapp:objective-metrics', args=[objective['key']])
     )
 
@@ -143,7 +143,7 @@ class ObjectiveViewSet(mixins.CreateModelMixin,
 
     def create_or_update_objective(self, channel_name, objective, pk):
         # get description from remote node
-        url = objective['description']['storageAddress']
+        url = objective['description']['storage_address']
 
         content = get_remote_asset(channel_name, url, objective['owner'], pk)
 

--- a/backend/substrapp/views/utils.py
+++ b/backend/substrapp/views/utils.py
@@ -48,7 +48,7 @@ class CustomFileResponse(FileResponse):
 def node_has_process_permission(asset):
     """Check if current node can process input asset."""
     permission = asset['permissions']['process']
-    return permission['public'] or get_owner() in permission['authorizedIDs']
+    return permission['public'] or get_owner() in permission['authorized_ids']
 
 
 class PermissionMixin(object):
@@ -67,7 +67,7 @@ class PermissionMixin(object):
         else:  # for classic user, test on current msp id
             node_id = get_owner()
 
-        return permission['public'] or node_id in permission['authorizedIDs']
+        return permission['public'] or node_id in permission['authorized_ids']
 
     def download_file(self, request, django_field, ledger_field=None):
         lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
@@ -123,7 +123,7 @@ class PermissionMixin(object):
     def _download_remote_file(self, channel_name, ledger_field, asset):
         node_id = asset['owner']
         auth = authenticate_outgoing_request(node_id)
-        r = get_remote_file(channel_name, asset[ledger_field]['storageAddress'], auth, stream=True)
+        r = get_remote_file(channel_name, asset[ledger_field]['storage_address'], auth, stream=True)
         if not r.ok:
             return Response({
                 'message': f'Cannot proxify asset from node {asset["owner"]}: {str(r.text)}'


### PR DESCRIPTION
The backend responses should be more consistent. The goal of this PR is to make sure that all inputs fields and response fields of backend endpoints are in snake_case format.

PRs:
https://github.com/SubstraFoundation/substra-backend/pull/315
https://github.com/SubstraFoundation/substra/pull/222
https://github.com/SubstraFoundation/substra-tests/pull/142
