### PR TITLE
feat: export models

### DIFF
--- a/backend/backend/settings/deps/ledger.py
+++ b/backend/backend/settings/deps/ledger.py
@@ -2,9 +2,9 @@ import os
 import json
 
 LEDGER_CHANNELS = {
-    channel: chaincode
+    channel: settings
     for channels in json.loads(os.getenv('LEDGER_CHANNELS'))
-    for channel, chaincode in channels.items()
+    for channel, settings in channels.items()
 }
 
 LEDGER_MSP_ID = os.getenv('LEDGER_MSP_ID')

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -25,7 +25,7 @@ from drf_spectacular.views import (
     SpectacularSwaggerView,
 )
 
-from backend.views import obtain_auth_token
+from backend.views import obtain_auth_token, config_view
 
 from substrapp.urls import router
 from node.urls import router as node_router
@@ -58,3 +58,5 @@ urlpatterns = [
 # only allow session authentication is the browsable API is enabled
 if BrowsableAPIRenderer in api_settings.DEFAULT_RENDERER_CLASSES:
     urlpatterns += [url(r'^api-auth/', include('rest_framework.urls'))]
+
+urlpatterns += [url(r'^config/', config_view)]

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -25,7 +25,7 @@ from drf_spectacular.views import (
     SpectacularSwaggerView,
 )
 
-from backend.views import obtain_auth_token, config_view
+from backend.views import obtain_auth_token, info_view
 
 from substrapp.urls import router
 from node.urls import router as node_router
@@ -59,4 +59,4 @@ urlpatterns = [
 if BrowsableAPIRenderer in api_settings.DEFAULT_RENDERER_CLASSES:
     urlpatterns += [url(r'^api-auth/', include('rest_framework.urls'))]
 
-urlpatterns += [url(r'^config/', config_view)]
+urlpatterns += [url(r'^info/', info_view)]

--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -49,7 +49,7 @@ class Config(APIView):
             'msp_id': settings.LEDGER_MSP_ID,
             'channel': channel_name,
             'config': {
-                'enable_model_export': channel['enable_model_export'],
+                'model_export_enabled': channel['model_export_enabled'],
             }
         })
 

--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -46,7 +46,7 @@ class Info(APIView):
         channel_name = get_channel_name(request)
         channel = settings.LEDGER_CHANNELS[channel_name]
         return Response({
-            'msp_id': settings.LEDGER_MSP_ID,
+            'host': request.META['HTTP_HOST'],
             'channel': channel_name,
             'config': {
                 'model_export_enabled': channel['model_export_enabled'],

--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -40,7 +40,7 @@ class ExpiryObtainAuthToken(ObtainAuthToken):
         })
 
 
-class Config(APIView):
+class Info(APIView):
 
     def get(self, request, *args, **kwargs):
         channel_name = get_channel_name(request)
@@ -55,4 +55,4 @@ class Config(APIView):
 
 
 obtain_auth_token = ExpiryObtainAuthToken.as_view()
-config_view = Config.as_view()
+info_view = Info.as_view()

--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -8,6 +8,10 @@ from rest_framework.response import Response
 from libs.expiry_token_authentication import token_expire_handler, expires_at
 from libs.user_login_throttle import UserLoginThrottle
 
+from rest_framework.views import APIView
+from substrapp.views.utils import get_channel_name
+from django.conf import settings
+
 
 class ExpiryObtainAuthToken(ObtainAuthToken):
     authentication_classes = []
@@ -36,4 +40,19 @@ class ExpiryObtainAuthToken(ObtainAuthToken):
         })
 
 
+class Config(APIView):
+
+    def get(self, request, *args, **kwargs):
+        channel_name = get_channel_name(request)
+        channel = settings.LEDGER_CHANNELS[channel_name]
+        return Response({
+            'msp_id': settings.LEDGER_MSP_ID,
+            'channel': channel_name,
+            'config': {
+                'enable_model_export': channel['enable_model_export'],
+            }
+        })
+
+
 obtain_auth_token = ExpiryObtainAuthToken.as_view()
+config_view = Config.as_view()

