### PR TITLE
fix the grpcio version to 1.30.0

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,6 +16,7 @@ tldextract==2.2.3
 uwsgi==2.0.19.1
 zxcvbn==4.4.28
 boto3==1.11.9
+grpcio==1.30.0  # Fix the grpcio version because of stability issues in 1.31.0+ (see https://github.com/grpc/grpc/issues/23796)
 fabric-sdk-py==1.0.0
 # dev-mode
 watchdog==1.0.1


### PR DESCRIPTION
Fix the grpcio version until the issue is fixed upstream.

Segmentation faults have been observed in some deployments (testnet) on the backend-server pod

```
!!! uWSGI process 306 got Segmentation Fault !!!
*** backtrace of 306 ***
uwsgi(uwsgi_backtrace+0x2a) [0x55909c38e34a]
uwsgi(uwsgi_segfault+0x23) [0x55909c38e703]
/lib/x86_64-linux-gnu/libc.so.6(+0x37840) [0x7f0f9af26840]
/usr/local/lib/python3.6/site-packages/grpc/_cython/cygrpc.cpython-36m-x86_64-linux-gnu.so(+0x2a7735) [0x7f0f97999735]
/usr/local/lib/python3.6/site-packages/grpc/_cython/cygrpc.cpython-36m-x86_64-linux-gnu.so(+0x29e7d2) [0x7f0f979907d2]
/usr/local/lib/python3.6/site-packages/grpc/_cython/cygrpc.cpython-36m-x86_64-linux-gnu.so(+0x29f649) [0x7f0f97991649]
/usr/local/lib/python3.6/site-packages/grpc/_cython/cygrpc.cpython-36m-x86_64-linux-gnu.so(+0x18dbed) [0x7f0f9787fbed]
/usr/local/lib/python3.6/site-packages/grpc/_cython/cygrpc.cpython-36m-x86_64-linux-gnu.so(+0x2a3fa4) [0x7f0f97995fa4]
/usr/local/lib/python3.6/site-packages/grpc/_cython/cygrpc.cpython-36m-x86_64-linux-gnu.so(+0x2bac49) [0x7f0f979acc49]
/usr/local/lib/python3.6/site-packages/grpc/_cython/cygrpc.cpython-36m-x86_64-linux-gnu.so(+0x293c88) [0x7f0f97985c88]
/lib/x86_64-linux-gnu/libpthread.so.0(+0x7fa3) [0x7f0f9b5bffa3]
/lib/x86_64-linux-gnu/libc.so.6(clone+0x3f) [0x7f0f9afe84cf]
*** end of backtrace ***
```

This PR attempts to mitigate the issue by using the solution described in https://github.com/grpc/grpc/issues/23796

With the fix enabled, I have not observed any segfault on the target environment (testnet), although this is not a guarantee that the fix works since the issue happens at random.
