### PR TITLE
Flatten volumes values

### DIFF
--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.8.0
+
+### Changed
+- `persistence.volumes` is now an object instead of an array
+- `persistence.volumes[].name` is now the key of the volume object
+
 ## 1.7.0
 
 ### Changed

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-backend
 home: https://substra.org/
-version: 1.7.0
+version: 1.8.0
 description: Main package for Substra
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/substra-backend/templates/deployment-server.yaml
+++ b/charts/substra-backend/templates/deployment-server.yaml
@@ -87,10 +87,10 @@ spec:
             containerPort: {{ .Values.backend.service.port }}
             protocol: TCP
         volumeMounts:
-          {{- range .Values.persistence.volumes }}
-          - name: data-{{ .name }}
-            mountPath: /var/substra/medias/{{ .name }}
-            readOnly: {{ .readOnly.server }}
+          {{- range $key, $val := .Values.persistence.volumes }}
+          - name: data-{{ $key }}
+            mountPath: /var/substra/medias/{{ $key }}
+            readOnly: {{ $val.readOnly.server }}
           {{- end }}
           - name: data-servermedias
             mountPath: /var/substra/servermedias
@@ -161,9 +161,9 @@ spec:
             chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }} $dir
           done
         volumeMounts:
-          {{- range .Values.persistence.volumes }}
-          - name: data-{{ .name }}
-            mountPath: /var/substra/medias/{{ .name }}
+          {{- range $key, $val := .Values.persistence.volumes }}
+          - name: data-{{ $key }}
+            mountPath: /var/substra/medias/{{ $key }}
           {{- end }}
       {{- end }}
       - name: wait-postgresql
@@ -210,10 +210,10 @@ spec:
           - name: statics
             mountPath: /usr/src/app/backend/statics
       volumes:
-      {{- range .Values.persistence.volumes }}
-      - name: data-{{ .name }}
+      {{- range $key, $val := .Values.persistence.volumes }}
+      - name: data-{{ $key }}
         persistentVolumeClaim:
-          claimName: {{ include "substra.fullname" $ }}-{{ .name }}
+          claimName: {{ include "substra.fullname" $ }}-{{ $key }}
       {{- end }}
       - name: data-servermedias
         persistentVolumeClaim:

--- a/charts/substra-backend/templates/deployment-worker.yaml
+++ b/charts/substra-backend/templates/deployment-worker.yaml
@@ -114,9 +114,9 @@ spec:
             - name: REQUESTS_CA_BUNDLE
               value: /etc/ssl/certs/ca-certificates.crt
             {{- end }}
-            {{- range .Values.persistence.volumes }}
-            - name: {{ .name | upper }}_PVC
-              value: {{ include "substra.fullname" $ }}-{{ .name }}
+            {{- range $key, $val := .Values.persistence.volumes }}
+            - name: {{ $key | upper }}_PVC
+              value: {{ include "substra.fullname" $ }}-{{ $key }}
             {{- end }}
             - name: SERVERMEDIAS_PVC
               value: {{ template "substra.fullname" $ }}-servermedias
@@ -157,10 +157,10 @@ spec:
 {{ toYaml . | indent 12 }}
           {{- end }}
           volumeMounts:
-            {{- range .Values.persistence.volumes }}
-            - name: data-{{ .name }}
-              mountPath: /var/substra/medias/{{ .name }}
-              readOnly: {{ .readOnly.worker }}
+            {{- range $key, $val := .Values.persistence.volumes }}
+            - name: data-{{ $key }}
+              mountPath: /var/substra/medias/{{ $key }}
+              readOnly: {{ $val.readOnly.worker }}
             {{- end }}
             - name: data-servermedias
               mountPath: /var/substra/servermedias
@@ -182,10 +182,10 @@ spec:
           resources:
             {{- toYaml .Values.celeryworker.resources | nindent 12 }}
       volumes:
-      {{- range .Values.persistence.volumes }}
-      - name: data-{{ .name }}
+      {{- range $key, $val := .Values.persistence.volumes }}
+      - name: data-{{ $key }}
         persistentVolumeClaim:
-          claimName: {{ include "substra.fullname" $ }}-{{ .name }}
+          claimName: {{ include "substra.fullname" $ }}-{{ $key }}
       {{- end }}
       - name: data-servermedias
         persistentVolumeClaim:

