### PR TITLE
worker: don't use CUDA as base image

### DIFF
--- a/docker/celerybeat/Dockerfile
+++ b/docker/celerybeat/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir -p /usr/src/app && chown -R ${USER_ID}:${GROUP_ID} /usr/src/app
 WORKDIR /usr/src/app
 
 COPY ./backend/requirements.txt /usr/src/app/.
-RUN chown -R ${USER_ID}:${GROUP_ID} /usr/src/app/.
+RUN chown -R ${USER_ID}:${GROUP_ID} /usr/src/app
 
 RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt
@@ -18,7 +18,7 @@ COPY ./backend/backend /usr/src/app/backend
 COPY ./backend/node /usr/src/app/node
 COPY ./backend/users /usr/src/app/users
 
-RUN chown -R ${USER_ID}:${GROUP_ID} /usr/src/app/.
+RUN chown -R ${USER_ID}:${GROUP_ID} /usr/src/app
 
 
 USER ${USER_ID}:${GROUP_ID}

--- a/docker/celeryworker/Dockerfile
+++ b/docker/celeryworker/Dockerfile
@@ -1,8 +1,4 @@
-FROM nvidia/cuda:9.2-base-ubuntu18.04
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3-dev python3-pip python3-setuptools python3-wheel build-essential git && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+FROM python:3.6
 
 ARG USER_ID=1001
 ARG GROUP_ID=1001


### PR DESCRIPTION
The CUDA image isn't necessary in the worker anymore.

Use the python image to improve cache reuse across generated docker images (substra-backend / celeryworker / celerybeat)