### PR TITLE
Data samples order

### DIFF
--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -48,6 +48,7 @@ TUPLE_COMMANDS = {
     AGGREGATETUPLE_TYPE: 'aggregate',
 }
 
+DATA_FOLDER = '/sandbox/data'
 MODEL_FOLDER = '/sandbox/model'
 OUTPUT_MODEL_FOLDER = '/sandbox/output_model'
 OUTPUT_PERF_PATH = '/sandbox/perf/perf.json'
@@ -780,7 +781,7 @@ def prepare_volumes(subtuple_directory, tuple_type, compute_plan_key, compute_pl
                 symlinks_volume[real_path] = {'bind': f'{real_path}', 'mode': 'ro'}
 
     volumes = {
-        data_path: {'bind': '/sandbox/data', 'mode': 'ro'},
+        data_path: {'bind': DATA_FOLDER, 'mode': 'ro'},
         opener_path: {'bind': '/sandbox/opener', 'mode': 'ro'}
     }
 
@@ -873,6 +874,15 @@ def prepare_chainkeys(compute_plan_key, compute_plan_tag, subtuple_directory):
     return chainkeys_volume
 
 
+def add_data_sample_paths_arg(command, subtuple):
+    data_sample_paths = [
+        os.path.join(DATA_FOLDER, key)
+        for key in subtuple['dataset']['keys']
+    ]
+    data_sample_paths = ' '.join(data_sample_paths)
+    return f"{command} --data-sample-paths {data_sample_paths}"
+
+
 def generate_command(tuple_type, subtuple, rank):
 
     command = TUPLE_COMMANDS[tuple_type]
@@ -888,8 +898,7 @@ def generate_command(tuple_type, subtuple, rank):
         if rank is not None:
             command = f"{command} --rank {rank}"
 
-        data_sample_keys = ' '.join([k for k in subtuple['dataset']['keys']])
-        command = f"{command} --data-samples-order {data_sample_keys}"
+        command = add_data_sample_paths_arg(command, subtuple)
 
     elif tuple_type == TESTTUPLE_TYPE:
 
@@ -901,6 +910,8 @@ def generate_command(tuple_type, subtuple, rank):
         else:
             in_model = subtuple["traintuple_key"]
             command = f'{command} {in_model}'
+
+        command = add_data_sample_paths_arg(command, subtuple)
 
     elif tuple_type == COMPOSITE_TRAINTUPLE_TYPE:
 
@@ -922,8 +933,7 @@ def generate_command(tuple_type, subtuple, rank):
         if rank is not None:
             command = f"{command} --rank {rank}"
 
-        data_sample_keys = ' '.join([k for k in subtuple['dataset']['keys']])
-        command = f"{command} --data-samples-order {data_sample_keys}"
+        command = add_data_sample_paths_arg(command, subtuple)
 
     elif tuple_type == AGGREGATETUPLE_TYPE:
 

--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -888,6 +888,9 @@ def generate_command(tuple_type, subtuple, rank):
         if rank is not None:
             command = f"{command} --rank {rank}"
 
+        data_sample_keys = ' '.join([k for k in subtuple['dataset']['keys']])
+        command = f"{command} --data-samples-order {data_sample_keys}"
+
     elif tuple_type == TESTTUPLE_TYPE:
 
         if COMPOSITE_TRAINTUPLE_TYPE == subtuple['traintuple_type']:
@@ -918,6 +921,9 @@ def generate_command(tuple_type, subtuple, rank):
 
         if rank is not None:
             command = f"{command} --rank {rank}"
+
+        data_sample_keys = ' '.join([k for k in subtuple['dataset']['keys']])
+        command = f"{command} --data-samples-order {data_sample_keys}"
 
     elif tuple_type == AGGREGATETUPLE_TYPE:
 

--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -877,7 +877,7 @@ def prepare_chainkeys(compute_plan_key, compute_plan_tag, subtuple_directory):
 def add_data_sample_paths_arg(command, subtuple):
     data_sample_paths = [
         os.path.join(DATA_FOLDER, key)
-        for key in subtuple['dataset']['keys']
+        for key in subtuple['dataset']['data_sample_keys']
     ]
     data_sample_paths = ' '.join(data_sample_paths)
     return f"{command} --data-sample-paths {data_sample_paths}"

--- a/backend/substrapp/tests/tests_tasks.py
+++ b/backend/substrapp/tests/tests_tasks.py
@@ -399,7 +399,12 @@ class TasksTests(APITestCase):
                 self.MEDIA_ROOT = MEDIA_ROOT
 
         subtuple_key = 'test_owkin'
-        subtuple = {'key': subtuple_key, 'in_models': None, 'algo': {'key': 'mykey', 'checksum': 'myhash'}, 'dataset': {'keys': []}}
+        subtuple = {
+            'key': subtuple_key,
+            'in_models': None,
+            'algo': {'key': 'mykey', 'checksum': 'myhash'},
+            'dataset': {'keys': []},
+        }
         subtuple_directory = build_subtuple_folders(subtuple)
 
         with mock.patch('substrapp.tasks.tasks.settings') as msettings, \

--- a/backend/substrapp/tests/tests_tasks.py
+++ b/backend/substrapp/tests/tests_tasks.py
@@ -403,7 +403,7 @@ class TasksTests(APITestCase):
             'key': subtuple_key,
             'in_models': None,
             'algo': {'key': 'mykey', 'checksum': 'myhash'},
-            'dataset': {'keys': []},
+            'dataset': {'data_sample_keys': []},
         }
         subtuple_directory = build_subtuple_folders(subtuple)
 

