### PR TITLE
Close db connection before launching Process under celery task.

### DIFF
--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -242,7 +242,7 @@ def fetch_models(channel_name, tuple_type, authorized_types, input_models, direc
             exceptions.append(Exception(f'fetch model failed for args {args}'))
 
     # Close django old connections to avoid potential leak
-    db.connections.close_old_connections()
+    db.close_old_connections()
 
     if exceptions:
         raise Exception(exceptions)

--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -27,8 +27,7 @@ from substrapp.ledger.api import (log_start_tuple, log_success_tuple, log_fail_t
                                   query_tuples, get_object_from_ledger)
 from substrapp.ledger.exceptions import LedgerError, LedgerStatusError
 from substrapp.tasks.utils import (compute_job, get_asset_content, get_and_put_asset_content,
-                                   list_files, do_not_raise, get_or_create_local_volume, remove_image,
-                                   authenticate_worker)
+                                   list_files, do_not_raise, get_or_create_local_volume, remove_image)
 
 from substrapp.tasks.exception_handler import compute_error_code
 
@@ -163,7 +162,7 @@ def get_tuple_status(channel_name, tuple_type, key):
     return metadata['status']
 
 
-def get_and_put_model_content(channel_name, tuple_type, hash_key, tuple_, out_model, model_dst_path, auth=None):
+def get_and_put_model_content(channel_name, tuple_type, hash_key, tuple_, out_model, model_dst_path):
     """Get out model content."""
     owner = tuple_get_owner(tuple_type, tuple_)
     return get_and_put_asset_content(
@@ -172,9 +171,7 @@ def get_and_put_model_content(channel_name, tuple_type, hash_key, tuple_, out_mo
         owner,
         out_model['checksum'],
         content_dst_path=model_dst_path,
-        hash_key=hash_key,
-        auth=auth
-    )
+        hash_key=hash_key)
 
 
 def get_and_put_local_model_content(hash_key, out_model, model_dst_path):
@@ -195,7 +192,7 @@ def get_and_put_local_model_content(hash_key, out_model, model_dst_path):
 
 
 @timeit
-def fetch_model(channel_name, parent_tuple_type, authorized_types, input_model, directory, auth=None):
+def fetch_model(channel_name, parent_tuple_type, authorized_types, input_model, directory):
 
     tuple_type, metadata = find_training_step_tuple_from_key(channel_name, input_model['traintuple_key'])
 
@@ -207,14 +204,10 @@ def fetch_model(channel_name, parent_tuple_type, authorized_types, input_model, 
 
     if tuple_type == TRAINTUPLE_TYPE:
         get_and_put_model_content(
-            channel_name, tuple_type, input_model['traintuple_key'], metadata, metadata['out_model'], model_dst_path,
-            auth
-        )
+            channel_name, tuple_type, input_model['traintuple_key'], metadata, metadata['out_model'], model_dst_path)
     elif tuple_type == AGGREGATETUPLE_TYPE:
         get_and_put_model_content(
-            channel_name, tuple_type, input_model['traintuple_key'], metadata, metadata['out_model'], model_dst_path,
-            auth
-        )
+            channel_name, tuple_type, input_model['traintuple_key'], metadata, metadata['out_model'], model_dst_path)
     elif tuple_type == COMPOSITE_TRAINTUPLE_TYPE:
         get_and_put_model_content(
             channel_name,
@@ -222,9 +215,7 @@ def fetch_model(channel_name, parent_tuple_type, authorized_types, input_model, 
             input_model['traintuple_key'],
             metadata,
             metadata['out_trunk_model']['out_model'],
-            model_dst_path,
-            auth
-        )
+            model_dst_path)
     else:
         raise TasksError(f'Traintuple: invalid input model: type={tuple_type}')
 
