### PR TITLE
Fix CI python version

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.6
       - uses: actions/cache@v2
         id: cache
         with:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Set CI python version to `3.6`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The python version in the CI was not matching the python version in the [Dockerfile](https://github.com/SubstraFoundation/substra-backend/blob/f8870a353d1d241bcf753a21147583a3d8a04651/docker/substra-backend/Dockerfile#L1), this was making the CI unreliable to validate modifications.

We noticed this issue after the merge of #366 where the CI was running okay but the DockerHub build was failing.

# How Has This Been Tested?

You can look at the logs of the checks tab.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)