### PR TITLE
Fix JWT token blacklist at logout

### DIFF
--- a/backend/users/views/user.py
+++ b/backend/users/views/user.py
@@ -8,6 +8,7 @@ from rest_framework.decorators import action, throttle_classes
 from rest_framework.response import Response
 from rest_framework.throttling import AnonRateThrottle
 from rest_framework_simplejwt.authentication import AUTH_HEADER_TYPES
+from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.exceptions import TokenError, InvalidToken, AuthenticationFailed
 
 from libs.user_login_throttle import UserLoginThrottle
@@ -113,6 +114,18 @@ class UserViewSet(GenericViewSet):
 
     @action(detail=False)
     def logout(self, request, *args, **kwargs):
+
+        # Blacklist jwt token at logout fetched from cookie
+        if 'refresh' in request.COOKIES:
+            refresh = RefreshToken(request.COOKIES['refresh'])
+            try:
+                # Attempt to blacklist the fetched refresh token
+                refresh.blacklist()
+            except AttributeError:
+                # If blacklist app not installed, `blacklist` method will
+                # not be present
+                pass
+
         response = Response({}, status=status.HTTP_200_OK)
 
         host = self.get_host(request)


### PR DESCRIPTION
## Description
JWT token was no blacklist when logout from substra-backend

## Closes issue(s)
None

## Companion PRs
None

## How to test / repro
```
curl -L -H "Accept: text/json;version=0.0, */*;version=0.0" -H "Content-Type: application/json" -X POST --data '{"username": "node-1", "password":"p@$swr0d44"}' http://substra-backend.node-1.com/user/login/ -vvv -c cookies

curl -L -H "Accept: text/json;version=0.0, */*;version=0.0" -H "Content-Type: application/json" -X GET http://substra-backend.node-1.com/user/logout/ -vvv -b cookies

# This should work before this PR, not after
curl -L -H "Accept: text/json;version=0.0, */*;version=0.0" -H "Content-Type: application/json" -X POST  http://substra-backend.node-1.com/user/refresh/ -vvv -b cookies 
```

## Screenshots / Trace
None

## Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

## Checklist
- [x] I have tested this code
- [ ] I have updated the Readme

## Other comments