--- a/charts/substra-backend/templates/storage.yaml
+++ b/charts/substra-backend/templates/storage.yaml
@@ -1,11 +1,11 @@
-{{- range .Values.persistence.volumes }}
+{{- range $key, $val := .Values.persistence.volumes }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   labels:
     {{ include "substra.labels" $ | nindent 4 }}
-  name: {{ template "substra.fullname" $ }}-{{ .name }}
+  name: {{ template "substra.fullname" $ }}-{{ $key }}
 spec:
   accessModes:
     - ReadWriteOnce
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       {{ include "substra.selectorLabels" $ | nindent 6 }}
-      app.kubernetes.io/name: {{ template "substra.name" $ }}-{{ .name }}
+      app.kubernetes.io/name: {{ template "substra.name" $ }}-{{ $key }}
   {{- else if $.Values.persistence.storageClassName }}
   storageClassName: {{ $.Values.persistence.storageClassName }}
   {{- end }}
@@ -25,22 +25,22 @@ spec:
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ template "substra.fullname" $ }}-{{ .name }}
+  name: {{ template "substra.fullname" $ }}-{{ $key }}
   labels:
     {{ include "substra.labels" $ | nindent 4 }}
-    app.kubernetes.io/name: {{ template "substra.name" $ }}-{{ .name }}
+    app.kubernetes.io/name: {{ template "substra.name" $ }}-{{ $key }}
 spec:
   storageClassName: ""
   persistentVolumeReclaimPolicy: Recycle
   claimRef:
-    name: {{ template "substra.fullname" $ }}-{{ .name }}
+    name: {{ template "substra.fullname" $ }}-{{ $key }}
     namespace: {{ $.Release.Namespace }}
   capacity:
-    storage: {{ .size | quote }}
+    storage: {{ $val.size | quote }}
   accessModes:
     - ReadWriteOnce
   hostPath:
-    path: {{ $.Values.persistence.hostPath }}/medias/{{ .name }}
+    path: {{ $.Values.persistence.hostPath }}/medias/{{ $key }}
     type: DirectoryOrCreate
 {{- end }}
 {{- end }}

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -86,52 +86,52 @@ persistence:
   # hostPathServerMedias: "/host/servermedias"
   size: "10Gi"
   volumes:
-    - name: algos
+    algos:
       size: "10Gi"
       readOnly:
         server: false
         worker: true
-    - name: aggregatealgos
+    aggregatealgos:
       size: "10Gi"
       readOnly:
         server: false
         worker: true
-    - name: compositealgos
+    compositealgos:
       size: "10Gi"
       readOnly:
         server: false
         worker: true
-    - name: datamanagers
+    datamanagers:
       size: "10Gi"
       readOnly:
         server: false
         worker: true
-    - name: datasamples
+    datasamples:
       size: "10Gi"
       readOnly:
         server: false
         worker: true
-    - name: objectives
+    objectives:
       size: "10Gi"
       readOnly:
         server: false
         worker: true
-    - name: models
+    models:
       size: "10Gi"
       readOnly:
         server: true
         worker: false
-    - name: subtuple
+    subtuple:
       size: "10Gi"
       readOnly:
         server: true
         worker: false
-    - name: computeplan
+    computeplan:
       size: "10Gi"
       readOnly:
         server: true
         worker: false
-    - name: local
+    local:
       size: "10Gi"
       readOnly:
         server: true


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Flatten the array of volumes under the key `persistence.volumes`.
This result in the same yaml manifest output by helm.

This change does not reduce our possibilities as it would never have been possible to write a `.name` property with a value like `Awesome volume`.  The value is used in object name and that field that must mach the object name policy of kubernetes.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With this modification a user is able to change the size of one of the volumes without redefining the whole array of values.
This prevent from a typo or mistakes in the other fields of these values when you only want to redefine one of them.

Previously you had to write this in your value file to redefine `aggregatealgos` volume size from `10Gi` to `255Gi`
```yaml
persistence:
  volumes:
      - name: algos
        size: "10Gi"
        readOnly:
          server: false
          worker: true
      - name: aggregatealgos
        size: "255Gi"
        readOnly:
          server: false
          worker: true
      - name: compositealgos
        size: "10Gi"
        readOnly:
          server: false
          worker: true
      - [...]
```
Now you have to write:
```yaml
persistence:
  volumes:
    aggregatealgos:
      size: "255Gi"
```

