### PR TITLE
Revive sourceRegistry

### DIFF
--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -8,7 +8,6 @@
 - Added `backend.kaniko.cache.warmer.images` (replaces `prePulledImages`)
 - By default, don't warm up kaniko cache
 - By default, don't prepopulate local docker registry
-- Deleted `registry.prepopulate.sourceRegistry`
 
 ## 1.1.2
 

--- a/charts/substra-backend/README.md
+++ b/charts/substra-backend/README.md
@@ -29,7 +29,8 @@ The following table lists the configurable parameters of the substra-backend cha
 | `httpClient.timeoutSeconds` | The timeout in seconds for outgoing HTTP requests  | `30` |
 | `registry.prepopulate` | A list of docker images to prepopulate the local docker registry with | `[]` |
 | `registry.prepopulate[].image` | A docker image | (undefined) |
-| `registry.prepopulate[].dockerConfigSecretName` | The name of a kubernetes secret containing the docker config used to pull the docker image | (undefined) |
+| `registry.prepopulate[].sourceRegistry` | The URL of a docker registry to pull the image from (leave blank for Docker Hub) | (undefined) |
+| `registry.prepopulate[].dockerConfigSecretName` | Optionally, a docker config to use when pulling the docker image | (undefined) |
 | `users` | A list of users who can log into the backend | `[]` |
 | `users[].name` | The user login | (undefined) |
 | `users[].password` | The user password | (undefined) |

--- a/charts/substra-backend/templates/job-registry-prepopulate.yaml
+++ b/charts/substra-backend/templates/job-registry-prepopulate.yaml
@@ -59,6 +59,10 @@ metadata:
     name: {{ template "substra.fullname" $ }}-registry-prepopulate-dockerfile-{{ $index }}
 data:
     Dockerfile: |
+      {{- if .sourceRegistry }}
+      FROM {{ .sourceRegistry }}/{{ .image }}
+      {{- else }}
       FROM {{ .image }}
+      {{ end }}
 {{- end }}
 {{- end }}

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -310,6 +310,7 @@ registry:
   ## Local registry pre-populate
   prepopulate: []
     # - image: substrafoundation/substra-tools:0.6.1
+    #   sourceRegistry: xxx.dkr.ecr.eu-west-1.amazonaws.com
     #   dockerConfigSecretName: docker-config
 
 ## Pod Security Policy


### PR DESCRIPTION
This chart parameter has been mistakenly deleted in https://github.com/SubstraFoundation/substra-backend/pull/326

We do need this parameter for melloddy deploys.﻿
