### PR TITLE
Handle chaincode pagination

### DIFF
--- a/backend/substrapp/ledger/api.py
+++ b/backend/substrapp/ledger/api.py
@@ -168,7 +168,19 @@ def call_ledger(channel_name, call_type, fcn, *args, **kwargs):
     ts = time.time()
     error = None
     try:
-        return _call_ledger(channel_name, call_type, fcn, *args, **kwargs)
+        response = _call_ledger(channel_name, call_type, fcn, *args, **kwargs)
+
+        if isinstance(response, dict) and 'bookmarks' in response:
+            results = response['result']  # first result
+            while response['result']:
+                kwargs['args'] = {'bookmarks': response['bookmarks']}
+                response = _call_ledger(channel_name, call_type, fcn, *args, **kwargs)
+                results.extend(response['result'])  # following results
+            else:
+                response = results
+
+        return response
+
     except Exception as e:
         error = e.__class__.__name__
         raise

--- a/backend/substrapp/ledger/api.py
+++ b/backend/substrapp/ledger/api.py
@@ -171,11 +171,11 @@ def call_ledger(channel_name, call_type, fcn, *args, **kwargs):
         response = _call_ledger(channel_name, call_type, fcn, *args, **kwargs)
 
         if isinstance(response, dict) and 'bookmarks' in response:
-            results = response['result']  # first result
-            while response['result']:
+            results = response['results']  # first results
+            while response['results']:
                 kwargs['args'] = {'bookmarks': response['bookmarks']}
                 response = _call_ledger(channel_name, call_type, fcn, *args, **kwargs)
-                results.extend(response['result'])  # following results
+                results.extend(response['results'])  # following results
             else:
                 response = results
 

--- a/backend/substrapp/ledger/api.py
+++ b/backend/substrapp/ledger/api.py
@@ -172,8 +172,8 @@ def call_ledger(channel_name, call_type, fcn, *args, **kwargs):
 
         if isinstance(response, dict) and 'bookmarks' in response:
             results = response['results']  # first results
-            while response['results']:
-                kwargs['args'] = {'bookmarks': response['bookmarks']}
+            while response['results'] and len(response['bookmark']) > 0:
+                kwargs['args'] = {'bookmark': response['bookmark']}
                 response = _call_ledger(channel_name, call_type, fcn, *args, **kwargs)
                 results.extend(response['results'])  # following results
             else:

--- a/backend/substrapp/ledger/api.py
+++ b/backend/substrapp/ledger/api.py
@@ -170,7 +170,7 @@ def call_ledger(channel_name, call_type, fcn, *args, **kwargs):
     try:
         response = _call_ledger(channel_name, call_type, fcn, *args, **kwargs)
 
-        if isinstance(response, dict) and 'bookmarks' in response:
+        if isinstance(response, dict) and 'bookmark' in response:
             results = response['results']  # first results
             while response['results'] and len(response['bookmark']) > 0:
                 kwargs['args'] = {'bookmark': response['bookmark']}


### PR DESCRIPTION
## Description
The aim of this PR is to handle chaincode pagination for query[Asset]s.

## Closes issue(s)
None

## Companion PRs
https://github.com/SubstraFoundation/substra-chaincode/pull/131

## How to test / repro
Launch e2e tests, no regression should appear.

## Screenshots / Trace
None

## Changes include
- [x] Loop over pagination in `call_ledger`

## Checklist
- [x] I have tested this code

## Other comments
None