### PR TITLE
fix: binding to service.port instead of 8000

### DIFF
--- a/charts/substra-backend/CHANGELOG.md
+++ b/charts/substra-backend/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.2
+
+- fix `service.port` incorrectly used in uwsgi configuration
+
 ## 2.0.1
 
 ### Added

--- a/charts/substra-backend/Chart.yaml
+++ b/charts/substra-backend/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: substra-backend
 home: https://substra.org/
-version: 2.0.1
+version: 2.0.2
 description: Main package for Substra
 icon: https://avatars1.githubusercontent.com/u/38098422?s=200&v=4
 sources:

--- a/charts/substra-backend/templates/configmap-events.yaml
+++ b/charts/substra-backend/templates/configmap-events.yaml
@@ -9,4 +9,4 @@ data:
   uwsgi.ini: |
     [uwsgi]
     module                        = backend.wsgi
-    http-socket                   = :{{ .Values.backend.service.port }}
+    http-socket                   = :8000

--- a/charts/substra-backend/templates/configmap-server-uwsgi.yaml
+++ b/charts/substra-backend/templates/configmap-server-uwsgi.yaml
@@ -16,7 +16,7 @@ data:
     processes                     = {{ .Values.backend.uwsgiProcesses }}
     threads                       = {{ .Values.backend.uwsgiThreads }}
 
-    http-socket                   = :{{ .Values.backend.service.port }}
+    http-socket                   = :8000
 
     need-app                      = true
     socket-timeout                = 300

--- a/charts/substra-backend/templates/deployment-server.yaml
+++ b/charts/substra-backend/templates/deployment-server.yaml
@@ -92,7 +92,7 @@ spec:
         {{- end }}
         ports:
           - name: http
-            containerPort: {{ .Values.backend.service.port }}
+            containerPort: 8000
             protocol: TCP
         volumeMounts:
           {{- range $key, $val := .Values.persistence.volumes }}


### PR DESCRIPTION
The backend-server service port can be different from the port the backend-server container binds to. 

However, we were incorrectly binding to the service port in the backend-server container. 

Since the service definition [targets](https://github.com/SubstraFoundation/substra-backend/blob/master/charts/substra-backend/templates/service-server.yaml#L41) the container port 8000, this would cause connectivity issues whenever the service port would be != 8000.

This PR fixes the uwsgi configuration files so that backend-server always bind to port 8000. There's no need to make this value configurable, as there's no use-case when that would be useful.