### PR TITLE
ledger: add debug toolbox

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,6 +10,8 @@ drf-spectacular==0.13.0
 pyjwt==1.7.1
 ipython==7.11.1
 ipython-genutils==0.2.0
+jedi==0.17.2  # Fix crashes in iPython. See https://github.com/ipython/ipython/issues/12740#issuecomment-751273584
+              # A better solution would be to bump ipython to 7.20.0, but it needs python 3.7+
 kubernetes==11.0.0
 psycopg2-binary==2.8.6
 requests>=2.20.0

--- a/backend/substrapp/ledger/debug_tools.py
+++ b/backend/substrapp/ledger/debug_tools.py
@@ -1,0 +1,59 @@
+import json
+from substrapp.ledger.connection import get_hfc
+from pathlib import Path
+
+
+def get_transactions(start_block, end_block):
+    for block_number in range(start_block, end_block + 1):
+        block = get_block(block_number)
+        for tx_index, tx in enumerate(block['data']['data']):
+            if "actions" not in tx['payload']['data']:
+                # not an invoke
+                continue
+            input = tx['payload']['data']['actions'][0]['payload']['chaincode_proposal_payload']['input']
+            if ('ApproveChaincode' not in str(input)):
+                print(f"block: {block_number}, tx_index: {tx_index}")
+                yield block_number, tx_index, tx
+
+
+def get_block(block_number):
+    with get_hfc('mychannel') as (loop, client, user):
+        block = loop.run_until_complete(client.query_block(
+            user,
+            'mychannel',
+            ['peer'],
+            str(block_number),
+            decode=True))
+        return block
+
+
+def dump_all_blocks(start_block, end_block, out_folder):
+    """Dump all the blocks from `start_block` to `end_block` as JSON files in `out_folder`.
+    Files are named "{block_number}.{transaction_index}.json", e.g. "0123,0.json"
+    """
+    for block_number, tx_index, tx in get_transactions(start_block, end_block):
+        dump_block(block_number, tx_index, tx, out_folder)
+
+
+def dump_block(block_number, tx_index, tx, out_folder):
+    path = Path(out_folder)
+    path.mkdir(parents=True, exist_ok=True)
+    with open(path / f"{block_number:04},{tx_index}.json", "w") as json_file:
+        json.dump(_make_jsonifiable(tx), json_file, indent=2)
+
+
+def _make_jsonifiable(x):
+    if type(x) == bytes:
+        return str(x)
+    if type(x) == dict:
+        res = {}
+        for k, v in x.items():
+            res[k] = _make_jsonifiable(v)
+        return res
+    if type(x) == list:
+        res = []
+        for _, v in enumerate(x):
+            res.append(_make_jsonifiable(v))
+        return res
+    else:
+        return str(x)


### PR DESCRIPTION
This PR adds tools to visualize and dump HLF blocks and transactions.

Usage (from a backend worker pod):

```sh
celery -A backend shell
```

```python
> from substrapp.ledger.debug_tools import *

> end_block = get_ledger_height('mychannel')
> dump_all_transactions(start_block=0, end_block=end_block out_folder='/tmp/blocks')
# /tmp/blocks now contains a bunch of JSON files

> txs = get_mvcc_transactions('mychannel', 0, end_block)
> txs[0]
{
  'block_number': 43,
  'tx_index': 1,
  'tx_id': 'fd31631d86e961caf97800d9ff5fae4b12b59ca20c364dc4868408f3c89e6c58'
}
# now open /tmp/blocks/43,1.json to get the full transaction as JSON, 
# or fetch it here with get_transaction(channel_name, tx_id)
```
