### PR TITLE
Add shared file based cache in django

### DIFF
--- a/backend/backend/settings/common.py
+++ b/backend/backend/settings/common.py
@@ -139,6 +139,13 @@ DATABASES = {
     }
 }
 
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': '/tmp/django_cache',
+    }
+}
+
 # Password validation
 # https://docs.djangoproject.com/en/2.0/ref/settings/#auth-password-validators
 

--- a/docker/substra-backend/Dockerfile
+++ b/docker/substra-backend/Dockerfile
@@ -32,6 +32,7 @@ WORKDIR /usr/src/app
 RUN chown -R ${USER_ID}:${GROUP_ID} /usr/src/app
 
 RUN mkdir -p /var/substra/
-RUN chown -R ${USER_ID}:${GROUP_ID} /var/substra/
+RUN mkdir -p /tmp/django_cache
+RUN chown -R ${USER_ID}:${GROUP_ID} /var/substra/ /tmp/django_cache
 
 USER ${USER_ID}:${GROUP_ID}


### PR DESCRIPTION
## Description
By default, django cache is memory based. With the use of uwsgi process, each worker has its own cache which cause throttle issue (not consistent) depending on which worker responds to the request.

## Closes issue(s)
None

## Companion PRs
None

## How to test / repro
```
# This should throttles consistently with this PR, not before (depends on which worker responds)
watch -n .01 curl -X POST http://substra-backend.node-1.com/user/login/
```

## Screenshots / Trace
None

## Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

## Checklist
- [x] I have tested this code
- [ ] I have updated the Readme

## Other comments