--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -46,7 +46,7 @@ class Info(APIView):
         channel_name = get_channel_name(request)
         channel = settings.LEDGER_CHANNELS[channel_name]
         return Response({
-            'host': request.META['HTTP_HOST'],
+            'host': settings.DEFAULT_DOMAIN,
             'channel': channel_name,
             'config': {
                 'model_export_enabled': channel['model_export_enabled'],

--- a/backend/substrapp/tests/query/tests_query_compositetraintuple.py
+++ b/backend/substrapp/tests/query/tests_query_compositetraintuple.py
@@ -19,9 +19,10 @@ from node.authentication import NodeUser
 from ..common import get_sample_objective, AuthenticatedClient, get_sample_model
 
 MEDIA_ROOT = tempfile.mkdtemp()
+TEST_ORG = 'MyTestOrg'
 
 
-@override_settings(MEDIA_ROOT=MEDIA_ROOT)
+@override_settings(MEDIA_ROOT=MEDIA_ROOT, LEDGER_CHANNELS={'mychannel': {}}, LEDGER_MSP_ID=TEST_ORG)
 class CompositeTraintupleQueryTests(APITestCase):
     client_class = AuthenticatedClient
 
@@ -198,12 +199,15 @@ class CompositeTraintupleQueryTests(APITestCase):
         checksum = compute_hash(self.model.read(), key='key_traintuple')
         head_model = Model.objects.create(file=self.model, checksum=checksum, validated=True)
         permissions = {
-            "process": {
-                "public": False,
-                "authorized_ids": ['substra']
+            "owner": TEST_ORG,
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorized_ids": ['substra']
+                }
             }
         }
-        with mock.patch('substrapp.views.utils.get_owner', return_value='foo'), \
+        with mock.patch('substrapp.views.utils.get_owner', return_value=TEST_ORG), \
                 mock.patch('substrapp.views.utils.get_object_from_ledger') \
                 as mget_object_from_ledger, \
                 mock.patch('substrapp.views.model.type') as mtype:
@@ -221,12 +225,15 @@ class CompositeTraintupleQueryTests(APITestCase):
         checksum = compute_hash(self.model.read(), key='key_traintuple')
         head_model = Model.objects.create(file=self.model, checksum=checksum, validated=True)
         permissions = {
-            "process": {
-                "public": False,
-                "authorized_ids": ['substra']
+            "owner": TEST_ORG,
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorized_ids": ['substra']
+                }
             }
         }
-        with mock.patch('substrapp.views.utils.get_owner', return_value='foo'), \
+        with mock.patch('substrapp.views.utils.get_owner', return_value=TEST_ORG), \
                 mock.patch('substrapp.views.utils.get_object_from_ledger') \
                 as mget_object_from_ledger:
             mget_object_from_ledger.return_value = permissions
@@ -241,12 +248,15 @@ class CompositeTraintupleQueryTests(APITestCase):
         checksum = compute_hash(self.model.read(), key='key_traintuple')
         head_model = Model.objects.create(file=self.model, checksum=checksum, validated=True)
         permissions = {
-            "process": {
-                "public": False,
-                "authorized_ids": ['owkin']
+            "owner": TEST_ORG,
+            "permissions": {
+                "process": {
+                    "public": False,
+                    "authorized_ids": ['owkin']
+                }
             }
         }
-        with mock.patch('substrapp.views.utils.get_owner', return_value='foo'), \
+        with mock.patch('substrapp.views.utils.get_owner', return_value=TEST_ORG), \
                 mock.patch('substrapp.views.utils.get_object_from_ledger') \
                 as mget_object_from_ledger, \
                 mock.patch('substrapp.views.model.type') as mtype:

--- a/backend/substrapp/tests/query/tests_query_compositetraintuple.py
+++ b/backend/substrapp/tests/query/tests_query_compositetraintuple.py
@@ -247,7 +247,8 @@ class CompositeTraintupleQueryTests(APITestCase):
     def test_get_head_model_ko_wrong_node(self):
         checksum = compute_hash(self.model.read(), key='key_traintuple')
         head_model = Model.objects.create(file=self.model, checksum=checksum, validated=True)
-        permissions = {
+        model = {
+            "key": 'some key',
             "owner": TEST_ORG,
             "permissions": {
                 "process": {
@@ -260,7 +261,7 @@ class CompositeTraintupleQueryTests(APITestCase):
                 mock.patch('substrapp.views.utils.get_object_from_ledger') \
                 as mget_object_from_ledger, \
                 mock.patch('substrapp.views.model.type') as mtype:
-            mget_object_from_ledger.return_value = permissions
+            mget_object_from_ledger.return_value = model
             mtype.return_value = NodeUser
 
             extra = {

--- a/backend/substrapp/tests/views/tests_utils.py
+++ b/backend/substrapp/tests/views/tests_utils.py
@@ -7,8 +7,7 @@ import requests
 from requests.auth import HTTPBasicAuth
 from rest_framework import status
 from rest_framework.test import APITestCase
-
-from substrapp.views.utils import PermissionMixin
+from substrapp.views.utils import PermissionMixin, PermissionError
 
 
 class MockRequest:
@@ -43,7 +42,10 @@ def with_permission_mixin(remote, same_file_property, has_access):
 
                 permission_mixin = PermissionMixin()
                 permission_mixin.get_object = mock.MagicMock(return_value=TestModel())
-                permission_mixin.has_access = mock.MagicMock(return_value=has_access)
+                if has_access:
+                    permission_mixin.check_access = mock.MagicMock()
+                else:
+                    permission_mixin.check_access = mock.MagicMock(side_effect=PermissionError())
                 permission_mixin.lookup_url_kwarg = 'foo'
                 permission_mixin.kwargs = {'foo': 'bar'}
                 permission_mixin.ledger_query_call = 'foo'

--- a/backend/substrapp/tests/views/tests_utils.py
+++ b/backend/substrapp/tests/views/tests_utils.py
@@ -2,6 +2,7 @@ import functools
 import os
 import tempfile
 
+import uuid
 import mock
 import requests
 from requests.auth import HTTPBasicAuth
@@ -47,7 +48,7 @@ def with_permission_mixin(remote, same_file_property, has_access):
                 else:
                     permission_mixin.check_access = mock.MagicMock(side_effect=PermissionError())
                 permission_mixin.lookup_url_kwarg = 'foo'
-                permission_mixin.kwargs = {'foo': 'bar'}
+                permission_mixin.kwargs = {'foo': str(uuid.uuid4())}
                 permission_mixin.ledger_query_call = 'foo'
 
                 kwargs = {

--- a/backend/substrapp/tests/views/tests_views_model.py
+++ b/backend/substrapp/tests/views/tests_views_model.py
@@ -24,6 +24,7 @@ from ..assets import objective, datamanager, algo, model
 MEDIA_ROOT = "/tmp/unittests_views/"
 CHANNEL = 'mychannel'
 TEST_ORG = 'MyTestOrg'
+MODEL_KEY = 'some-key'
 
 
 # APITestCase
@@ -169,20 +170,20 @@ class ModelViewTests(APITestCase):
         pvs.check_access(
             CHANNEL,
             NodeUser(),
-            {'permissions': {'process': {'public': True}}},
+            {'key': MODEL_KEY, 'permissions': {'process': {'public': True}}},
             is_proxied_request=False)
 
         with self.assertRaises(PermissionError):
             pvs.check_access(
                 CHANNEL,
                 NodeUser(),
-                {'permissions': {'process': {'public': False, 'authorized_ids': []}}},
+                {'key': MODEL_KEY, 'permissions': {'process': {'public': False, 'authorized_ids': []}}},
                 is_proxied_request=False)
 
         pvs.check_access(
             CHANNEL,
             NodeUser(username='foo'),
-            {'permissions': {'process': {'public': False, 'authorized_ids': ['foo']}}},
+            {'key': MODEL_KEY, 'permissions': {'process': {'public': False, 'authorized_ids': ['foo']}}},
             is_proxied_request=False)
 
     @override_settings(LEDGER_CHANNELS={CHANNEL: {'model_export_enabled': True}})
@@ -193,20 +194,20 @@ class ModelViewTests(APITestCase):
         pvs.check_access(
             CHANNEL,
             NodeUser(),
-            {'permissions': {'download': {'public': True}}},
+            {'key': MODEL_KEY, 'permissions': {'download': {'public': True}}},
             is_proxied_request=True)
 
         with self.assertRaises(PermissionError):
             pvs.check_access(
                 CHANNEL,
                 NodeUser(),
-                {'permissions': {'download': {'public': False, 'authorized_ids': []}}},
+                {'key': MODEL_KEY, 'permissions': {'download': {'public': False, 'authorized_ids': []}}},
                 is_proxied_request=True)
 
         pvs.check_access(
             CHANNEL,
             NodeUser(username='foo'),
-            {'permissions': {'download': {'public': False, 'authorized_ids': ['foo']}}},
+            {'key': MODEL_KEY, 'permissions': {'download': {'public': False, 'authorized_ids': ['foo']}}},
             is_proxied_request=True)
 
     @override_settings(LEDGER_CHANNELS={CHANNEL: {'model_export_enabled': False}})
@@ -218,7 +219,7 @@ class ModelViewTests(APITestCase):
             pvs.check_access(
                 CHANNEL,
                 NodeUser(),
-                {'permissions': {'download': {'public': True}}},
+                {'key': MODEL_KEY, 'permissions': {'download': {'public': True}}},
                 is_proxied_request=True)
 
     @override_settings(LEDGER_CHANNELS={CHANNEL: {'model_export_enabled': True}})
@@ -229,14 +230,14 @@ class ModelViewTests(APITestCase):
         pvs.check_access(
             CHANNEL,
             User(),
-            {'permissions': {'download': {'public': True}}},
+            {'key': MODEL_KEY, 'permissions': {'download': {'public': True}}},
             is_proxied_request=False)
 
         with self.assertRaises(PermissionError):
             pvs.check_access(
                 CHANNEL,
                 User(),
-                {'permissions': {'download': {'public': False, 'authorized_ids': []}}},
+                {'key': MODEL_KEY, 'permissions': {'download': {'public': False, 'authorized_ids': []}}},
                 is_proxied_request=False)
 
     @override_settings(LEDGER_CHANNELS={CHANNEL: {'model_export_enabled': False}})
@@ -248,7 +249,7 @@ class ModelViewTests(APITestCase):
             pvs.check_access(
                 CHANNEL,
                 User(),
-                {'permissions': {'process': {'public': True}}},
+                {'key': MODEL_KEY, 'permissions': {'process': {'public': True}}},
                 is_proxied_request=False)
 
     @override_settings(LEDGER_CHANNELS={CHANNEL: {}})
@@ -261,5 +262,5 @@ class ModelViewTests(APITestCase):
             pvs.check_access(
                 CHANNEL,
                 User(),
-                {'permissions': {'process': {'public': True}}},
+                {'key': MODEL_KEY, 'permissions': {'process': {'public': True}}},
                 is_proxied_request=False)

--- a/backend/substrapp/tests/views/tests_views_model.py
+++ b/backend/substrapp/tests/views/tests_views_model.py
@@ -162,53 +162,56 @@ class ModelViewTests(APITestCase):
 
             self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_model_download_by_node_not_proxied(self):
+    def test_model_download_by_node_for_worker(self):
+        """"Simple node-to-node download, e.g. worker downloads in-model"""
         pvs = ModelPermissionViewSet()
 
         pvs.check_access(
             CHANNEL,
             NodeUser(),
             {'permissions': {'process': {'public': True}}},
-            is_proxied=False)
+            is_proxied_request=False)
 
         with self.assertRaises(PermissionError):
             pvs.check_access(
                 CHANNEL,
                 NodeUser(),
                 {'permissions': {'process': {'public': False, 'authorized_ids': []}}},
-                is_proxied=False)
+                is_proxied_request=False)
 
         pvs.check_access(
             CHANNEL,
             NodeUser(username='foo'),
             {'permissions': {'process': {'public': False, 'authorized_ids': ['foo']}}},
-            is_proxied=False)
+            is_proxied_request=False)
 
-    @override_settings(LEDGER_CHANNELS={CHANNEL: {'enable_model_export': True}})
-    def test_model_download_by_node_proxied(self):
+    @override_settings(LEDGER_CHANNELS={CHANNEL: {'model_export_enabled': True}})
+    def test_model_export_proxied(self):
+        """Model export (proxied) with option enabled"""
         pvs = ModelPermissionViewSet()
 
         pvs.check_access(
             CHANNEL,
             NodeUser(),
             {'permissions': {'download': {'public': True}}},
-            is_proxied=True)
+            is_proxied_request=True)
 
         with self.assertRaises(PermissionError):
             pvs.check_access(
                 CHANNEL,
                 NodeUser(),
                 {'permissions': {'download': {'public': False, 'authorized_ids': []}}},
-                is_proxied=True)
+                is_proxied_request=True)
 
         pvs.check_access(
             CHANNEL,
             NodeUser(username='foo'),
             {'permissions': {'download': {'public': False, 'authorized_ids': ['foo']}}},
-            is_proxied=True)
+            is_proxied_request=True)
 
-    @override_settings(LEDGER_CHANNELS={CHANNEL: {'enable_model_export': False}})
+    @override_settings(LEDGER_CHANNELS={CHANNEL: {'model_export_enabled': False}})
     def test_model_download_by_node_proxied_option_disabled(self):
+        """Model export (proxied) with option disabled"""
         pvs = ModelPermissionViewSet()
 
         with self.assertRaises(PermissionError):
@@ -216,27 +219,29 @@ class ModelViewTests(APITestCase):
                 CHANNEL,
                 NodeUser(),
                 {'permissions': {'download': {'public': True}}},
-                is_proxied=True)
+                is_proxied_request=True)
 
