### PR TITLE
relax version requirement on requests package

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,7 +11,7 @@ ipython==7.11.1
 ipython-genutils==0.2.0
 kubernetes==11.0.0
 psycopg2-binary==2.8.4
-requests==2.24.0
+requests>=2.20.0
 tldextract==2.2.2
 uwsgi==2.0.18
 zxcvbn==4.4.28


### PR DESCRIPTION
This fixes the [currently failing docker build](https://hub.docker.com/repository/registry-1.docker.io/substrafoundation/substra-backend/builds/cb6f01cc-88eb-4c89-b564-8c85410c0e17)

```
ERROR: Cannot install -r requirements.txt (line 19) and requests==2.24.0 because these package versions have conflicting dependencies.
The conflict is caused by:
The user requested requests==2.24.0
fabric-sdk-py 1.0.0 depends on requests==2.20.0
```

See also: https://github.com/hyperledger/fabric-sdk-py/pull/125