## How Has This Been Tested?
```sh
helm template test charts/substra-backend/ > upgraded.yml
git switch master
helm template test charts/substra-backend/ > master.yml
dyff between master.yml upgraded.yml
```
[dyff](https://github.com/homeport/dyff) showed only reorder of the keys in the resulting yaml and change of randomly generated values.
<details>
  <summary>Result (click to unfold)</summary>

 ```plain
     _        __  __
   _| |_   _ / _|/ _|  between /workspace/substra/substra-backend/master.yml, documents
 / _' | | | | |_| |_       and /workspace/substra/substra-backend/upgraded.yml, documents
| (_| | |_| |  _|  _|
 \__,_|\__, |_| |_|   returned 51 differences
        |___/

metadata.labels.helm.sh/chart  (document #1)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.labels.helm.sh/chart  (document #2)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.labels.helm.sh/chart  (document #4)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

data.haSharedSecret  (document #5)
  ± value change
    - M1VMR1p1RU9KZ2NKWjNtSw==
    + TDJqY1ZzWUZNWmZSYlJCSQ==

data.rabbitmq-erlang-cookie  (document #7)
  ± value change
    - RlJiTmZZS2k4VTNxaHlkclZiMjFyREFlRE1xNzA4QVU=
    + OVZkSlptUE56RGZBS2t1UW9WNVhYTnJEOTVINE9KdXo=

metadata.labels.helm.sh/chart  (document #11)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.labels.helm.sh/chart  (document #12)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.labels.helm.sh/chart  (document #13)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.labels.helm.sh/chart  (document #14)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.labels.helm.sh/chart  (document #16)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.name  (document #16)
  ± value change
    - test-substra-backend-algos
    + test-substra-backend-aggregatealgos

metadata.labels.helm.sh/chart  (document #18)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.name  (document #18)
  ± value change
    - test-substra-backend-aggregatealgos
    + test-substra-backend-algos

metadata.labels.helm.sh/chart  (document #20)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.labels.helm.sh/chart  (document #22)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.name  (document #22)
  ± value change
    - test-substra-backend-datamanagers
    + test-substra-backend-computeplan

metadata.labels.helm.sh/chart  (document #24)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.name  (document #24)
  ± value change
    - test-substra-backend-datasamples
    + test-substra-backend-datamanagers

metadata.labels.helm.sh/chart  (document #26)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.name  (document #26)
  ± value change
    - test-substra-backend-objectives
    + test-substra-backend-datasamples

metadata.labels.helm.sh/chart  (document #28)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.name  (document #28)
  ± value change
    - test-substra-backend-models
    + test-substra-backend-local

metadata.labels.helm.sh/chart  (document #30)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.name  (document #30)
  ± value change
    - test-substra-backend-subtuple
    + test-substra-backend-models

metadata.labels.helm.sh/chart  (document #32)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.name  (document #32)
  ± value change
    - test-substra-backend-computeplan
    + test-substra-backend-objectives

metadata.labels.helm.sh/chart  (document #34)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.name  (document #34)
  ± value change
    - test-substra-backend-local
    + test-substra-backend-subtuple

metadata.labels.helm.sh/chart  (document #36)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.labels.helm.sh/chart  (document #38)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.labels.helm.sh/chart  (document #39)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.labels.helm.sh/chart  (document #40)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.labels.helm.sh/chart  (document #48)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.labels.helm.sh/chart  (document #50)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

spec.template.metadata.labels.helm.sh/chart  (document #50)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.labels.helm.sh/chart  (document #51)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

spec.template.metadata.labels.helm.sh/chart  (document #51)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.labels.helm.sh/chart  (document #52)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

spec.template.metadata.labels.helm.sh/chart  (document #52)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.labels.helm.sh/chart  (document #53)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

spec.template.metadata.labels.helm.sh/chart  (document #53)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

metadata.labels.helm.sh/chart  (document #54)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

spec.template.metadata.labels.helm.sh/chart  (document #54)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

spec.template.spec.containers.substra-backend.volumeMounts  (document #54)
  ⇆ order changed
    data-algos            data-aggregatealgos
    data-aggregatealgos   data-algos
    data-compositealgos   data-compositealgos
    data-datamanagers     data-computeplan
    data-datasamples      data-datamanagers
    data-objectives       data-datasamples
    data-models           data-local
    data-subtuple         data-models
    data-computeplan      data-objectives
    data-local            data-subtuple
    data-servermedias     data-servermedias
    statics               statics
    uwsgi                 uwsgi
    user-cert             user-cert
    user-key              user-key
    peer-tls-server       peer-tls-server
    peer-tls-client       peer-tls-client
    cacert                cacert
spec.template.spec.volumes  (document #54)
  ⇆ order changed
    data-algos            data-aggregatealgos
    data-aggregatealgos   data-algos
    data-compositealgos   data-compositealgos
    data-datamanagers     data-computeplan
    data-datasamples      data-datamanagers
    data-objectives       data-datasamples
    data-models           data-local
    data-subtuple         data-models
    data-computeplan      data-objectives
    data-local            data-subtuple
    data-servermedias     data-servermedias
    statics               statics
    uwsgi                 uwsgi
    user-cert             user-cert
    user-key              user-key
    peer-tls-server       peer-tls-server
    peer-tls-client       peer-tls-client
    cacert                cacert
metadata.labels.helm.sh/chart  (document #55)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

spec.template.metadata.labels.helm.sh/chart  (document #55)
  ± value change
    - substra-backend-1.7.0
    + substra-backend-2.0.0

spec.template.spec.containers.worker.env  (document #55)
  ⇆ order changed
    DJANGO_SETTINGS_MODULE        DJANGO_SETTINGS_MODULE
    ORG_NAME                      ORG_NAME
    BACKEND_DB_NAME               BACKEND_DB_NAME
    BACKEND_DB_USER               BACKEND_DB_USER
    BACKEND_DB_PWD                BACKEND_DB_PWD
    DATABASE_HOST                 DATABASE_HOST
    DEFAULT_DOMAIN                DEFAULT_DOMAIN
    CELERY_BROKER_URL             CELERY_BROKER_URL
    MEDIA_ROOT                    MEDIA_ROOT
    PYTHONUNBUFFERED              PYTHONUNBUFFERED
    CELERYWORKER_IMAGE            CELERYWORKER_IMAGE
    CELERY_WORKER_CONCURRENCY     CELERY_WORKER_CONCURRENCY
    ALGOS_PVC                     AGGREGATEALGOS_PVC
    AGGREGATEALGOS_PVC            ALGOS_PVC
    COMPOSITEALGOS_PVC            COMPOSITEALGOS_PVC
    DATAMANAGERS_PVC              COMPUTEPLAN_PVC
    DATASAMPLES_PVC               DATAMANAGERS_PVC
    OBJECTIVES_PVC                DATASAMPLES_PVC
    MODELS_PVC                    LOCAL_PVC
    SUBTUPLE_PVC                  MODELS_PVC
    COMPUTEPLAN_PVC               OBJECTIVES_PVC
    LOCAL_PVC                     SUBTUPLE_PVC
    SERVERMEDIAS_PVC              SERVERMEDIAS_PVC
    REGISTRY                      REGISTRY
    REGISTRY_SCHEME               REGISTRY_SCHEME
    REGISTRY_PULL_DOMAIN          REGISTRY_PULL_DOMAIN
    NAMESPACE                     NAMESPACE
    DOCKER_CACHE_PVC              DOCKER_CACHE_PVC
    NODE_NAME                     NODE_NAME
    RUN_AS_USER                   RUN_AS_USER
    RUN_AS_GROUP                  RUN_AS_GROUP
    FS_GROUP                      FS_GROUP
    KANIKO_IMAGE                  KANIKO_IMAGE
    KANIKO_MIRROR                 KANIKO_MIRROR
    COMPUTE_REGISTRY              COMPUTE_REGISTRY
    HTTP_CLIENT_TIMEOUT_SECONDS   HTTP_CLIENT_TIMEOUT_SECONDS
spec.template.spec.containers.worker.volumeMounts  (document #55)
  ⇆ order changed
    data-algos            data-aggregatealgos
    data-aggregatealgos   data-algos
    data-compositealgos   data-compositealgos
    data-datamanagers     data-computeplan
    data-datasamples      data-datamanagers
    data-objectives       data-datasamples
    data-models           data-local
    data-subtuple         data-models
    data-computeplan      data-objectives
    data-local            data-subtuple
    data-servermedias     data-servermedias
    user-cert             user-cert
    user-key              user-key
    peer-tls-server       peer-tls-server
    peer-tls-client       peer-tls-client
    cacert                cacert
spec.template.spec.volumes  (document #55)
  ⇆ order changed
    data-algos            data-aggregatealgos
    data-aggregatealgos   data-algos
    data-compositealgos   data-compositealgos
    data-datamanagers     data-computeplan
    data-datasamples      data-datamanagers
    data-objectives       data-datasamples
    data-models           data-local
    data-subtuple         data-models
    data-computeplan      data-objectives
    data-local            data-subtuple
    data-servermedias     data-servermedias
    user-cert             user-cert
    user-key              user-key
    peer-tls-server       peer-tls-server
    peer-tls-client       peer-tls-client
    cacert                cacert
spec.template.metadata.annotations.checksum/secret  (document #57)
  ± value change
    - 22cfedb17295a4e249ec46f61ebc03218e5c369e11bc1e3c7f8881e9aaba405b
    + a73b027e02e3910c34e622b962dc14bcd5335dbb3a0aa097f5920d1c48d696f4
 ```
</details>

```sh
helm install -f values/backend-org-1.yaml -n org-1 substra ./charts/substra-backend
helm upgrade -f values/backend-org-1.yaml -n org-1 substra ./charts/substra-backend
```
A new backend and everything started correctly, I just had an error because the kaniko job can't be patched.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.