### PR TITLE
Introduce restricted channels

### DIFF
--- a/backend/libs/health_check_middleware.py
+++ b/backend/libs/health_check_middleware.py
@@ -32,8 +32,7 @@ class HealthCheckMiddleware(object):
 
 
 def validate_solo_channels():
-    for channel_name in settings.LEDGER_CHANNELS.keys():
-        channel = settings.LEDGER_CHANNELS[channel_name]
+    for channel_name, channel in settings.LEDGER_CHANNELS.items():
         if channel_name.startswith('solo-') or channel['restricted']:
             with get_hfc(channel_name) as (loop, client, user):
                 # get_hfc will throw if the solo channel has more than 1 member

--- a/backend/libs/health_check_middleware.py
+++ b/backend/libs/health_check_middleware.py
@@ -1,4 +1,6 @@
+from django.conf import settings
 from django.http import HttpResponse
+from substrapp.ledger.connection import get_hfc
 
 
 class HealthCheckMiddleware(object):
@@ -18,10 +20,21 @@ class HealthCheckMiddleware(object):
         """
         Returns that the server is alive.
         """
+        validate_solo_channels()
         return HttpResponse("OK")
 
     def readiness(self, request):
         """
         Returns that the server is alive.
         """
+        validate_solo_channels()
         return HttpResponse("OK")
+
+
+def validate_solo_channels():
+    for channel_name in settings.LEDGER_CHANNELS.keys():
+        channel = settings.LEDGER_CHANNELS[channel_name]
+        if channel_name.startswith('solo-') or channel['restricted']:
+            with get_hfc(channel_name) as (loop, client, user):
+                # get_hfc will throw if the solo channel has more than 1 member
+                pass

--- a/backend/substrapp/ledger/connection.py
+++ b/backend/substrapp/ledger/connection.py
@@ -123,9 +123,23 @@ def _get_hfc(channel_name):
 
     results = _deserialize_discovery(results)
 
+    _validate_channels(channel_name, results)
     _update_client_with_discovery(client, results)
 
     return loop, client, user
+
+
+def _validate_channels(channel_name, discovery_results):
+
+    channel = settings.LEDGER_CHANNELS[channel_name]
+
+    # Esnure solo channels have 1 member at most
+    if channel_name.startswith('solo-') or channel['restricted']:
+        channel_members = list(discovery_results['config']['msps'].keys())
+        num_members = len(channel_members) - 1  # remove orderer
+        if (num_members > 1):
+            raise Exception(f'Restricted channel {channel_name} should have at most 1 member, but has '
+                            f'{num_members}')
 
 
 def _update_client_with_discovery(client, discovery_results):

--- a/backend/substrapp/ledger/connection.py
+++ b/backend/substrapp/ledger/connection.py
@@ -133,7 +133,7 @@ def _validate_channels(channel_name, discovery_results):
 
     channel = settings.LEDGER_CHANNELS[channel_name]
 
-    # Esnure solo channels have 1 member at most
+    # Ensure solo channels have 1 member at most
     if channel_name.startswith('solo-') or channel['restricted']:
         channel_members = list(discovery_results['config']['msps'].keys())
         num_members = len(channel_members) - 1  # remove orderer

--- a/charts/substra-backend/README.md
+++ b/charts/substra-backend/README.md
@@ -25,7 +25,10 @@ The following table lists the configurable parameters of the substra-backend cha
 | `backend.kaniko.cache.warmer.images[].image` | A docker image | (undefined) |
 | `backend.kaniko.image` | The docker image for kaniko builds | `gcr.io/kaniko-project/executor:v1.0.0` |
 | `backend.kaniko.mirror` | If true, pull base images from the local registry | `False` |
