### PR TITLE
[chart] expose FLUSH_REFRESH_EXPIRED_TOKENS_TASK_PERIOD setting

### DIFF
--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.1
+
+### Added
+- new `celerybeat.expiredTokensFlushPeriod` option
+
 ## 2.0.0
 
 ### Changed

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-backend
 home: https://substra.org/
-version: 2.0.0
+version: 2.0.1
 description: Main package for Substra
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/substra-backend/README.md
+++ b/charts/substra-backend/README.md
@@ -108,6 +108,7 @@ The following table lists the configurable parameters of the substra-backend cha
 | `docker-registry.service.type` | service type (If you use the local docker registry, you must use a `NodePort` to expose it kubernetes) | `NodePort` |
 | `docker-registry.service.nodePort` | if `docker-registry.service.type` is `NodePort` and this is non-empty, sets the node port of the service | (undefined)` |
 | `celerybeat.replicaCount` | Replica count for celerybeat service | `1` |
+| `celerybeat.expiredTokensFlushPeriod` | Flushing of expired tokens task period | `86400` |
 | `celerybeat.taskPeriod` | Celery beat task period | `10800` |
 | `celerybeat.image.repository` | `celerybeat` image repository | `substrafoundation/substra-backend` |
 | `celerybeat.image.tag` | `celerybeat` image tag | `latest` |
@@ -163,4 +164,3 @@ The following table lists the configurable parameters of the substra-backend cha
 ### Basic example
 
 For a simple example, see the [skaffold.yaml](../../skaffold.yaml) file.
-

--- a/charts/substra-backend/templates/deployment-celerybeat.yaml
+++ b/charts/substra-backend/templates/deployment-celerybeat.yaml
@@ -47,6 +47,8 @@ spec:
               value: backend.settings.common
             - name: SCHEDULE_TASK_PERIOD
               value: "{{ .Values.celerybeat.taskPeriod }}"
+            - name: FLUSH_EXPIRED_TOKENS_TASK_PERIOD
+              value: "{{ .Values.celerybeat.expiredTokensFlushPeriod }}"
             - name: PYTHONUNBUFFERED
               value: "1"
           resources:

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -201,6 +201,7 @@ docker-registry:
 
 celerybeat:
   replicaCount: 1
+  expiredTokensFlushPeriod: 86400
   taskPeriod: 10800
   image:
     repository: substrafoundation/substra-backend


### PR DESCRIPTION
This patch exposes a new configuration option to adapt the period of expired token purge.

It defaults to 24h to match application's behavior when the env var is not set.