-    @override_settings(LEDGER_CHANNELS={CHANNEL: {'enable_model_export': True}})
+    @override_settings(LEDGER_CHANNELS={CHANNEL: {'model_export_enabled': True}})
     def test_model_download_by_classic_user_enabled(self):
+        """Model export (by end-user, not proxied) with option enabled"""
         pvs = ModelPermissionViewSet()
 
         pvs.check_access(
             CHANNEL,
             User(),
             {'permissions': {'download': {'public': True}}},
-            is_proxied=False)
+            is_proxied_request=False)
 
         with self.assertRaises(PermissionError):
             pvs.check_access(
                 CHANNEL,
                 User(),
                 {'permissions': {'download': {'public': False, 'authorized_ids': []}}},
-                is_proxied=False)
+                is_proxied_request=False)
 
-    @override_settings(LEDGER_CHANNELS={CHANNEL: {'enable_model_export': False}})
+    @override_settings(LEDGER_CHANNELS={CHANNEL: {'model_export_enabled': False}})
     def test_model_download_by_classic_user_disabled(self):
+        """Model export (by end-user, not proxied) with option disabled"""
         pvs = ModelPermissionViewSet()
 
         with self.assertRaises(PermissionError):
@@ -244,17 +249,17 @@ class ModelViewTests(APITestCase):
                 CHANNEL,
                 User(),
                 {'permissions': {'process': {'public': True}}},
