### PR TITLE
Improve local volume handling in case of retries

### DIFF
--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -598,11 +598,6 @@ def delete_compute_pod(name):
     logger.info(f'Deleted pod {NAMESPACE}/{name}')
 
 
-def k8s_get_or_create_local_volume(volume_id):
-    pvc = K8S_PVC['LOCAL_PVC']
-    logger.info(f'{volume_id} will be created in the PVC {pvc}')
-
-
 def get_security_context(enabled=True, root=False, privileged=False, add_capabilities=None):
     if enabled:
         if not root:

--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -732,7 +732,7 @@ def do_task(channel_name, subtuple, tuple_type):
         # Copy content of local folder from subtuple directory to local folder in pvc
         # to fetch modification of local folder content
         distutils.dir_util.copy_tree(local_path, local_path_in_pvc)
-        logger.info(f'Content from {local_path} has been copied to {local_path_in_pvc}')
+        logger.info(f'Content from sandbox {local_path} has been copied to pvc {local_path_in_pvc}')
 
     # Evaluation
     if tuple_type == TESTTUPLE_TYPE:
@@ -822,7 +822,7 @@ def prepare_volumes(subtuple_directory, tuple_type, compute_plan_key, compute_pl
         # local data.
         if os.path.exists(local_path_in_pvc):
             distutils.dir_util.copy_tree(local_path_in_pvc, local_path)
-            logger.info(f'Content from {local_path_in_pvc} has been copied to {local_path}')
+            logger.info(f'Content from pvc {local_path_in_pvc} has been copied to sandbox {local_path}')
 
         mode = 'ro' if tuple_type == TESTTUPLE_TYPE else 'rw'
         model_volume[local_path] = {'bind': LOCAL_FOLDER, 'mode': mode}

--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -730,7 +730,7 @@ def do_task(channel_name, subtuple, tuple_type):
         local_path_in_pvc = get_local_folder(compute_plan_key)
 
         # Copy content of local folder from subtuple directory to local folder in pvc
-        # to fetch modification of ocal folder content
+        # to fetch modification of local folder content
         distutils.dir_util.copy_tree(local_path, local_path_in_pvc)
         logger.info(f'Content from {local_path} has been copied to {local_path_in_pvc}')
 

--- a/backend/substrapp/tasks/tasks.py
+++ b/backend/substrapp/tasks/tasks.py
@@ -818,7 +818,7 @@ def prepare_volumes(subtuple_directory, tuple_type, compute_plan_key, compute_pl
         get_or_create_local_volume(get_local_folder_name(compute_plan_key))
 
         # Copy content of local folder from pvc to local folder in subtuple directory
-        # It allows the cp subtuple to be retried with compromising the
+        # It allows the cp subtuple to be retried without compromising the
         # local data.
         if os.path.exists(local_path_in_pvc):
             distutils.dir_util.copy_tree(local_path_in_pvc, local_path)

--- a/backend/substrapp/tasks/utils.py
+++ b/backend/substrapp/tasks/utils.py
@@ -8,8 +8,7 @@ from requests.auth import HTTPBasicAuth
 from substrapp.utils import get_owner, get_remote_file_content, get_and_put_remote_file_content, NodeError, timeit
 
 from substrapp.tasks.k8s_backend import (
-    k8s_get_image, k8s_build_image, k8s_get_or_create_local_volume,
-    k8s_remove_image, k8s_compute, ImageNotFound, BuildError)
+    k8s_get_image, k8s_build_image, k8s_remove_image, k8s_compute, ImageNotFound, BuildError)
 
 
 CELERYWORKER_IMAGE = os.environ.get('CELERYWORKER_IMAGE', 'substrafoundation/celery:latest')
@@ -79,10 +78,6 @@ def list_files(startpath, as_json=True):
             res += f'{subindent}{f}' + "\n"
 
     return res
-
-
-def get_or_create_local_volume(volume_id):
-    return k8s_get_or_create_local_volume(volume_id)
 
 
 def remove_image(image_name):

--- a/backend/substrapp/tests/views/tests_local_folder.py
+++ b/backend/substrapp/tests/views/tests_local_folder.py
@@ -1,0 +1,78 @@
+import os
+import mock
+import tempfile
+import uuid
+from django.test import override_settings
+from rest_framework.test import APITestCase
+from substrapp.tasks.tasks import build_subtuple_folders, do_task, TRAINTUPLE_TYPE
+from substrapp.utils import get_cp_local_folder
+from parameterized import parameterized
+
+MEDIA_ROOT = tempfile.mkdtemp()
+
+
+@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+class LocalFolderTests(APITestCase):
+
+    # This test ensures that changes to the subtuple local folder are
+    # reflected to the compute plan local folder iff the tuple execution succeeds.
+    @parameterized.expand([
+        ("without_exception", True),
+        ("with_exception", False)
+    ])
+    def test_local_folder(self, _, compute_job_raises):
+        channel_name = 'dummy_channel'
+        compute_plan_tag = 'cp1'
+        compute_plan_key = str(uuid.uuid4())
+
+        file = 'model.txt'
+        initial_value = 'initial value'
+        updated_value = 'updated value'
+
+        subtuple = {
+            'key': str(uuid.uuid4()),
+            'compute_plan_key': compute_plan_key,
+            'rank': 1,
+            'algo': {
+                'key': 'some key'
+            }
+        }
+
+        # Write an initial value into the compute plan local folder
+        cp_local_folder = get_cp_local_folder(compute_plan_key)
+        os.makedirs(cp_local_folder, exist_ok=True)
+        with open(os.path.join(cp_local_folder, file), 'w') as x:
+            x.write(initial_value)
+
+        # Call `do_task`, which will:
+        # 1. write a new value to the subtuple local folder
+        # 2. and then:
+        #    - complete successfully (compute_job_raises == False)
+        #    - or raise an exception (compute_job_raises == True)
+        with mock.patch('substrapp.ledger.api.query_ledger') as mquery_ledger,\
+             mock.patch('substrapp.tasks.tasks.generate_command'),\
+             mock.patch('substrapp.tasks.tasks.save_models'),\
+             mock.patch('substrapp.tasks.tasks.compute_job') as mcompute_job:
+            mquery_ledger.return_value = {'tag': compute_plan_tag}
+
+            def compute_job(*args, **kwargs):
+                for vol in kwargs['volumes']:
+                    if vol.endswith('/local'):
+                        with open(os.path.join(vol, file), 'w') as x:
+                            x.write(updated_value)
+                if compute_job_raises:
+                    raise Exception('Boom!')
+
+            mcompute_job.side_effect = compute_job
+            try:
+                build_subtuple_folders(subtuple)
+                do_task(channel_name, subtuple, TRAINTUPLE_TYPE)
+            except Exception:
+                pass
+
+        # Check the compute plan local folder value is correct:
+        # - If do_task did raise an exception then the local value should be unchanged
+        # - If do_task did not raise an exception then the local value should be updated
+        with open(os.path.join(cp_local_folder, file), 'r') as x:
+            content = x.read()
+        self.assertEqual(content, initial_value if compute_job_raises else updated_value)

--- a/backend/substrapp/tests/views/tests_local_folder.py
+++ b/backend/substrapp/tests/views/tests_local_folder.py
@@ -53,7 +53,6 @@ class LocalFolderTests(APITestCase):
              mock.patch('substrapp.tasks.tasks.generate_command'),\
              mock.patch('substrapp.tasks.tasks.save_models'),\
              mock.patch('substrapp.tasks.tasks.compute_job') as mcompute_job:
-            mquery_ledger.return_value = {'tag': compute_plan_tag}
 
             def compute_job(*args, **kwargs):
                 for vol in kwargs['volumes']:
@@ -63,12 +62,16 @@ class LocalFolderTests(APITestCase):
                 if compute_job_raises:
                     raise Exception('Boom!')
 
+            mquery_ledger.return_value = {'tag': compute_plan_tag}
             mcompute_job.side_effect = compute_job
+
             try:
                 build_subtuple_folders(subtuple)
                 do_task(channel_name, subtuple, TRAINTUPLE_TYPE)
             except Exception:
-                pass
+                if compute_job_raises:
+                    # exception expected
+                    pass
 
         # Check the compute plan local folder value is correct:
         # - If do_task did raise an exception then the local value should be unchanged

--- a/backend/substrapp/utils.py
+++ b/backend/substrapp/utils.py
@@ -271,13 +271,8 @@ def get_and_put_remote_file_content(channel_name, url, auth, content_checksum, c
         raise NodeError(f"url {url}: checksum doesn't match {content_checksum} vs {computed_checksum}")
 
 
-def get_local_folder_name(compute_plan_key):
-    return f'local-{compute_plan_key}-{settings.ORG_NAME}'
-
-
-def get_local_folder(compute_plan_key):
-    volume_id = get_local_folder_name(compute_plan_key)
-    return path.join(getattr(settings, 'MEDIA_ROOT'), 'local', volume_id)
+def get_cp_local_folder(compute_plan_key):
+    return path.join(getattr(settings, 'MEDIA_ROOT'), 'local', f'local-{compute_plan_key}-{settings.ORG_NAME}')
 
 
 def get_subtuple_directory(subtuple_key):


### PR DESCRIPTION
## Description
The aim of this PR is to be able to retry composite traintuple in a deterministic way. Indeed, as we mount the local folder as it, in case of files modification inside it with the algorithm **and** a fail the composite traintuple, the retry was done with everything clean and restore except the local folder.

## Closes issue(s)
None
## Companion PRs
None

## How to test / repro
Launch a compute plan which use the local folder to share hyperparameters between composite traintuples.

## Screenshots / Trace
None

## Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

## Checklist
- [x] I have tested this code
- [ ] I have updated the Readme

## Other comments
None