-| `channels` | A list of Hyperledger Fabric channels to connect to. See [hlf-k8s](https://github.com/SubstraFoundation/hlf-k8s). | `[mychannel]` |
+| `channels` | A list of Hyperledger Fabric channels to connect to. See [hlf-k8s](https://github.com/SubstraFoundation/hlf-k8s). | `{ mychannel: { restricted: false, chaincode: { name: mycc, version: 1.0 } } }` |
+| `channels[].restricted` | If true, the channel must have at most 1 member, else the backend readiness/liveliness probes will fail. | (undefined) |
+| `channels[].chaincode.name` | The name of the chaincode instantiated on this channel. | (undefined) |
+| `channels[].chaincode.version` | The version of the chaincode instantiated on this channel. | (undefined) |
 | `events.nodeSelector` | Node labels for pod assignment | `{}` |
 | `events.tolerations` | Toleration labels for pod assignment | `[]` |
 | `events.affinity` | Affinity settings for pod assignment | `{}` |

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -167,6 +167,7 @@ peer:
 
 channels:
   - mychannel:
+      restricted: false
       chaincode:
         name: mycc
         version: "1.0"

--- a/values/backend-org-1.yaml
+++ b/values/backend-org-1.yaml
@@ -89,9 +89,11 @@ extraEnv:
 channels:
   - mychannel:
       chaincode:
+        restricted: false
         name: mycc
         version: "1.0"
   - yourchannel:
+      restricted: false
       chaincode:
         name: yourcc
         version: "1.0"

--- a/values/backend-org-1.yaml
+++ b/values/backend-org-1.yaml
@@ -88,8 +88,8 @@ extraEnv:
 
 channels:
   - mychannel:
+      restricted: false
       chaincode:
-        restricted: false
         name: mycc
         version: "1.0"
   - yourchannel:

--- a/values/backend-org-2.yaml
+++ b/values/backend-org-2.yaml
@@ -87,10 +87,12 @@ extraEnv:
 
 channels:
   - mychannel:
+      restricted: false
       chaincode:
         name: mycc
         version: "1.0"
   - yourchannel:
+      restricted: false
       chaincode:
         name: yourcc
         version: "1.0"


### PR DESCRIPTION
**TL;DR:** Channels can be marked as "restricted" (also called "solo"). Restricted channels can only have one member, else the backend will (deliberately) crash.

---

A channel is configured as restricted if either of these conditions are true in the helm values file:

- the `restricted` field of the channel is set to true
- the name of the channel starts with `solo-`

*Note: In the rest of this doc, "misconfigured" refers to a solo channel with more than one member.*

2 protections are implemented to prevent any operation on a misconfigured solo channel.

## Protections

### Protection 1

Throw an exception when trying to operate on a misconfigured solo channel

`get_hfc(channel_name)` will 

1. check if `channel_name` refers to a solo channel
2. check the channel's discovery results
3. if the channel has more than one member, throw an exception

Since `get_hfc` is the only entry point to the ledger, it is not possible for a consumer to operate on a misconfigured channel _at all_.

### Protection 2

Crash the readiness/liveness probes if a solo channel is misconfigured

Both the readiness and liveness probes will validate all the solo channels: if any solo channel is misconfigured, the HTTP call will return a 500 error, which will instruct Kubernetes to crash the pod. The exception is shown in the logs.


## Testing

### Test 1: correct configuration

In `backend-org-1.yaml`, add a new channel in `channels`

```yaml
  - solo-org1:
      restricted: true
      chaincode:
        name: mycc
        version: "1.0"
```

In hlf-k8s `examples/2-orgs-policy-any-no-ca/values/org-1-peer-1.yaml`, add a solo channel

```yaml
- channelName: solo-org1
  channelPolicies: |-
    Readers:
        Type: ImplicitMeta
        Rule: "ANY Readers"
    Writers:
        Type: ImplicitMeta
        Rule: "ANY Writers"
    Admins:
        Type: ImplicitMeta
        Rule: "ANY Admins"
  appPolicies: |-
    LifecycleEndorsement:
        Type: ImplicitMeta
        Rule: "ANY Endorsement"
    Endorsement:
        Type: ImplicitMeta
        Rule: "ANY Endorsement"
    Readers:
        Type: ImplicitMeta
        Rule: "ANY Readers"
    Writers:
        Type: ImplicitMeta
        Rule: "ANY Writers"
    Admins:
        Type: ImplicitMeta
        Rule: "ANY Admins"

  chaincodes:
  - address: network-org-1-peer-1-hlf-k8s-chaincode-mycc.org-1
    policy: "OR('MyOrg1MSP.member')"
    name: mycc
    port: 7052
    version: "1.0"
    image:
      repository: substrafoundation/substra-chaincode
      tag: 0.1.0
      pullPolicy: IfNotPresent

  organizations:
    - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }
```

The backend works correctly.

### Test 2: incorrect configuration

From Test 1, modify the `solo-org1` configuration to add a new `organization` 

```yaml
organizations:
  - { org: MyOrg1, mspid: MyOrg1MSP, configUrl: network-org-1-peer-1-hlf-k8s-config-operator.org-1/config/configOrgWithAnchors.json }
  - { org: MyOrg2, mspid: MyOrg2MSP, configUrl: network-org-2-peer-1-hlf-k8s-config-operator.org-2/config/configOrgWithAnchors.json }
```

Run `skaffold run` and observe the deluge of errors in the backend.
