### PR TITLE
Remove trailing slash in CORS whitelist

### DIFF
--- a/values/backend-org-1.yaml
+++ b/values/backend-org-1.yaml
@@ -76,7 +76,7 @@ persistence:
 extraEnv:
   # Should be a json list
   - name: CORS_ORIGIN_WHITELIST
-    value: '["http://substra-frontend.node-1.com/", "http://substra-frontend.node-1.com:3000/", "http://substra-frontend.node-1.com:3001/"]'
+    value: '["http://substra-frontend.node-1.com", "http://substra-frontend.node-1.com:3000", "http://substra-frontend.node-1.com:3001"]'
   - name: CORS_ALLOW_CREDENTIALS
     value: "true"
   - name: DEFAULT_THROTTLE_RATES

--- a/values/backend-org-2.yaml
+++ b/values/backend-org-2.yaml
@@ -75,7 +75,7 @@ persistence:
 extraEnv:
   # Should be a json list
   - name: CORS_ORIGIN_WHITELIST
-    value: '["http://substra-frontend.node-2.com/", "http://substra-frontend.node-2.com:3000/", "http://substra-frontend.node-2.com:3001/"]'
+    value: '["http://substra-frontend.node-2.com", "http://substra-frontend.node-2.com:3000", "http://substra-frontend.node-2.com:3001"]'
   - name: CORS_ALLOW_CREDENTIALS
     value: "true"
   - name: DEFAULT_THROTTLE_RATES


### PR DESCRIPTION
Django checks are failing because of the trailing slash: CORS
whitelist items should not contain path.

django-cors-headers [explicitly check](https://github.com/adamchainz/django-cors-headers/blob/3.2.1/src/corsheaders/checks.py#L99) that there is no path.