### PR TITLE
Faster startup in case of initialization error + more verbose logs

### DIFF
--- a/backend/node-register/apps.py
+++ b/backend/node-register/apps.py
@@ -4,8 +4,6 @@ from django.apps import AppConfig
 from django.conf import settings
 from substrapp.ledger_utils import invoke_ledger
 
-from aiogrpc import RpcError
-
 logger = logging.getLogger(__name__)
 LEDGER = getattr(settings, 'LEDGER', None)
 
@@ -19,14 +17,12 @@ class NodeRegisterConfig(AppConfig):
             try:
                 # args is set to empty because fabric-sdk-py doesn't allow None args for invoke operations
                 invoke_ledger(channel_name, fcn='registerNode', args=[''], sync=True)
-            except RpcError as e:
-                if not settings.DEBUG:
-                    raise
+            except Exception as e:
                 logger.exception(e)
-                time.sleep(5)
-                logger.info(f'({channel_name}) Retry to register the node to the ledger')
+                time.sleep(1)
+                logger.info(f'({channel_name}) Retry registring the node on the ledger')
             else:
-                logger.info(f'({channel_name}) Node registered in the ledger')
+                logger.info(f'({channel_name}) Node registered on the ledger')
                 return
 
     def ready(self):

--- a/charts/substra-backend/templates/configmap-server.yaml
+++ b/charts/substra-backend/templates/configmap-server.yaml
@@ -50,7 +50,6 @@ data:
   uwsgi.ini: |
     [uwsgi]
     module                        = backend.wsgi
-    log-master                    = true
     env                           = DJANGO_SETTINGS_MODULE=backend.settings.server.{{ .Values.backend.settings }}
     static-map                    = /static=/usr/src/app/backend/statics
 


### PR DESCRIPTION
This PR makes the startup faster and more verbose in case of initialization error (e.g. peer not in channel yet)

1. If an exception occurs when calling the ledger in the application initialization (register-node), do not crash the app. 

Instead, retry the ledger call indefinitely. This is faster than crashing the pod and waiting for it to restart. Note that kubernetes will still crash the pod if the readiness probe fails (i.e. initialization repeatedly fails for > 30 secs or so)


2. With the `log-master=true`﻿ option, no logs are output until the app initialization is complete or the pod is crashed. In other words, if the app initialization takes a long time, we can't see the logs until either the initialization finally succeeds, or the container is stopped by kubernetes.

![image](https://user-images.githubusercontent.com/168382/93654545-16e62100-f9ec-11ea-931e-555ebb4c6abd.png)

...wait...

...wait more...

...what is going on?....

After a good 30 seconds all the logs arrive at once

![image](https://user-images.githubusercontent.com/168382/93654609-675d7e80-f9ec-11ea-841a-61c8413fcdbe.png)

![image](https://user-images.githubusercontent.com/168382/93654600-5ca2e980-f9ec-11ea-90e3-0db6f95dc2f5.png)


This PR removes this option. As a result, logs aren't delayed anymore.
