### PR TITLE
GRPC: add keepalive (120 sec)

### DIFF
--- a/backend/events/apps.py
+++ b/backend/events/apps.py
@@ -154,7 +154,7 @@ def wait(channel_name):
 
         target_peer.init_with_bundle({
             'url': f'{peer["host"]}:{peer_port}',
-            'grpcOptions': peer['grpcOptions'],
+            'grpcOptions': LEDGER['grpc_options'](peer["host"]),
             'tlsCACerts': {'path': peer['tlsCACerts']},
             'clientKey': {'path': peer['clientKey']},
             'clientCert': {'path': peer['clientCert']},
@@ -209,8 +209,8 @@ class EventsConfig(AppConfig):
     name = 'events'
 
     def listen_to_channel(self, channel_name):
-        # We try to connect a client first, if it fails the backend will not start
-        # It avoid potential issue when we launch the channel event hub in a subprocess
+        # We try to connect a client first, if it fails the backend will not start.
+        # It prevents potential issues when we launch the channel event hub in a subprocess.
         while True:
             try:
                 with get_hfc(channel_name) as (loop, client):

--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.1
+
+- added `grpc.keepalive.timeMs`
+
 ## 1.1.0
 
 - `channel` (scalar type) is replaced with `channels` (list type)

--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.1
 
-- added `grpc.keepalive.timeMs`
+- added `backend.grpc.keepalive.timeMs`
 
 ## 1.1.0
 

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-backend
 home: https://substra.org/
-version: 1.1.0
+version: 1.1.1
 description: Main package for Substra
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/substra-backend/templates/configmap-server.yaml
+++ b/charts/substra-backend/templates/configmap-server.yaml
@@ -28,15 +28,18 @@ data:
         "docker_core_dir": "/var/hyperledger/fabric_cfg",
         "tlsCACerts": "/var/hyperledger/ca/cacert.pem",
         "clientKey": "/var/hyperledger/tls/client/pair/tls.key",
-        "clientCert": "/var/hyperledger/tls/client/pair/tls.crt",
-        "grpcOptions": {
-          "grpc.ssl_target_name_override": "{{ .Values.peer.host }}",
-          "grpc.max_send_message_length": -1,
-          "grpc.max_receive_message_length": -1
-        }
+        "clientCert": "/var/hyperledger/tls/client/pair/tls.crt"
+      },
+      "grpcOptions": {
+        "grpc.max_send_message_length": -1,
+        "grpc.max_receive_message_length": -1,
+        "grpc.keepalive_time_ms": {{ .Values.grpc.keepalive.timeMs }},
+        "grpc.http2.min_time_between_pings_ms": {{ .Values.grpc.keepalive.timeMs }},
+        "grpc.keepalive_timeout_ms": 20000,
+        "grpc.http2.max_pings_without_data": 0,
+        "grpc.keepalive_permit_without_calls": 1
       }
     }
-
 ---
 
 apiVersion: v1

--- a/charts/substra-backend/templates/configmap-server.yaml
+++ b/charts/substra-backend/templates/configmap-server.yaml
@@ -33,8 +33,8 @@ data:
       "grpcOptions": {
         "grpc.max_send_message_length": -1,
         "grpc.max_receive_message_length": -1,
-        "grpc.keepalive_time_ms": {{ .Values.grpc.keepalive.timeMs }},
-        "grpc.http2.min_time_between_pings_ms": {{ .Values.grpc.keepalive.timeMs }},
+        "grpc.keepalive_time_ms": {{ .Values.backend.grpc.keepalive.timeMs }},
+        "grpc.http2.min_time_between_pings_ms": {{ .Values.backend.grpc.keepalive.timeMs }},
         "grpc.keepalive_timeout_ms": 20000,
         "grpc.http2.max_pings_without_data": 0,
         "grpc.keepalive_permit_without_calls": 1

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -58,6 +58,11 @@ backend:
     #   cpu: 100m
     #   memory: 128Mi
 
+  grpc:
+    keepalive:
+      timeMs: 120000
+
+
 outgoingNodes: []
   # - name: nodeId
   #   secret: nodeSecret
@@ -316,6 +321,3 @@ securityContext:
   runAsUser: 1001
   runAsGroup: 1001
 
-grpc:
-  keepalive:
-    timeMs: 120000

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -320,4 +320,3 @@ securityContext:
   fsGroup: 1001
   runAsUser: 1001
   runAsGroup: 1001
-

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -315,3 +315,7 @@ securityContext:
   fsGroup: 1001
   runAsUser: 1001
   runAsGroup: 1001
+
+grpc:
+  keepalive:
+    timeMs: 120000


### PR DESCRIPTION
Add a keepalive (120 sec) to all the GRPC links﻿.

This prevents links from being closed by network software/equipment because of inactivity.
