### PR TITLE
[doc] expose generated openapi spec

### DIFF
--- a/backend/backend/settings/common.py
+++ b/backend/backend/settings/common.py
@@ -77,7 +77,8 @@ INSTALLED_APPS = [
     'rest_framework_simplejwt.token_blacklist',
     'substrapp',
     'node',
-    'users'
+    'users',
+    'drf_spectacular',
 ]
 
 AUTHENTICATION_BACKENDS = [

--- a/backend/backend/settings/deps/restframework.py
+++ b/backend/backend/settings/deps/restframework.py
@@ -30,6 +30,7 @@ REST_FRAMEWORK = {
         'rest_framework.parsers.FormParser',
         'libs.json_multipart_parser.JsonMultiPartParser'
     ],
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
 }
 
 SIMPLE_JWT = {
@@ -38,4 +39,8 @@ SIMPLE_JWT = {
     'ROTATE_REFRESH_TOKENS': True,
     'AUTH_HEADER_TYPES': ('JWT',),
     'BLACKLIST_AFTER_ROTATION': True,
+}
+
+SPECTACULAR_SETTINGS = {
+    'SERVE_PERMISSIONS': ['rest_framework.permissions.IsAuthenticated'],
 }

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -16,9 +16,14 @@ Including another URLconf
 from django.conf.urls import url
 from django.conf import settings
 from django.conf.urls.static import static
-from django.urls import include
+from django.urls import include, path
 from rest_framework.settings import api_settings
 from rest_framework.renderers import BrowsableAPIRenderer
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularRedocView,
+    SpectacularSwaggerView,
+)
 
 from backend.views import obtain_auth_token
 
@@ -35,7 +40,20 @@ urlpatterns = [
         url(r'^api-token-auth/', obtain_auth_token)  # for expiry token authent
     ])),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT) \
-  + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+  + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT) \
+  + [  # OpenAPI spec and UI
+      path("schema/", SpectacularAPIView.as_view(), name="schema"),
+      path(
+          "schema/swagger-ui/",
+          SpectacularSwaggerView.as_view(url_name="schema"),
+          name="swagger-ui",
+      ),
+      path(
+          "schema/redoc/",
+          SpectacularRedocView.as_view(url_name="schema"),
+          name="redoc",
+      ),
+]
 
 # only allow session authentication is the browsable API is enabled
 if BrowsableAPIRenderer in api_settings.DEFAULT_RENDERER_CLASSES:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,7 @@ django-cors-headers==3.2.1
 django-celery-results==1.1.2
 djangorestframework==3.11.2
 djangorestframework-simplejwt==4.4.0
+drf-spectacular==0.13.0
 pyjwt==1.7.1
 ipython==7.11.1
 ipython-genutils==0.2.0


### PR DESCRIPTION
This adds 3 new routes:
- /schema/ exposing the openapi spec
- /schema/swagger-ui/ to browse the spec with the swagger UI
- /schema/redoc/ to browse the spec with the redoc UI

A similar feature previously existed, provided by django-rest-swagger
but the repository has been archived and the author recommended
drf-yasg. On the documentation page of drf-yasg, the author mentions
that drf-yasg won't support openapi 3.0 and recommend to use
drf-spectacular to expose an openapi 3.0 spec.

That's why I chose drf-spectacular, which works the same way than
django-rest-framework and is BSD licensed.

## Examples

<details>
<summary>Here is the swagger view ⬇️ </summary>

![image](https://user-images.githubusercontent.com/49146345/105334013-abe56a80-5bd6-11eb-877e-7ec3500ee1ec.png)
</details>

<details>
<summary>And the redoc one ⬇️ </summary>

![image](https://user-images.githubusercontent.com/49146345/105334100-c881a280-5bd6-11eb-9dae-ee8fec58c3db.png)
</details>

Here is the generated schema: [schema.txt](https://github.com/SubstraFoundation/substra-backend/files/5848423/schema.txt) (.yml but github only allows .txt uploads)
