### PR TITLE
[doc] prefered way to deploy with images from repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ Provided you have correctly setup your [network configuration](https://doc.subst
 Make sure you deploy this backend with a compatible ecosystem (chaincode, hlf-k8s, etc).
 Always refer to the [compatibility table](https://github.com/SubstraFoundation/substra#compatibility-table).
 
+The recommended way to run a specific version (0.1.6) of substra-backend is to execute:
+
+```bash
+SUBSTRA_BACKEND_VERSION=0.1.6
+git checkout $SUBSTRA_BACKEND_VERSION
+skaffold deploy --images substrafoundation/substra-backend:$SUBSTRA_BACKEND_VERSION
+```
+
 ## Companion repositories
 
 The Substra platform is built from several components (see the [architecture](https://doc.substra.ai/architecture.html) documentation for a comprehensive overview):


### PR DESCRIPTION
## Motivation

Rebuilding some images now leads to broken backend. While this has been fixed by #367, previous releases cannot be rebuilt correctly. However, images in [registry](https://hub.docker.com/r/substrafoundation/substra-backend) are fine, so this only really impacts local usage of previous tags.

In order to run a previous version locally, instead of rebuilding the image, this PR introduce a new skaffold config file to run an arbitrary backend version.

## How to address this ?

Skaffold allows to deploy without building (`deploy` command), so let's just leverage that.
Here is the snippet added to the readme:
```bash
SUBSTRA_BACKEND_VERSION=0.1.6
git checkout $SUBSTRA_BACKEND_VERSION
docker pull substrafoundation/substra-backend:$SUBSTRA_BACKEND_VERSION
skaffold deploy --images substrafoundation/substra-backend:$SUBSTRA_BACKEND_VERSION
```

- it will work as long as images are in the repository
- this doesn't add any maintenance burden
- as opposed to the previous implementation with a separate skaffold file, since we can checkout the tag values files will be compatible with the release

ℹ️ Here the backend is impacted but other components of the stack may face the same rebuild issue at some point. Besides, having a harmonized way to run specific tags throughout the stack is a better developer experience. So it might be desirable to implement the same strategy for other projects, what do you think?