--- a/backend/substrapp/tests/tests_tasks.py
+++ b/backend/substrapp/tests/tests_tasks.py
@@ -399,7 +399,7 @@ class TasksTests(APITestCase):
                 self.MEDIA_ROOT = MEDIA_ROOT
 
         subtuple_key = 'test_owkin'
-        subtuple = {'key': subtuple_key, 'in_models': None, 'algo': {'key': 'mykey', 'checksum': 'myhash'}}
+        subtuple = {'key': subtuple_key, 'in_models': None, 'algo': {'key': 'mykey', 'checksum': 'myhash'}, 'dataset': {'keys': []}}
         subtuple_directory = build_subtuple_folders(subtuple)
 
         with mock.patch('substrapp.tasks.tasks.settings') as msettings, \

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -15,7 +15,7 @@ backend:
       warmer:
         image: gcr.io/kaniko-project/warmer:v1.0.0
         images: []
-          # - image: substrafoundation/substra-tools:0.6.1
+          # - image: substrafoundation/substra-tools:0.7.0
 
   compute:
     registry: null  # Pull compute tasks images (image builder, cleanup, ...) from a custom registry
@@ -310,7 +310,7 @@ registry:
 
   ## Local registry pre-populate
   prepopulate: []
-    # - image: substrafoundation/substra-tools:0.6.1
+    # - image: substrafoundation/substra-tools:0.7.0
     #   sourceRegistry: xxx.dkr.ecr.eu-west-1.amazonaws.com
     #   dockerConfigSecretName: docker-config
 

--- a/values/backend-org-1.yaml
+++ b/values/backend-org-1.yaml
@@ -13,7 +13,7 @@ registry:
   scheme: http
   pullDomain: 127.0.0.1:32001
   prepopulate:
-    - image: substrafoundation/substra-tools:0.6.1-minimal
+    - image: substrafoundation/substra-tools:0.7.0-minimal
 
 secrets:
   fabricConfigmap: network-org-1-hlf-k8s-fabric
@@ -31,7 +31,7 @@ backend:
     cache:
       warmer:
         images:
-          - image: substrafoundation/substra-tools:0.6.1-minimal
+          - image: substrafoundation/substra-tools:0.7.0-minimal
   ingress:
     enabled: true
     hosts:

--- a/values/backend-org-2.yaml
+++ b/values/backend-org-2.yaml
@@ -12,7 +12,7 @@ registry:
   scheme: http
   pullDomain: 127.0.0.1:32002
   prepopulate:
-    - image: substrafoundation/substra-tools:0.6.1-minimal
+    - image: substrafoundation/substra-tools:0.7.0-minimal
 
 secrets:
   fabricConfigmap: network-org-2-hlf-k8s-fabric
@@ -30,7 +30,7 @@ backend:
     cache:
       warmer:
         images:
-          - image: substrafoundation/substra-tools:0.6.1-minimal
+          - image: substrafoundation/substra-tools:0.7.0-minimal
   ingress:
     enabled: true
     hosts:


### PR DESCRIPTION
:warning: In order for this PR to be merged, https://github.com/SubstraFoundation/substra-tools/pull/43 has to be merged first and the 0.7.0 release done.

With this change, the relative order of data samples is added to the command executed by the algo container during training.