### PR TITLE
Refactor kubernetes labels

### DIFF
--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.7.0
+
+### Changed
+- Refactor of the kubernetes objects labels
 
 ## 1.6.0
 

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-backend
 home: https://substra.org/
-version: 1.6.0
+version: 1.7.0
 description: Main package for Substra
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/substra-backend/templates/_helpers.tpl
+++ b/charts/substra-backend/templates/_helpers.tpl
@@ -26,3 +26,33 @@ Return the appropriate apiVersion for PodSecurityPolicy.
 {{- print "extensions/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "substra.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+
+{{/*
+Common labels
+*/}}
+{{- define "substra.labels" -}}
+helm.sh/chart: {{ include "substra.chart" . }}
+{{ include "substra.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: {{ template "substra.name" . }}
+{{- end }}
+
+
+{{/*
+Selector labels
+*/}}
+{{- define "substra.selectorLabels" -}}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/substra-backend/templates/add-account-operator.yaml
+++ b/charts/substra-backend/templates/add-account-operator.yaml
@@ -3,22 +3,19 @@ kind: Deployment
 metadata:
   name: {{ template "substra.fullname" . }}-add-account
   labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    {{ include "substra.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ template "substra.name" . }}-add-account
-    app.kubernetes.io/part-of: {{ template "substra.name" . }}
 spec:
   replicas: 1
   selector:
     matchLabels:
         app.kubernetes.io/name: {{ template "substra.name" . }}-add-account
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{ include "substra.selectorLabels" . | nindent 8}}
   template:
     metadata:
       labels:
+        {{ include "substra.labels" . | nindent 8 }}
         app.kubernetes.io/name: {{ template "substra.name" . }}-add-account
-        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
       - name: add-account

--- a/charts/substra-backend/templates/configmap-add-account.yaml
+++ b/charts/substra-backend/templates/configmap-add-account.yaml
@@ -1,7 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "substra.fullname" . }}-add-account
+  name: {{ include "substra.fullname" . }}-add-account
+  labels:
+    {{ include "substra.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "substra.name" . }}-add-account
 data:
   users: |
     {{- range .Values.users }}

--- a/charts/substra-backend/templates/configmap-events.yaml
+++ b/charts/substra-backend/templates/configmap-events.yaml
@@ -1,7 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "substra.fullname" . }}-events-uwsgi
+  name: {{ include "substra.fullname" . }}-events-uwsgi
+  labels:
+    {{ include "substra.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "substra.name" . }}-events
 data:
   uwsgi.ini: |
     [uwsgi]

--- a/charts/substra-backend/templates/configmap-ledger.yaml
+++ b/charts/substra-backend/templates/configmap-ledger.yaml
@@ -1,7 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "substra.fullname" . }}-ledger
+  name: {{ include "substra.fullname" . }}-ledger
+  labels:
+    {{ include "substra.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "substra.name" . }}
 data:
   LEDGER_CHANNELS: {{ .Values.channels | toJson | quote }}
   LEDGER_MSP_ID: {{ .Values.peer.mspID }}

--- a/charts/substra-backend/templates/configmap-private-ca.yaml
+++ b/charts/substra-backend/templates/configmap-private-ca.yaml
@@ -2,12 +2,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.privateCa.configMap.name }} 
+  name: {{ .Values.privateCa.configMap.name }}
   labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/name: {{ template "substra.name" . }}
+    {{ include "substra.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "substra.name" . }}
 data:
   {{ .Values.privateCa.configMap.fileName }}: |
 {{ .Values.privateCa.configMap.data | indent 4}}

--- a/charts/substra-backend/templates/configmap-server-uwsgi.yaml
+++ b/charts/substra-backend/templates/configmap-server-uwsgi.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "substra.fullname" . }}-server-uwsgi
+  labels:
+    {{ include "substra.labels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "substra.name" . }}
 data:
   uwsgi.ini: |
     [uwsgi]

--- a/charts/substra-backend/templates/deployment-celerybeat.yaml
+++ b/charts/substra-backend/templates/deployment-celerybeat.yaml
@@ -3,22 +3,19 @@ kind: Deployment
 metadata:
   name: {{ template "substra.fullname" . }}-celerybeat
   labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    {{ include "substra.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ template "substra.name" . }}-celerybeat
-    app.kubernetes.io/part-of: {{ template "substra.name" . }}
 spec:
   replicas: {{ .Values.celerybeat.replicaCount }}
   selector:
     matchLabels:
         app.kubernetes.io/name: {{ template "substra.name" . }}-celerybeat
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{ include "substra.selectorLabels" . | nindent 8}}
   template:
     metadata:
       labels:
+        {{ include "substra.labels" . | nindent 8 }}
         app.kubernetes.io/name: {{ template "substra.name" . }}-celerybeat
-        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       {{- with $.Values.celerybeat.image.pullSecrets }}
       imagePullSecrets:

--- a/charts/substra-backend/templates/deployment-events.yaml
+++ b/charts/substra-backend/templates/deployment-events.yaml
@@ -3,11 +3,8 @@ kind: Deployment
 metadata:
   name: {{ template "substra.fullname" . }}-events
   labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    {{ include "substra.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ template "substra.name" . }}-events
-    app.kubernetes.io/part-of: {{ template "substra.name" . }}
 spec:
   replicas: 1
   strategy:
@@ -15,12 +12,12 @@ spec:
   selector:
     matchLabels:
         app.kubernetes.io/name: {{ template "substra.name" . }}-events
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{ include "substra.selectorLabels" . | nindent 8}}
   template:
     metadata:
       labels:
+        {{ include "substra.labels" . | nindent 8 }}
         app.kubernetes.io/name: {{ template "substra.name" . }}-events
-        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       {{- if .Values.securityContext.enabled }}
       securityContext:

--- a/charts/substra-backend/templates/deployment-scheduler.yaml
+++ b/charts/substra-backend/templates/deployment-scheduler.yaml
@@ -3,22 +3,19 @@ kind: Deployment
 metadata:
   name: {{ template "substra.fullname" . }}-scheduler
   labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    {{ include "substra.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ template "substra.name" . }}-scheduler
-    app.kubernetes.io/part-of: {{ template "substra.name" . }}
 spec:
   replicas: {{ .Values.celeryworker.replicaCount }}
   selector:
     matchLabels:
         app.kubernetes.io/name: {{ template "substra.name" . }}-scheduler
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{ include "substra.selectorLabels" . | nindent 8}}
   template:
     metadata:
       labels:
+        {{ include "substra.labels" . | nindent 8 }}
         app.kubernetes.io/name: {{ template "substra.name" . }}-scheduler
-        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       {{- if .Values.securityContext.enabled }}
       securityContext:

--- a/charts/substra-backend/templates/deployment-server.yaml
+++ b/charts/substra-backend/templates/deployment-server.yaml
@@ -3,22 +3,20 @@ kind: Deployment
 metadata:
   name: {{ template "substra.fullname" . }}-server
   labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ include "substra.labels" . | nindent 4 }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ template "substra.name" . }}-server
-    app.kubernetes.io/part-of: {{ template "substra.name" . }}
 spec:
   replicas: {{ .Values.backend.replicaCount }}
   selector:
     matchLabels:
         app.kubernetes.io/name: {{ template "substra.name" . }}-server
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{ include "substra.selectorLabels" . | nindent 8}}
   template:
     metadata:
       labels:
+        {{ include "substra.labels" . | nindent 8 }}
         app.kubernetes.io/name: {{ template "substra.name" . }}-server
-        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       {{- if .Values.securityContext.enabled }}
       securityContext:

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -3,11 +3,9 @@ kind: Deployment
 metadata:
   name: {{ template "substra.fullname" . }}-worker
   labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{ include "substra.labels" . | nindent 4 }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ template "substra.name" . }}-worker
-    app.kubernetes.io/part-of: {{ template "substra.name" . }}
 spec:
   replicas: {{ .Values.celeryworker.replicaCount }}
   strategy:
@@ -15,12 +13,12 @@ spec:
   selector:
     matchLabels:
         app.kubernetes.io/name: {{ template "substra.name" . }}-worker
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{ include "substra.selectorLabels" . | nindent 8}}
   template:
     metadata:
       labels:
+        {{ include "substra.labels" . | nindent 8 }}
         app.kubernetes.io/name: {{ template "substra.name" . }}-worker
-        app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: substra-worker
     spec:
       {{- if .Values.securityContext.enabled }}

--- a/charts/substra-backend/templates/ingress.yaml
+++ b/charts/substra-backend/templates/ingress.yaml
@@ -4,10 +4,7 @@ kind: Ingress
 metadata:
   name: {{ template "substra.fullname" . }}-server
   labels:
-    app.kubernetes.io/name: {{ template "substra.fullname" . }}-server
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{ include "substra.labels" . | nindent 4 }}
   {{- with .Values.backend.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/substra-backend/templates/job-image-builder-warmer.yaml
+++ b/charts/substra-backend/templates/job-image-builder-warmer.yaml
@@ -4,13 +4,13 @@ kind: Job
 metadata:
   name: {{ template "substra.fullname" . }}-kaniko-cache-warmer
   labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    {{ include "substra.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ template "substra.name" . }}-kaniko-cache-warmer
-    app.kubernetes.io/part-of: {{ template "substra.name" . }}
 spec:
   template:
+    metadata:
+      labels:
+        {{ include "substra.labels" . | nindent 8 }}
     spec:
       # Run the cache warmer on the same node as the worker pod, because
       # they both use the "docker-cache" PV.

--- a/charts/substra-backend/templates/job-registry-prepopulate.yaml
+++ b/charts/substra-backend/templates/job-registry-prepopulate.yaml
@@ -6,20 +6,18 @@ kind: Deployment
 metadata:
   name: {{ template "substra.fullname" $ }}-registry-prepopulate-{{ $index }}
   labels:
-    app.kubernetes.io/managed-by: {{ $.Release.Service }}
-    app.kubernetes.io/instance: {{ $.Release.Name }}
-    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    {{ include "substra.labels" $ | nindent 4 }}
     app.kubernetes.io/name: {{ template "substra.name" $ }}-registry-prepopulate-{{ $index }}
-    app.kubernetes.io/part-of: {{ template "substra.name" $ }}
 spec:
   replicas: 1
   selector:
     matchLabels:
         app.kubernetes.io/name: {{ template "substra.name" $ }}-registry-prepopulate-{{ $index }}
-        app.kubernetes.io/instance: {{ $.Release.Name }}
+        {{ include "substra.selectorLabels" $ | nindent 8}}
   template:
     metadata:
       labels:
+        {{ include "substra.labels" $ | nindent 8 }}
         app.kubernetes.io/name: {{ template "substra.name" $ }}-registry-prepopulate-{{ $index }}
         app.kubernetes.io/instance: {{ $.Release.Name }}
     spec:

--- a/charts/substra-backend/templates/network-task-deny-all.yaml
+++ b/charts/substra-backend/templates/network-task-deny-all.yaml
@@ -4,6 +4,8 @@ kind: NetworkPolicy
 metadata:
   name: {{ template "substra.fullname". }}-deny-ingress
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "substra.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/substra-backend/templates/pod-security-policy.yaml
+++ b/charts/substra-backend/templates/pod-security-policy.yaml
@@ -4,11 +4,8 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ template "substra.fullname" . }}-psp
   labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    {{ include "substra.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ template "substra.name" . }}-psp
-    app.kubernetes.io/part-of: {{ template "substra.name" . }}
 spec:
   allowPrivilegeEscalation: false
   volumes:

--- a/charts/substra-backend/templates/rbac.yaml
+++ b/charts/substra-backend/templates/rbac.yaml
@@ -6,11 +6,8 @@ metadata:
   name: {{ template "substra.fullname" . }}-worker
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    {{ include "substra.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ template "substra.name" . }}
-    app.kubernetes.io/part-of: {{ template "substra.name" . }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -18,11 +15,8 @@ metadata:
   name: {{ template "substra.fullname" . }}-worker
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    {{ include "substra.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ template "substra.name" . }}
-    app.kubernetes.io/part-of: {{ template "substra.name" . }}
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
@@ -50,11 +44,8 @@ metadata:
   name: {{ template "substra.fullname" . }}-worker
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    {{ include "substra.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ template "substra.name" . }}
-    app.kubernetes.io/part-of: {{ template "substra.name" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "substra.fullname" . }}-worker

--- a/charts/substra-backend/templates/secret-pull.yaml
+++ b/charts/substra-backend/templates/secret-pull.yaml
@@ -7,10 +7,7 @@ kind: Secret
 metadata:
   name: {{ template "substra.fullname" $ }}-pull-secret-{{ $index }}
   labels:
-    app.kubernetes.io/managed-by: {{ $.Release.Service }}
-    app.kubernetes.io/instance: {{ $.Release.Name }}
-    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    {{ include "substra.labels" $ | nindent 4 }}
     app.kubernetes.io/name: {{ template "substra.fullname" $ }}-pull-secret-{{ $index }}
-    app.kubernetes.io/part-of: {{ template "substra.name" $ }}
 type: kubernetes.io/dockerconfigjson
 {{- end }}

--- a/charts/substra-backend/templates/service-server.yaml
+++ b/charts/substra-backend/templates/service-server.yaml
@@ -3,11 +3,8 @@ kind: Service
 metadata:
   name: {{ template "substra.fullname" . }}-server
   labels:
+    {{ include "substra.labels" . | nindent 4 }}
     app.kubernetes.io/name: {{ template "substra.name" . }}-server
-    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/part-of: {{ template "substra.name" . }}
     {{- if .Values.backend.service.labels }}
     {{- toYaml .Values.backend.service.labels | nindent 4 }}
     {{- end }}

--- a/charts/substra-backend/templates/storage.yaml
+++ b/charts/substra-backend/templates/storage.yaml
@@ -3,6 +3,8 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
+  labels:
+    {{ include "substra.labels" $ | nindent 4 }}
   name: {{ template "substra.fullname" $ }}-{{ .name }}
 spec:
   accessModes:
@@ -13,11 +15,8 @@ spec:
   {{- if $.Values.persistence.hostPath }}
   selector:
     matchLabels:
-      app.kubernetes.io/managed-by: {{ $.Release.Service }}
-      app.kubernetes.io/instance: {{ $.Release.Name }}
-      helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+      {{ include "substra.selectorLabels" $ | nindent 6 }}
       app.kubernetes.io/name: {{ template "substra.name" $ }}-{{ .name }}
-      app.kubernetes.io/part-of: {{ template "substra.name" $ }}-{{ .name }}
   {{- else if $.Values.persistence.storageClassName }}
   storageClassName: {{ $.Values.persistence.storageClassName }}
   {{- end }}
@@ -28,11 +27,8 @@ kind: PersistentVolume
 metadata:
   name: {{ template "substra.fullname" $ }}-{{ .name }}
   labels:
-    app.kubernetes.io/managed-by: {{ $.Release.Service }}
-    app.kubernetes.io/instance: {{ $.Release.Name }}
-    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    {{ include "substra.labels" $ | nindent 4 }}
     app.kubernetes.io/name: {{ template "substra.name" $ }}-{{ .name }}
-    app.kubernetes.io/part-of: {{ template "substra.name" $ }}-{{ .name }}
 spec:
   storageClassName: ""
   persistentVolumeReclaimPolicy: Recycle
@@ -53,6 +49,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ template "substra.fullname" $ }}-servermedias
+  labels:
+  {{ include "substra.labels" $ | nindent 4 }}
 spec:
   accessModes:
     - ReadWriteOnce
@@ -62,11 +60,8 @@ spec:
   {{- if $.Values.persistence.hostPath }}
   selector:
     matchLabels:
-      app.kubernetes.io/managed-by: {{ $.Release.Service }}
-      app.kubernetes.io/instance: {{ $.Release.Name }}
-      helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+      {{ include "substra.selectorLabels" $ | nindent 6 }}
       app.kubernetes.io/name: {{ template "substra.name" $ }}-servermedias
-      app.kubernetes.io/part-of: {{ template "substra.name" $ }}-servermedias
   {{- else if $.Values.persistence.storageClassName }}
   storageClassName: {{ $.Values.persistence.storageClassName }}
   {{- end }}
@@ -77,11 +72,8 @@ kind: PersistentVolume
 metadata:
   name: {{ template "substra.fullname" $ }}-servermedias
   labels:
-    app.kubernetes.io/managed-by: {{ $.Release.Service }}
-    app.kubernetes.io/instance: {{ $.Release.Name }}
-    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    {{ include "substra.labels" $ | nindent 4 }}
     app.kubernetes.io/name: {{ template "substra.name" $ }}-servermedias
-    app.kubernetes.io/part-of: {{ template "substra.name" $ }}-servermedias
 spec:
   storageClassName: ""
   persistentVolumeReclaimPolicy: Recycle
@@ -102,11 +94,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ template "substra.fullname" $ }}-docker-cache
   labels:
-    app.kubernetes.io/managed-by: {{ $.Release.Service }}
-    app.kubernetes.io/instance: {{ $.Release.Name }}
-    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    {{ include "substra.labels" $ | nindent 4 }}
     app.kubernetes.io/name: {{ template "substra.name" $ }}-docker-cache
-    app.kubernetes.io/part-of: {{ template "substra.name" $ }}-docker-cache
 spec:
   accessModes:
   - ReadWriteOnce
@@ -116,11 +105,8 @@ spec:
   {{- if $.Values.persistence.hostPath }}
   selector:
     matchLabels:
-      app.kubernetes.io/managed-by: {{ $.Release.Service }}
-      app.kubernetes.io/instance: {{ $.Release.Name }}
-      helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+      {{ include "substra.selectorLabels" $ | nindent 6 }}
       app.kubernetes.io/name: {{ template "substra.name" $ }}-docker-cache
-      app.kubernetes.io/part-of: {{ template "substra.name" $ }}-docker-cache
   {{- else if $.Values.persistence.storageClassName }}
   storageClassName: {{ $.Values.persistence.storageClassName }}
   {{- end }}
@@ -131,11 +117,8 @@ kind: PersistentVolume
 metadata:
   name: {{ template "substra.fullname" $ }}-docker-cache
   labels:
-    app.kubernetes.io/managed-by: {{ $.Release.Service }}
-    app.kubernetes.io/instance: {{ $.Release.Name }}
-    helm.sh/chart: {{ .Chart.Name }}-{{ $.Chart.Version }}
+    {{ include "substra.labels" $ | nindent 4 }}
     app.kubernetes.io/name: {{ template "substra.name" $ }}-docker-cache
-    app.kubernetes.io/part-of: {{ template "substra.name" $ }}-docker-cache
 spec:
   storageClassName: ""
   persistentVolumeReclaimPolicy: Recycle


### PR DESCRIPTION
## Description
This PR introduces a template for k8s labels in the helm chart. 
I updated all the old labels to use this new template for common labels and added labels to objects that were not labeled before.

The common labels includes:
- `helm.sh/chart`
- `app.kubernetes.io/managed-by`
- `app.kubernetes.io/part-of`
- `app.kubernetes.io/instance`

I hesitated to make `app.kubernetes.io/name` part of the common labels as it is all a single app and replace it in the code by `app.kubernetes/component` as we use it as a label selector for substra components deployments. Let me know if this is something we would like.

## Motivation and Context

The goal here is to simplify label usage from the point of view of a chart maintainer avoiding drift in the labels as we could have before. You also have only to write one line to add all the required labels instead of 4/5.

Another objective is to simplify filtering of the objects in kubernetes by harmonising all the labels used for substra.

## How Has This Been Tested?
- Local deployment with skaffold
- E2e tests

## Types of changes
- Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] Tested
- [x] Updated changelog