@@ -234,12 +225,13 @@ def fetch_models(channel_name, tuple_type, authorized_types, input_models, direc
     models = []
     exceptions = []
 
+    # Close django connection to force each Process to create its own as
+    # django orm connection is not fork safe https://code.djangoproject.com/ticket/20562
+    from django import db
+    db.connections.close_all()
+
     for input_model in input_models:
-        # Authentification should be retrieved before sending the function fetch model to a subProcess
-        # as, fetching it from django models give random results
-        # Don't know why
-        auth = get_model_auth(channel_name, input_model)
-        args = (channel_name, tuple_type, authorized_types, input_model, directory, auth)
+        args = (channel_name, tuple_type, authorized_types, input_model, directory)
         proc = Process(target=fetch_model, args=args)
         models.append((proc, args))
         proc.start()
@@ -249,13 +241,11 @@ def fetch_models(channel_name, tuple_type, authorized_types, input_models, direc
         if proc.exitcode != 0:
             exceptions.append(Exception(f'fetch model failed for args {args}'))
 
+    # Close django old connections to avoid potential leak
+    db.connections.close_old_connections()
+
     if exceptions:
         raise Exception(exceptions)
-
-
-def get_model_auth(channel_name, input_model):
-    tuple_type, metadata = find_training_step_tuple_from_key(channel_name, input_model['traintuple_key'])
-    return authenticate_worker(tuple_get_owner(tuple_type, metadata))
 
 
 def prepare_traintuple_input_models(channel_name, directory, tuple_):

--- a/backend/substrapp/tasks/utils.py
+++ b/backend/substrapp/tasks/utils.py
@@ -31,6 +31,8 @@ def authenticate_worker(node_id):
         raise NodeError(f'Unauthorized to call node_id: {node_id}')
 
     if node_id != outgoing.node_id:
+        # Ensure the response is valid. This is a safety net for the case when the DB connection is shared
+        # across processes running in parallel.
         raise NodeError(f'Wrong response: Request {node_id} - Get {outgoing.node_id}')
 
     auth = HTTPBasicAuth(owner, outgoing.secret)

--- a/backend/substrapp/tasks/utils.py
+++ b/backend/substrapp/tasks/utils.py
@@ -30,6 +30,9 @@ def authenticate_worker(node_id):
     except OutgoingNode.DoesNotExist:
         raise NodeError(f'Unauthorized to call node_id: {node_id}')
 
+    if node_id != outgoing.node_id:
+        raise NodeError(f'Wrong response: Request {node_id} - Get {outgoing.node_id}')
+
     auth = HTTPBasicAuth(owner, outgoing.secret)
 
     return auth
@@ -39,12 +42,8 @@ def get_asset_content(channel_name, url, node_id, content_checksum, salt=None):
     return get_remote_file_content(channel_name, url, authenticate_worker(node_id), content_checksum, salt=salt)
 
 
-def get_and_put_asset_content(channel_name, url, node_id, content_checksum, content_dst_path, hash_key, auth=None):
-
-    if auth is None:
-        auth = authenticate_worker(node_id)
-
-    return get_and_put_remote_file_content(channel_name, url, auth, content_checksum,
+def get_and_put_asset_content(channel_name, url, node_id, content_checksum, content_dst_path, hash_key):
+    return get_and_put_remote_file_content(channel_name, url, authenticate_worker(node_id), content_checksum,
                                            content_dst_path=content_dst_path, hash_key=hash_key)
 
 


### PR DESCRIPTION
## Description
Django ORM connections are not fork safe. We need to close them all in celery task to force Process open new connection once launched

## Closes issue(s)
Fix #353 

## Companion PRs
None

## How to test / repro
Update outgoing node values for org-1:
​
```yaml
outgoingNodes:
  - { name: MyOrg1MSP, secret: selfSecret1 }
  - { name: MyOrg2MSP, secret: nodeSecret2w1 }
  - { name: MyOrg3MSP, secret: nodeSecret3w1 }
  - { name: MyOrg4MSP, secret: nodeSecret4w1 }
  - { name: MyOrg5MSP, secret: nodeSecret5w1 }
  - { name: MyOrg6MSP, secret: nodeSecret6w1 }
  - { name: MyOrg7MSP, secret: nodeSecret7w1 }
  - { name: MyOrg8MSP, secret: nodeSecret8w1 }
  - { name: MyOrg9MSP, secret: nodeSecret9w1 }
  - { name: MyOrg10MSP, secret: nodeSecret10w1 }
  - { name: MyOrg12MSP, secret: nodeSecret12w1 }
  - { name: MyOrg13MSP, secret: nodeSecret13w1 }
  - { name: MyOrg14MSP, secret: nodeSecret14w1 }
  - { name: MyOrg15MSP, secret: nodeSecret15w1 }
  - { name: MyOrg16MSP, secret: nodeSecret16w1 }
  - { name: MyOrg17MSP, secret: nodeSecret17w1 }
  - { name: MyOrg18MSP, secret: nodeSecret18w1 }
  - { name: MyOrg19MSP, secret: nodeSecret19w1 }
  - { name: MyOrg20MSP, secret: nodeSecret20w1 }
```
​
Launch substra-backend with skaffold
Create HLF secrets with `./examples/dev-secrets create` from hlf-k8s
Connect to the substra-backend worker and launch a celery shell : `celery -A backend shell`

Launch this code : 

``` python
import logging
from django import db
from billiard import Process
from backend.celery import app
​
​
def authenticate_worker(node_id):
    from node.models import OutgoingNode
    try:
        outgoing = OutgoingNode.objects.get(node_id=node_id)
        psqlDB = db.connections.all()[0]
        logging.error(f'ASK:{node_id}, RES:{outgoing.node_id}, '
                      f'SEC:{outgoing.secret}, DB:{psqlDB.connection.fileno()} - {psqlDB.connection.info.backend_pid} '
                      f'- {psqlDB.connection.info.socket}')
    except OutgoingNode.DoesNotExist:
        raise Exception(f'Unauthorized to call node_id: {node_id}')
​
    if outgoing.node_id != node_id:
        raise Exception(f'{node_id} - {outgoing.node_id}')
​
    return outgoing.secret
​
​
def fetch_auth(node_id):
    return authenticate_worker(f'MyOrg{node_id}MSP')
​
​
@app.task()
def fetch_node_ids_task():
    models = []
    for node_id in range(1, 21):
        args = (node_id, )
        proc = Process(target=fetch_auth,
                       args=args)
        models.append((proc, args))
        proc.start()
​
    for proc, args in models:
        proc.terminate()
        proc.join()
​
​
@app.task()
def fetch_node_ids_task_close_db():
    models = []
    from django import db
    db.connections.close_all()
    for node_id in range(1, 21):
        args = (node_id, )
        proc = Process(target=fetch_auth,
                       args=args)
        models.append((proc, args))
        proc.start()
​
    for proc, args in models:
        proc.join()
​
​
# ASYNC THEN SYNC
# Launching under celery task with one async before
# Use the same db connection, not safe same backend_pid
fetch_node_ids_task.apply_async()
for _ in range(4):
    fetch_node_ids_task.apply()
​
print('-' * 30)
​
# Close DB before force each process to create it's connection (backend_pid new)
fetch_node_ids_task_close_db.apply_async()
for _ in range(4):
    fetch_node_ids_task_close_db.apply()
​
# SYNC
# Launching function no celery
# Each process to create it's connection (backend_pid new)
for _ in range(4):
    fetch_node_ids_task.apply()
print('-' * 30)
​
# Close DB before force each process to create it's connection (backend_pid new)
for _ in range(4):
    fetch_node_ids_task_close_db.apply()
​
# NO CELERY
# Launching under celery task with no async before
# Each process to create it's connection (backend_pid new)
for _ in range(4):
    fetch_node_ids_task.apply()
print('-' * 30)
​
# Close DB before force each process to create it's connection (backend_pid new)
for _ in range(4):

```

## Screenshots / Trace

``` python

# ASYNC THEN SYNC

2020-12-01 08:25:52,564 - [621bb51a] - ERROR - ASK:MyOrg1MSP, RES:MyOrg1MSP, SEC:selfSecret1, DB:13 - 85226 - 13
2020-12-01 08:25:52,568 - [621bb51a] - ERROR - ASK:MyOrg2MSP, RES:MyOrg2MSP, SEC:nodeSecret2w1, DB:13 - 85226 - 13
2020-12-01 08:25:52,576 - [621bb51a] - ERROR - ASK:MyOrg4MSP, RES:MyOrg4MSP, SEC:nodeSecret4w1, DB:13 - 85226 - 13
2020-12-01 08:25:52,577 - [621bb51a] - ERROR - ASK:MyOrg5MSP, RES:MyOrg5MSP, SEC:nodeSecret5w1, DB:13 - 85226 - 13
2020-12-01 08:25:52,579 - [621bb51a] - ERROR - ASK:MyOrg3MSP, RES:MyOrg3MSP, SEC:nodeSecret3w1, DB:13 - 85226 - 13
2020-12-01 08:25:52,592 - [621bb51a] - ERROR - ASK:MyOrg8MSP, RES:MyOrg8MSP, SEC:nodeSecret8w1, DB:13 - 85226 - 13
2020-12-01 08:25:52,601 - [621bb51a] - ERROR - ASK:MyOrg11MSP, RES:MyOrg7MSP, SEC:nodeSecret7w1, DB:13 - 85226 - 13
Process Process-11:
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/billiard/process.py", line 327, in _bootstrap
    self.run()
  File "/usr/local/lib/python3.6/site-packages/billiard/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "<ipython-input-1-f39bbe0bee60>", line 25, in fetch_auth
    return authenticate_worker(f'MyOrg{node_id}MSP')
  File "<ipython-input-1-f39bbe0bee60>", line 19, in authenticate_worker
    raise Exception(f'{node_id} - {outgoing.node_id}')
Exception: MyOrg11MSP - MyOrg7MSP
2020-12-01 08:25:52,605 - [621bb51a] - ERROR - ASK:MyOrg6MSP, RES:MyOrg9MSP, SEC:nodeSecret9w1, DB:13 - 85226 - 13
.
.
.
----------------------
2020-12-01 08:25:53,113 - [87738439] - ERROR - ASK:MyOrg1MSP, RES:MyOrg1MSP, SEC:selfSecret1, DB:14 - 85227 - 14
2020-12-01 08:25:53,117 - [87738439] - ERROR - ASK:MyOrg2MSP, RES:MyOrg2MSP, SEC:nodeSecret2w1, DB:17 - 85228 - 17
2020-12-01 08:25:53,132 - [87738439] - ERROR - ASK:MyOrg4MSP, RES:MyOrg4MSP, SEC:nodeSecret4w1, DB:19 - 85229 - 19
2020-12-01 08:25:53,134 - [87738439] - ERROR - ASK:MyOrg3MSP, RES:MyOrg3MSP, SEC:nodeSecret3w1, DB:18 - 85230 - 18
2020-12-01 08:25:53,146 - [87738439] - ERROR - ASK:MyOrg5MSP, RES:MyOrg5MSP, SEC:nodeSecret5w1, DB:20 - 85231 - 20
2020-12-01 08:25:53,151 - [87738439] - ERROR - ASK:MyOrg6MSP, RES:MyOrg6MSP, SEC:nodeSecret6w1, DB:21 - 85232 - 21
2020-12-01 08:25:53,160 - [87738439] - ERROR - ASK:MyOrg7MSP, RES:MyOrg7MSP, SEC:nodeSecret7w1, DB:22 - 85233 - 22
2020-12-01 08:25:53,167 - [87738439] - ERROR - ASK:MyOrg10MSP, RES:MyOrg10MSP, SEC:nodeSecret10w1, DB:25 - 85234 - 25
2020-12-01 08:25:53,175 - [87738439] - ERROR - ASK:MyOrg8MSP, RES:MyOrg8MSP, SEC:nodeSecret8w1, DB:23 - 85235 - 23
2020-12-01 08:25:53,183 - [87738439] - ERROR - ASK:MyOrg11MSP, RES:MyOrg11MSP, SEC:nodeSecret11w1, DB:26 - 85238 - 26
2020-12-01 08:25:53,183 - [87738439] - ERROR - ASK:MyOrg13MSP, RES:MyOrg13MSP, SEC:nodeSecret13w1, DB:28 - 85237 - 28
2020-12-01 08:25:53,185 - [87738439] - ERROR - ASK:MyOrg9MSP, RES:MyOrg9MSP, SEC:nodeSecret9w1, DB:24 - 85236 - 24
2020-12-01 08:25:53,197 - [87738439] - ERROR - ASK:MyOrg12MSP, RES:MyOrg12MSP, SEC:nodeSecret12w1, DB:27 - 85239 - 27
2020-12-01 08:25:53,213 - [87738439] - ERROR - ASK:MyOrg14MSP, RES:MyOrg14MSP, SEC:nodeSecret14w1, DB:29 - 85240 - 29
2020-12-01 08:25:53,216 - [87738439] - ERROR - ASK:MyOrg15MSP, RES:MyOrg15MSP, SEC:nodeSecret15w1, DB:30 - 85241 - 30
2020-12-01 08:25:53,228 - [87738439] - ERROR - ASK:MyOrg16MSP, RES:MyOrg16MSP, SEC:nodeSecret16w1, DB:31 - 85242 - 31
2020-12-01 08:25:53,232 - [87738439] - ERROR - ASK:MyOrg17MSP, RES:MyOrg17MSP, SEC:nodeSecret17w1, DB:32 - 85243 - 32
2020-12-01 08:25:53,244 - [87738439] - ERROR - ASK:MyOrg20MSP, RES:MyOrg20MSP, SEC:nodeSecret20w1, DB:35 - 85245 - 35
2020-12-01 08:25:53,248 - [87738439] - ERROR - ASK:MyOrg18MSP, RES:MyOrg18MSP, SEC:nodeSecret18w1, DB:33 - 85244 - 33
2020-12-01 08:25:53,252 - [87738439] - ERROR - ASK:MyOrg19MSP, RES:MyOrg19MSP, SEC:nodeSecret19w1, DB:34 - 85246 - 34


# SYNC
2020-12-01 08:35:16,044 -  - ERROR - ASK:MyOrg1MSP, RES:MyOrg1MSP, SEC:selfSecret1, DB:15 - 86175 - 15
2020-12-01 08:35:16,050 -  - ERROR - ASK:MyOrg2MSP, RES:MyOrg2MSP, SEC:nodeSecret2w1, DB:16 - 86176 - 16
2020-12-01 08:35:16,056 -  - ERROR - ASK:MyOrg3MSP, RES:MyOrg3MSP, SEC:nodeSecret3w1, DB:17 - 86177 - 17
2020-12-01 08:35:16,073 -  - ERROR - ASK:MyOrg4MSP, RES:MyOrg4MSP, SEC:nodeSecret4w1, DB:18 - 86178 - 18
2020-12-01 08:35:16,079 -  - ERROR - ASK:MyOrg6MSP, RES:MyOrg6MSP, SEC:nodeSecret6w1, DB:20 - 86180 - 20
2020-12-01 08:35:16,081 -  - ERROR - ASK:MyOrg5MSP, RES:MyOrg5MSP, SEC:nodeSecret5w1, DB:19 - 86179 - 19
2020-12-01 08:35:16,092 -  - ERROR - ASK:MyOrg7MSP, RES:MyOrg7MSP, SEC:nodeSecret7w1, DB:21 - 86181 - 21
.
.
.
------------------------------
2020-12-01 08:35:16,564 -  - ERROR - ASK:MyOrg1MSP, RES:MyOrg1MSP, SEC:selfSecret1, DB:15 - 86248 - 15
2020-12-01 08:35:16,573 -  - ERROR - ASK:MyOrg2MSP, RES:MyOrg2MSP, SEC:nodeSecret2w1, DB:16 - 86249 - 16
2020-12-01 08:35:16,580 -  - ERROR - ASK:MyOrg3MSP, RES:MyOrg3MSP, SEC:nodeSecret3w1, DB:17 - 86250 - 17
2020-12-01 08:35:16,585 -  - ERROR - ASK:MyOrg4MSP, RES:MyOrg4MSP, SEC:nodeSecret4w1, DB:18 - 86251 - 18
2020-12-01 08:35:16,587 -  - ERROR - ASK:MyOrg5MSP, RES:MyOrg5MSP, SEC:nodeSecret5w1, DB:19 - 86252 - 19
2020-12-01 08:35:16,596 -  - ERROR - ASK:MyOrg6MSP, RES:MyOrg6MSP, SEC:nodeSecret6w1, DB:20 - 86253 - 20
2020-12-01 08:35:16,610 -  - ERROR - ASK:MyOrg8MSP, RES:MyOrg8MSP, SEC:nodeSecret8w1, DB:22 - 86254 - 22
2020-12-01 08:35:16,613 -  - ERROR - ASK:MyOrg7MSP, RES:MyOrg7MSP, SEC:nodeSecret7w1, DB:21 - 86255 - 21
2020-12-01 08:35:16,613 -  - ERROR - ASK:MyOrg9MSP, RES:MyOrg9MSP, SEC:nodeSecret9w1, DB:23 - 86256 - 23


# NO CELERY
2020-12-01 08:36:00,992 - [6b32d54f] - ERROR - ASK:MyOrg1MSP, RES:MyOrg1MSP, SEC:selfSecret1, DB:16 - 86407 - 16
2020-12-01 08:36:01,001 - [6b32d54f] - ERROR - ASK:MyOrg2MSP, RES:MyOrg2MSP, SEC:nodeSecret2w1, DB:16 - 86408 - 16
2020-12-01 08:36:01,012 - [6b32d54f] - ERROR - ASK:MyOrg3MSP, RES:MyOrg3MSP, SEC:nodeSecret3w1, DB:17 - 86409 - 17
2020-12-01 08:36:01,025 - [6b32d54f] - ERROR - ASK:MyOrg4MSP, RES:MyOrg4MSP, SEC:nodeSecret4w1, DB:18 - 86410 - 18
2020-12-01 08:36:01,030 - [6b32d54f] - ERROR - ASK:MyOrg6MSP, RES:MyOrg6MSP, SEC:nodeSecret6w1, DB:20 - 86411 - 20
2020-12-01 08:36:01,035 - [6b32d54f] - ERROR - ASK:MyOrg5MSP, RES:MyOrg5MSP, SEC:nodeSecret5w1, DB:19 - 86412 - 19
2020-12-01 08:36:01,053 - [6b32d54f] - ERROR - ASK:MyOrg7MSP, RES:MyOrg7MSP, SEC:nodeSecret7w1, DB:21 - 86413 - 21
2020-12-01 08:36:01,063 - [6b32d54f] - ERROR - ASK:MyOrg8MSP, RES:MyOrg8MSP, SEC:nodeSecret8w1, DB:22 - 86414 - 22
.
.
.
------------------------------
2020-12-01 08:36:01,630 - [2d654273] - ERROR - ASK:MyOrg1MSP, RES:MyOrg1MSP, SEC:selfSecret1, DB:15 - 86490 - 15
2020-12-01 08:36:01,633 - [2d654273] - ERROR - ASK:MyOrg2MSP, RES:MyOrg2MSP, SEC:nodeSecret2w1, DB:16 - 86491 - 16
2020-12-01 08:36:01,639 - [2d654273] - ERROR - ASK:MyOrg3MSP, RES:MyOrg3MSP, SEC:nodeSecret3w1, DB:17 - 86492 - 17
2020-12-01 08:36:01,655 - [2d654273] - ERROR - ASK:MyOrg5MSP, RES:MyOrg5MSP, SEC:nodeSecret5w1, DB:19 - 86494 - 19
2020-12-01 08:36:01,656 - [2d654273] - ERROR - ASK:MyOrg4MSP, RES:MyOrg4MSP, SEC:nodeSecret4w1, DB:18 - 86493 - 18
2020-12-01 08:36:01,660 - [2d654273] - ERROR - ASK:MyOrg7MSP, RES:MyOrg7MSP, SEC:nodeSecret7w1, DB:21 - 86495 - 21
2020-12-01 08:36:01,671 - [2d654273] - ERROR - ASK:MyOrg6MSP, RES:MyOrg6MSP, SEC:nodeSecret6w1, DB:20 - 86496 - 20
2020-12-01 08:36:01,689 - [2d654273] - ERROR - ASK:MyOrg8MSP, RES:MyOrg8MSP, SEC:nodeSecret8w1, DB:22 - 86497 - 22

```

We can see that, when there is a issue, process share the same DB connection, i. e. backend_pid.
We print DB information (fileno, backend_pid, socket) from :
- https://www.psycopg.org/docs/connection.html#connection
- https://www.psycopg.org/docs/extensions.html#psycopg2.extensions.ConnectionInfo


It looks like DJANGO ORM is not fork safe according to https://code.djangoproject.com/ticket/20562

To solve this, we need to close all connection, like we do in `fetch_node_ids_task_close_db`
https://stackoverflow.com/questions/8242837/django-multiprocessing-and-database-connections

## Changes include
- [x] Close db connections before launching Process
- [x] Clean old db connections at the end 
- [x] Remove auth argument in *_model functions

## Checklist
- [x] I have tested this code


## Other comments
None