### PR TITLE
Fix compute plan intermediary models not being deleted

### DIFF
--- a/backend/events/apps.py
+++ b/backend/events/apps.py
@@ -104,7 +104,7 @@ def on_compute_plan_event(channel_name, block_number, tx_id, tx_status, asset):
     task_id = f'{key}_{tx_id}'
 
     if AsyncResult(task_id).state != 'PENDING':
-        logger.info(f'Skipping cleaning task {key} (from block {block_number}): already exists')
+        logger.info(f'Skipping cleaning task: already exists. Info: compute_plan={key}, block_numer={block_number}, tx_id={tx_id}')
         return
 
     on_compute_plan.apply_async(

--- a/backend/events/apps.py
+++ b/backend/events/apps.py
@@ -104,7 +104,8 @@ def on_compute_plan_event(channel_name, block_number, tx_id, tx_status, asset):
     task_id = f'{key}_{tx_id}'
 
     if AsyncResult(task_id).state != 'PENDING':
-        logger.info(f'Skipping cleaning task: already exists. Info: compute_plan={key}, block_numer={block_number}, tx_id={tx_id}')
+        logger.info(f'Skipping cleaning task: already exists. '
+                    f'Info: compute_plan={key}, block_numer={block_number}, tx_id={tx_id}')
         return
 
     on_compute_plan.apply_async(

--- a/backend/events/apps.py
+++ b/backend/events/apps.py
@@ -101,7 +101,7 @@ def on_compute_plan_event(channel_name, block_number, tx_id, tx_status, asset):
 
     logger.info(f'Processing cleaning task {key}: type=computePlan status={status}')
 
-    task_id = f'{key}-{block_number}'
+    task_id = f'{key}_{tx_id}'
 
     if AsyncResult(task_id).state != 'PENDING':
         logger.info(f'Skipping cleaning task {key} (from block {block_number}): already exists')


### PR DESCRIPTION
## Background

The backend receives events from the ledger instructing it to delete compute plan intermediary models.

Historically, the ledger was configured to only have one transaction per block. However, we changed this pradigm a few months back when we changed the ledger configuration to allow multiple transactions per block. **So the block_id is not sufficient anymore to identify a unique transaction**. Since we were using the block_id to uniquely identify celery tasks, when a block containing multiple transactions with events was received, only the first event was processed, and the other ones were skipped. 

As a result, the removal of intermediary models was skipped and many (up to 25% empirically) of intermediary models stayed on disk.

## Fix

This PR fixes the issue by changing the key to uniquely identify each event/transaction.
