### PR TITLE
Fix branch ref

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -25,7 +25,7 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/tags/master' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
     needs: test
     steps:
       - uses: actions/checkout@v2

--- a/charts/substra-backend/README.md
+++ b/charts/substra-backend/README.md
@@ -54,4 +54,3 @@ The following table lists the configurable parameters of the substra-backend cha
 ### Basic example
 
 For a simple example, see the [skaffold.yaml](../../skaffold.yaml) file.
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
 
## Description

Update git ref to target a branch instead of a tag.

I also added a small change to the chart (removed an empty line) just to trigger a publication of the chart that was not published.

## Motivation and Context

This is preventing the CI from publishing the helm chart as the current ref is a master tag and not a branch.
 
## How Has This Been Tested?

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)