### PR TITLE
Update peer host value

### DIFF
--- a/values/backend-org-1.yaml
+++ b/values/backend-org-1.yaml
@@ -49,7 +49,7 @@ organization:
   name: MyOrg1
 
 peer:
-  host: network-org-1-peer-1-hlf-peer.org-1
+  host: network-org-1-peer-1-hlf-peer.org-1.svc.cluster.local
   port: 7051
   mspID: MyOrg1MSP
   waitForEventTimeoutSeconds: 120

--- a/values/backend-org-2.yaml
+++ b/values/backend-org-2.yaml
@@ -48,7 +48,7 @@ organization:
   name: MyOrg2
 
 peer:
-  host: network-org-2-peer-1-hlf-peer.org-2
+  host: network-org-2-peer-1-hlf-peer.org-2.svc.cluster.local
   port: 7051
   mspID: MyOrg2MSP
   waitForEventTimeoutSeconds: 120


### PR DESCRIPTION
Update peer host values on local with .svc.cluster.local to avoid potential issue with network resolution like "Invalid toplevel subdomain" issue in substra-backend grpc client.

Companion PR : https://github.com/SubstraFoundation/hlf-k8s/pull/128