-                is_proxied=False)
+                is_proxied_request=False)
 
     @override_settings(LEDGER_CHANNELS={CHANNEL: {}})
     def test_model_download_by_classic_user_default(self):
         pvs = ModelPermissionViewSet()
 
-        # Access to model download should be denied because the "enable_model_export"
+        # Access to model download should be denied because the "model_export_enabled"
         # option is not specified in the app configuration.
         with self.assertRaises(PermissionError):
             pvs.check_access(
                 CHANNEL,
                 User(),
                 {'permissions': {'process': {'public': True}}},
-                is_proxied=False)
+                is_proxied_request=False)

--- a/backend/substrapp/utils.py
+++ b/backend/substrapp/utils.py
@@ -216,10 +216,12 @@ class NodeError(Exception):
 
 def get_remote_file(channel_name, url, auth, content_dst_path=None, **kwargs):
 
+    headers = {
+        'Accept': 'application/json;version=0.0',
+        'Substra-Channel-Name': channel_name
+    }
     kwargs.update({
-        'headers': {
-            'Accept': 'application/json;version=0.0',
-            'Substra-Channel-Name': channel_name},
+        'headers': {**headers, **kwargs.get('headers', {})},
         'auth': auth,
         'timeout': HTTP_CLIENT_TIMEOUT_SECONDS
     })

