### PR TITLE
Add LedgerNotFound exception in retry update_ledger

### DIFF
--- a/backend/substrapp/ledger/api.py
+++ b/backend/substrapp/ledger/api.py
@@ -9,7 +9,8 @@ from grpc import RpcError
 from substrapp.ledger.connection import get_hfc
 from substrapp.ledger.exceptions import (raise_for_status, LedgerForbidden, LedgerTimeout, LedgerMVCCError,
                                          LedgerInvalidResponse, LedgerUnavailable, LedgerPhantomReadConflictError,
-                                         LedgerEndorsementPolicyFailure, LedgerStatusError, LedgerError)
+                                         LedgerEndorsementPolicyFailure, LedgerStatusError, LedgerError,
+                                         LedgerAssetNotFound)
 
 logger = logging.getLogger(__name__)
 
@@ -214,7 +215,7 @@ def invoke_ledger(channel_name, *args, **kwargs):
     return _invoke_ledger(channel_name, *args, **kwargs)
 
 
-@retry_on_error(exceptions=[LedgerTimeout])
+@retry_on_error(exceptions=[LedgerTimeout, LedgerAssetNotFound])
 def update_ledger(channel_name, *args, **kwargs):
     return _invoke_ledger(channel_name, *args, **kwargs)
 

--- a/backend/substrapp/ledger/exceptions.py
+++ b/backend/substrapp/ledger/exceptions.py
@@ -86,7 +86,7 @@ class LedgerConflict(LedgerError):
         return cls(response['error'], key=key)
 
 
-class LedgerNotFound(LedgerError):
+class LedgerAssetNotFound(LedgerError):
     """Asset not found."""
     status = status.HTTP_404_NOT_FOUND
 
@@ -99,6 +99,6 @@ class LedgerForbidden(LedgerError):
 _STATUS_TO_EXCEPTION = {
     status.HTTP_400_BAD_REQUEST: LedgerBadRequest,
     status.HTTP_403_FORBIDDEN: LedgerForbidden,
-    status.HTTP_404_NOT_FOUND: LedgerNotFound,
+    status.HTTP_404_NOT_FOUND: LedgerAssetNotFound,
     status.HTTP_409_CONFLICT: LedgerConflict,
 }

--- a/backend/substrapp/tests/tests_misc.py
+++ b/backend/substrapp/tests/tests_misc.py
@@ -4,7 +4,7 @@ from mock import patch
 
 from substrapp.utils import raise_if_path_traversal, uncompress_path
 
-from substrapp.ledger.exceptions import LedgerNotFound, LedgerInvalidResponse
+from substrapp.ledger.exceptions import LedgerAssetNotFound, LedgerInvalidResponse
 
 from substrapp.ledger.api import get_object_from_ledger, log_fail_tuple, log_start_tuple, \
     log_success_tuple, query_tuples
@@ -53,8 +53,8 @@ class MiscTests(TestCase):
 
     def test_get_object_from_ledger(self):
         with patch('substrapp.ledger.api.query_ledger') as mquery_ledger:
-            mquery_ledger.side_effect = LedgerNotFound('Not Found')
-            self.assertRaises(LedgerNotFound, get_object_from_ledger, CHANNEL, 'key', 'fake_query')
+            mquery_ledger.side_effect = LedgerAssetNotFound('Not Found')
+            self.assertRaises(LedgerAssetNotFound, get_object_from_ledger, CHANNEL, 'key', 'fake_query')
 
         with patch('substrapp.ledger.api.query_ledger') as mquery_ledger:
             mquery_ledger.side_effect = LedgerInvalidResponse('Bad Response')


### PR DESCRIPTION
Add LedgerNotFound exception in retry `update_ledger`
A org may try to launch a traintuple (i.e. `log_start_tuple` via an invoke). During this procedure, the transaction is endorsed by each peer (Another org here).
But, even if the first org had already the block with the traintuple metadata, the second org may not have it at this moment so the endorsement request will fail with a `no asset for key` error.
In order to fix this potential issue, we can use the retry mecanism and add LedgerNotFound exception)