### PR TITLE
[deps] remove django-rest-swagger

### DIFF
--- a/backend/backend/settings/common.py
+++ b/backend/backend/settings/common.py
@@ -72,7 +72,6 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.sites',
     'django_celery_results',
-    'rest_framework_swagger',
     'rest_framework',
     'rest_framework.authtoken',
     'rest_framework_simplejwt.token_blacklist',

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,7 +4,6 @@ checksumdir==1.1.7
 cryptography>=2.8
 django-cors-headers==3.2.1
 django-celery-results==1.1.2
-django-rest-swagger==2.2.0
 djangorestframework==3.11.2
 djangorestframework-simplejwt==4.4.0
 ipython==7.11.1


### PR DESCRIPTION
The removal of the swagger generation has been mostly done in #196
The dependency was unused since, this commit removes it.