### PR TITLE
Add dev frontend to list of CORS whitelist

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -171,7 +171,7 @@ deploy:
           extraEnv:
             # Should be a json list
             - name: CORS_ORIGIN_WHITELIST
-              value: '["http://substra-frontend.node-1.com/"]'
+              value: '["http://substra-frontend.node-1.com/", "http://substra-frontend.node-1.com:3000/", "http://substra-frontend.node-1.com:3001/"]'
             - name: CORS_ALLOW_CREDENTIALS
               value: "true"
             - name: DEFAULT_THROTTLE_RATES
@@ -254,7 +254,7 @@ deploy:
           extraEnv:
             # Should be a json list
             - name: CORS_ORIGIN_WHITELIST
-              value: '["http://substra-frontend.node-2.com/"]'
+              value: '["http://substra-frontend.node-2.com/", "http://substra-frontend.node-2.com:3000/", "http://substra-frontend.node-2.com:3001/"]'
             - name: CORS_ALLOW_CREDENTIALS
               value: "true"
             - name: DEFAULT_THROTTLE_RATES


### PR DESCRIPTION
When launching the frontend locally through yarn, it is served at port 3000 (dev mode) or 3001 (prod mode). It was previously rejected by the backend because not in the CORS whitelist.