### PR TITLE
Bump status check deadline

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -100,7 +100,7 @@ build:
           strip: backend/users/
 
 deploy:
-  statusCheckDeadlineSeconds: 300
+  statusCheckDeadlineSeconds: 600
   helm:
     releases:
       - name: backend-org-1


### PR DESCRIPTION
Some users have reported that 5 minutes is not enough time on their machines for the application to stabilize.﻿
