### PR TITLE
Bump djangorestframework-simplejwt to 4.6.0

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,7 +5,7 @@ cryptography>=2.8
 django-cors-headers==3.2.1
 django-celery-results==1.1.2
 djangorestframework==3.11.2
-djangorestframework-simplejwt==4.4.0
+djangorestframework-simplejwt==4.6.0
 ipython==7.11.1
 ipython-genutils==0.2.0
 kubernetes==11.0.0


### PR DESCRIPTION
Bump djangorestframework-simplejwt version to be compatible with PyJWT 2.0.0