### PR TITLE
Update kaniko builder

### DIFF
--- a/backend/substrapp/tasks/k8s_backend.py
+++ b/backend/substrapp/tasks/k8s_backend.py
@@ -259,7 +259,9 @@ def _k8s_build_image(path, tag, rm, cache_index):
         f'--dockerfile={dockerfile_fullpath}',
         f'--context=dir://{path}',
         f'--destination={REGISTRY}/{tag}:substra',
-        f'--cache={str(not(rm)).lower()}'
+        f'--cache={str(not(rm)).lower()}',
+        '--snapshotMode=redo',
+        '--single-snapshot'
     ]
 
     if REGISTRY_SCHEME == 'http':

--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+
+## 1.9.0
+
+### Changed
+- `kaniko` image is now `gcr.io/kaniko-project/executor:v1.3.0`
+
+
 ## 1.8.0
 
 ### Changed

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-backend
 home: https://substra.org/
-version: 1.8.0
+version: 1.9.0
 description: Main package for Substra
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/substra-backend/README.md
+++ b/charts/substra-backend/README.md
@@ -23,7 +23,7 @@ The following table lists the configurable parameters of the substra-backend cha
 | `backend.kaniko.cache.warmer.image` | The docker image for the kaniko cache warmer | `gcr.io/kaniko-project/warmer:v1.0.0` |
 | `backend.kaniko.cache.warmer.images` | A list of docker images to warm up the kaniko local cache with | `[]` |
 | `backend.kaniko.cache.warmer.images[].image` | A docker image | (undefined) |
-| `backend.kaniko.image` | The docker image for kaniko builds | `gcr.io/kaniko-project/executor:v1.0.0` |
+| `backend.kaniko.image` | The docker image for kaniko builds | `gcr.io/kaniko-project/executor:v1.3.0` |
 | `backend.kaniko.mirror` | If true, pull base images from the local registry | `False` |
 | `channels` | A list of Hyperledger Fabric channels to connect to. See [hlf-k8s](https://github.com/SubstraFoundation/hlf-k8s). | `{ mychannel: { restricted: false, chaincode: { name: mycc, version: 1.0 } } }` |
 | `channels[].restricted` | If true, the channel must have at most 1 member, else the backend readiness/liveliness probes will fail. | (undefined) |

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -9,11 +9,11 @@ backend:
   gzipModels: false
 
   kaniko:
-    image: gcr.io/kaniko-project/executor:v1.0.0
+    image: gcr.io/kaniko-project/executor:v1.3.0
     mirror: false  # If true, kaniko will pull base images from the local registry
     cache:
       warmer:
-        image: gcr.io/kaniko-project/warmer:v1.0.0
+        image: gcr.io/kaniko-project/warmer:v1.3.0
         images: []
           # - image: substrafoundation/substra-tools:0.7.0
 


### PR DESCRIPTION
## Description
Update kaniko executor and add option to speed up build.

## Closes issue(s)
None

## Companion PRs
None

## How to test / repro
```
kubectl exec -it -n org-1 backend-org-1-substra-backend-worker-XXX -- mkdir /var/substra/medias/subtuple/test
kubectl cp /PATH/TO/ALGO/algo.tar.gz org-1/backend-org-1-substra-backend-worker-XXX:/var/substra/medias/subtuple/algo.tar.gz

kubectl exec -it -n org-1 backend-org-1-substra-backend-worker-XXX -- tar xzf /var/substra/medias/subtuple/algo.tar.gz -C /var/substra/medias/subtuple/test/

# Inside the worker
celery -A backend shell --python
from substrapp.tasks.k8s_backend import k8s_build_image
k8s_build_image('/var/substra/medias/subtuple/test/', 'test', True)

```
## Screenshots / Trace
```
kaniko executor:v1.3.0 --snapshotMode=redo --single-snapshot - 204.925s
kaniko executor:v1.0.0                                       - 701.026s
kaniko executor:v1.0.0 --single-snapshot                     - 401.697s

```
## Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

## Checklist
- [x] I have tested this code
- [x] I have updated the Readme

## Other comments
None