--- a/backend/substrapp/utils.py
+++ b/backend/substrapp/utils.py
@@ -220,8 +220,10 @@ def get_remote_file(channel_name, url, auth, content_dst_path=None, **kwargs):
         'Accept': 'application/json;version=0.0',
         'Substra-Channel-Name': channel_name
     }
+    headers.update(kwargs.get('headers', {}))
+
     kwargs.update({
-        'headers': {**headers, **kwargs.get('headers', {})},
+        'headers': headers,
         'auth': auth,
         'timeout': HTTP_CLIENT_TIMEOUT_SECONDS
     })

--- a/backend/substrapp/views/model.py
+++ b/backend/substrapp/views/model.py
@@ -143,7 +143,7 @@ class ModelPermissionViewSet(PermissionMixin,
     def _check_permission(permission_type, asset, node_id):
         permissions = asset['permissions'][permission_type]
         if not permissions['public'] and node_id not in permissions['authorized_ids']:
-            raise PermissionError()
+            raise PermissionError(f'{node_id} doesn\'t have permission to download model {asset["key"]}')
 
     @gzip_action
     @action(detail=True)

--- a/backend/substrapp/views/model.py
+++ b/backend/substrapp/views/model.py
@@ -110,8 +110,12 @@ class ModelPermissionViewSet(PermissionMixin,
     queryset = Model.objects.all()
     ledger_query_call = 'queryModel'
 
-    def check_access(self, channel_name, user, asset, is_proxied_request):
-        """Returns true if API consumer can access asset data."""
+    def check_access(self, channel_name: str, user, asset, is_proxied_request: bool) -> None:
+        """Return true if API consumer is allowed to access the model.
+
+        :param is_proxied_request: True if the API consumer is another backend-server proxying a user request
+        :raises: PermissionError
+        """
         if user.is_anonymous:
             raise PermissionError()
 

--- a/backend/substrapp/views/utils.py
+++ b/backend/substrapp/views/utils.py
@@ -63,8 +63,12 @@ class PermissionMixin(object):
     authentication_classes = api_settings.DEFAULT_AUTHENTICATION_CLASSES + [BasicAuthentication]
     permission_classes = [IsAuthenticated]
 
-    def check_access(self, channel_name, user, asset, is_proxied_request):
-        """Returns true if API consumer can access asset data."""
+    def check_access(self, channel_name: str, user, asset, is_proxied_request: bool) -> None:
+        """Returns true if API consumer is allowed to access data.
+
+        :param is_proxied_request: True if the API consumer is another backend-server proxying a user request
+        :raises: PermissionError
+        """
         if user.is_anonymous:  # safeguard, should never happened
             raise PermissionError()
 
@@ -214,4 +218,8 @@ def get_channel_name(request):
 
 
 def is_proxied_request(request) -> bool:
+    """Return True if the API consumer is another backend-server node proxying a user request.
+
+    :param request: incoming HTTP request
+    """
     return HTTP_HEADER_PROXY_ASSET in request.headers

--- a/backend/substrapp/views/utils.py
+++ b/backend/substrapp/views/utils.py
@@ -153,7 +153,7 @@ class PermissionMixin(object):
             storage_address,
             auth,
             stream=True,
-            headers={HTTP_HEADER_PROXY_ASSET: True}
+            headers={HTTP_HEADER_PROXY_ASSET: 'True'}
         )
 
         if not r.ok:

--- a/backend/substrapp/views/utils.py
+++ b/backend/substrapp/views/utils.py
@@ -1,7 +1,7 @@
 import os
 import uuid
 
-from django.http import FileResponse, HttpResponse
+from django.http import FileResponse
 from rest_framework.authentication import BasicAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -19,6 +19,13 @@ from requests.auth import HTTPBasicAuth
 from wsgiref.util import is_hop_by_hop
 
 from substrapp import exceptions
+
+HTTP_HEADER_PROXY_ASSET = 'Substra-Proxy-Asset'
+
+
+class PermissionError(Exception):
+    def __init__(self, message='Unauthorized'):
+        Exception.__init__(self, message)
 
 
 def authenticate_outgoing_request(outgoing_node_id):
@@ -56,58 +63,68 @@ class PermissionMixin(object):
     authentication_classes = api_settings.DEFAULT_AUTHENTICATION_CLASSES + [BasicAuthentication]
     permission_classes = [IsAuthenticated]
 
-    def has_access(self, user, asset):
+    def check_access(self, channel_name, user, asset, is_proxied):
         """Returns true if API consumer can access asset data."""
         if user.is_anonymous:  # safeguard, should never happened
-            return False
-
-        permission = asset['permissions']['process']
+            raise PermissionError()
 
         if type(user) is NodeUser:  # for node
+            permission = asset['permissions']['process']
             node_id = user.username
-        else:  # for classic user, test on current msp id
+        else:
+            # for classic user, test on current msp id
+            # TODO: This should be 'download' instead of 'process',
+            #       but 'download' is not consistently exposed by chaincode yet.
+            permission = asset['permissions']['process']
             node_id = get_owner()
 
-        return permission['public'] or node_id in permission['authorized_ids']
+        if not permission['public'] and node_id not in permission['authorized_ids']:
+            raise PermissionError()
+
+    def get_storage_address(self, asset, ledger_field) -> str:
+        return asset[ledger_field]['storage_address']
 
     def download_file(self, request, django_field, ledger_field=None):
         lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
         key = self.kwargs[lookup_url_kwarg]
+        channel_name = get_channel_name(request)
 
         try:
-            asset = get_object_from_ledger(get_channel_name(request), key, self.ledger_query_call)
+            asset = get_object_from_ledger(channel_name, key, self.ledger_query_call)
         except LedgerError as e:
             return Response({'message': str(e.msg)}, status=e.status)
 
-        if not self.has_access(request.user, asset):
-            return Response({'message': 'Unauthorized'},
+        try:
+            self.check_access(channel_name, request.user, asset, is_proxied(request))
+        except PermissionError as e:
+            return Response({'message': str(e)},
                             status=status.HTTP_403_FORBIDDEN)
-
-        if not ledger_field:
-            ledger_field = django_field
 
         if get_owner() == asset['owner']:
             response = self._download_local_file(django_field)
         else:
-            response = self._download_remote_file(get_channel_name(request), ledger_field, asset)
+            if not ledger_field:
+                ledger_field = django_field
+            storage_address = self.get_storage_address(asset, ledger_field)
+            response = self._download_remote_file(channel_name, storage_address, asset)
 
         return response
 
-    def download_local_file(self, request, django_field, ledger_field=None):
+    def download_local_file(self, request, django_field):
         lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
         key = self.kwargs[lookup_url_kwarg]
+        channel_name = get_channel_name(request)
 
         try:
-            asset = get_object_from_ledger(get_channel_name(request), key, self.ledger_query_call)
+            asset = get_object_from_ledger(channel_name, key, self.ledger_query_call)
         except LedgerError as e:
-            return HttpResponse({'message': str(e.msg)}, status=e.status)
+            return Response({'message': str(e.msg)}, status=e.status)
 
-        if not self.has_access(request.user, asset):
-            return HttpResponse({'message': 'Unauthorized'},
-                                status=status.HTTP_403_FORBIDDEN)
-
-        if not ledger_field:
-            ledger_field = django_field
+        try:
+            self.check_access(channel_name, request.user, asset, is_proxied(request))
+        except PermissionError as e:
+            return Response({'message': str(e)},
+                            status=status.HTTP_403_FORBIDDEN)
 
         return self._download_local_file(django_field)
 
@@ -121,10 +138,18 @@ class PermissionMixin(object):
         )
         return response
 
-    def _download_remote_file(self, channel_name, ledger_field, asset):
+    def _download_remote_file(self, channel_name, storage_address, asset):
         node_id = asset['owner']
         auth = authenticate_outgoing_request(node_id)
-        r = get_remote_file(channel_name, asset[ledger_field]['storage_address'], auth, stream=True)
+
+        r = get_remote_file(
+            channel_name,
+            storage_address,
+            auth,
+            stream=True,
+            headers={HTTP_HEADER_PROXY_ASSET: True}
+        )
+
         if not r.ok:
             return Response({
                 'message': f'Cannot proxify asset from node {asset["owner"]}: {str(r.text)}'
@@ -186,3 +211,7 @@ def get_channel_name(request):
         return request.headers['Substra-Channel-Name']
 
     raise exceptions.BadRequestError('Could not determine channel name')
+
+
+def is_proxied(request) -> bool:
+    return HTTP_HEADER_PROXY_ASSET in request.headers

--- a/backend/substrapp/views/utils.py
+++ b/backend/substrapp/views/utils.py
@@ -63,7 +63,7 @@ class PermissionMixin(object):
     authentication_classes = api_settings.DEFAULT_AUTHENTICATION_CLASSES + [BasicAuthentication]
     permission_classes = [IsAuthenticated]
 
-    def check_access(self, channel_name, user, asset, is_proxied):
+    def check_access(self, channel_name, user, asset, is_proxied_request):
         """Returns true if API consumer can access asset data."""
         if user.is_anonymous:  # safeguard, should never happened
             raise PermissionError()
@@ -95,7 +95,7 @@ class PermissionMixin(object):
             return Response({'message': str(e.msg)}, status=e.status)
 
         try:
-            self.check_access(channel_name, request.user, asset, is_proxied(request))
+            self.check_access(channel_name, request.user, asset, is_proxied_request(request))
         except PermissionError as e:
             return Response({'message': str(e)},
                             status=status.HTTP_403_FORBIDDEN)
@@ -121,7 +121,7 @@ class PermissionMixin(object):
             return Response({'message': str(e.msg)}, status=e.status)
 
         try:
-            self.check_access(channel_name, request.user, asset, is_proxied(request))
+            self.check_access(channel_name, request.user, asset, is_proxied_request(request))
         except PermissionError as e:
             return Response({'message': str(e)},
                             status=status.HTTP_403_FORBIDDEN)
@@ -213,5 +213,5 @@ def get_channel_name(request):
     raise exceptions.BadRequestError('Could not determine channel name')
 
 
-def is_proxied(request) -> bool:
+def is_proxied_request(request) -> bool:
     return HTTP_HEADER_PROXY_ASSET in request.headers

--- a/backend/substrapp/views/utils.py
+++ b/backend/substrapp/views/utils.py
@@ -93,6 +93,8 @@ class PermissionMixin(object):
         key = self.kwargs[lookup_url_kwarg]
         channel_name = get_channel_name(request)
 
+        validate_key(key)
+
         try:
             asset = get_object_from_ledger(channel_name, key, self.ledger_query_call)
         except LedgerError as e:

--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.0.3
 
 ### Added
-- New channel configuration setting `enable_model_export`. When enabled, it allows authenticated users to download models trained on the current node.
+- Add new channel configuration setting `model_export_enabled`. When enabled, it allows authenticated users to download models trained on the current node.
 
 ## 2.0.2
 

--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.3
+
+### Added
+- New channel configuration setting `enable_model_export`. When enabled, it allows authenticated users to download models trained on the current node.
+
 ## 2.0.2
 
 - fix `service.port` incorrectly used in uwsgi configuration

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-backend
 home: https://substra.org/
-version: 2.0.2
+version: 2.0.3
 description: Main package for Substra
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/substra-backend/README.md
+++ b/charts/substra-backend/README.md
@@ -82,8 +82,9 @@ The following table lists the configurable parameters of the substra-backend cha
 | `peer.waitForEventTimeoutSeconds` | Time to wait for confirmation from the peers that the transaction has been committed successfully | `45` |
 | `peer.strategy.invoke` | Chaincode invocation endorsement strategy. Can be `SELF` or `ALL` (request endorsement from all peers) | `ALL` |
 | `peer.strategy.query` | Chaincode query endorsement strategy. Can be `SELF` or `ALL` (request endorsement from all peers) | `SELF` |
-| `channels` | A list of Hyperledger Fabric channels to connect to. See [hlf-k8s](https://github.com/SubstraFoundation/hlf-k8s). | `{ mychannel: { restricted: False, chaincode: { name: mycc, version: 1.0 } } }` |
+| `channels` | A list of Hyperledger Fabric channels to connect to. See [hlf-k8s](https://github.com/SubstraFoundation/hlf-k8s). | `{ mychannel: { restricted: False, enable_model_export: False, chaincode: { name: mycc, version: 1.0 } } }` |
 | `channels[].restricted` | If true, the channel must have at most 1 member, else the backend readiness/liveliness probes will fail. | (undefined) |
+| `channels[].enable_model_export` | If True, allow logged-in users to download models trained on this node | (undefined) |
 | `channels[].chaincode.name` | The name of the chaincode instantiated on this channel. | (undefined) |
 | `channels[].chaincode.version` | The version of the chaincode instantiated on this channel. | (undefined) |
 | `postgresql` | PostgreSQL configuration. For more info, See [postgresql](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) | |

--- a/charts/substra-backend/README.md
+++ b/charts/substra-backend/README.md
@@ -82,9 +82,9 @@ The following table lists the configurable parameters of the substra-backend cha
 | `peer.waitForEventTimeoutSeconds` | Time to wait for confirmation from the peers that the transaction has been committed successfully | `45` |
 | `peer.strategy.invoke` | Chaincode invocation endorsement strategy. Can be `SELF` or `ALL` (request endorsement from all peers) | `ALL` |
 | `peer.strategy.query` | Chaincode query endorsement strategy. Can be `SELF` or `ALL` (request endorsement from all peers) | `SELF` |
-| `channels` | A list of Hyperledger Fabric channels to connect to. See [hlf-k8s](https://github.com/SubstraFoundation/hlf-k8s). | `{ mychannel: { restricted: False, enable_model_export: False, chaincode: { name: mycc, version: 1.0 } } }` |
+| `channels` | A list of Hyperledger Fabric channels to connect to. See [hlf-k8s](https://github.com/SubstraFoundation/hlf-k8s). | `{ mychannel: { restricted: False, model_export_enabled: False, chaincode: { name: mycc, version: 1.0 } } }` |
 | `channels[].restricted` | If true, the channel must have at most 1 member, else the backend readiness/liveliness probes will fail. | (undefined) |
-| `channels[].enable_model_export` | If True, allow logged-in users to download models trained on this node | (undefined) |
+| `channels[].model_export_enabled` | If True, allow logged-in users to download models trained on this node | (undefined) |
 | `channels[].chaincode.name` | The name of the chaincode instantiated on this channel. | (undefined) |
 | `channels[].chaincode.version` | The version of the chaincode instantiated on this channel. | (undefined) |
 | `postgresql` | PostgreSQL configuration. For more info, See [postgresql](https://github.com/bitnami/charts/tree/master/bitnami/postgresql) | |

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -167,7 +167,7 @@ peer:
 channels:
   - mychannel:
       restricted: false
-      enable_model_export: false
+      model_export_enabled: false
       chaincode:
         name: mycc
         version: "1.0"

--- a/charts/substra-backend/values.yaml
+++ b/charts/substra-backend/values.yaml
@@ -167,6 +167,7 @@ peer:
 channels:
   - mychannel:
       restricted: false
+      enable_model_export: false
       chaincode:
         name: mycc
         version: "1.0"

--- a/values/backend-org-1.yaml
+++ b/values/backend-org-1.yaml
@@ -90,13 +90,13 @@ extraEnv:
 channels:
   - mychannel:
       restricted: false
-      enable_model_export: true
+      model_export_enabled: true
       chaincode:
         name: mycc
         version: "1.0"
   - yourchannel:
       restricted: false
-      enable_model_export: true
+      model_export_enabled: true
       chaincode:
         name: yourcc
         version: "1.0"

--- a/values/backend-org-1.yaml
+++ b/values/backend-org-1.yaml
@@ -90,11 +90,13 @@ extraEnv:
 channels:
   - mychannel:
       restricted: false
+      enable_model_export: true
       chaincode:
         name: mycc
         version: "1.0"
   - yourchannel:
       restricted: false
+      enable_model_export: true
       chaincode:
         name: yourcc
         version: "1.0"

--- a/values/backend-org-2.yaml
+++ b/values/backend-org-2.yaml
@@ -89,13 +89,13 @@ extraEnv:
 channels:
   - mychannel:
       restricted: false
-      enable_model_export: true
+      model_export_enabled: true
       chaincode:
         name: mycc
         version: "1.0"
   - yourchannel:
       restricted: false
-      enable_model_export: true
+      model_export_enabled: true
       chaincode:
         name: yourcc
         version: "1.0"

--- a/values/backend-org-2.yaml
+++ b/values/backend-org-2.yaml
@@ -89,11 +89,13 @@ extraEnv:
 channels:
   - mychannel:
       restricted: false
+      enable_model_export: true
       chaincode:
         name: mycc
         version: "1.0"
   - yourchannel:
       restricted: false
+      enable_model_export: true
       chaincode:
         name: yourcc
         version: "1.0"


### PR DESCRIPTION
Companion PRs:

- https://github.com/SubstraFoundation/substra/pull/261
- https://github.com/SubstraFoundation/substra-tests/pull/182
- https://github.com/SubstraFoundation/substra-chaincode/pull/141

---

Allow end users to export compute task out-models.

## Request proxying 

The end user can export a model from a node even if the model is owned by a different organization. If the model is not present on the current node, the request is proxied to the relevant node, from which the model is downloaded. This process is transparent to the end user.

### Direct download

```
[Substra CLI/SDK] -> [Node A] -> [model owned by org A]
```

### Proxied download

```
[Substra CLI/SDK] -> [Node A] -> [Node B] -> [model owned by org B]
                              ^^ proxy
```

## Permissions

A new configuration option is introduced for each channel: `model_export_enabled`

This permissions is checked on the node owning the model (as well as on the node performing the request proxy, if any). Both nodes must have the configuration option set to `True` for the model export to be successful. 

In addition to the `model_export_enabled` permission check, the traditional permission checks are also performed, i.e. the model must be `public` or the proxying node must be part of a list of  `authorized_ids`.

